### PR TITLE
Architecture: Initiators tier + consolidated invariant checklist + spec-review gate

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,69 +1,77 @@
 ---
 name: architecture-reviewer
-description: Reviews code changes for Hedron's 4-layer architecture discipline, ECS component purity, event-bus rules, and idealized-API alignment. Use proactively after any PR-sized change to Core/, before merging, or when the user asks for an architectural sanity check.
+description: Reviews Hedron changes against the architecture invariant checklist. Runs in two modes — spec-review (a use-case doc, before implementation) and code-review (a diff, before merge). Use spec mode after use-case-planner and before implement-use-case; use code mode after any PR-sized change to Core/ and before merging.
 tools: Read, Grep, Glob, Bash
 ---
 
-You are the architecture reviewer for the Hedron MUD engine. You have read the `docs/architecture/` and `docs/roadmap/` trees and treat them as the authoritative design. You do not write code — you review it.
+You are the architecture reviewer for the Hedron MUD engine. You do not write code or specs — you review them against the authoritative invariant list and report.
 
-## Your job
+## The rules are not in this prompt
 
-Given a set of changes (a PR, a branch, or a working tree diff), flag violations of the rules that matter in Hedron specifically. You are not a generic code reviewer — stay on architecture.
+The single source of truth for every architectural invariant is **[docs/architecture/checklist.md](../../docs/architecture/checklist.md)**. Read it at the start of every review. Cite invariants by ID (`INV-7`, `SR-2`). This prompt deliberately carries **no** inline rule list — a private copy would drift from the checklist, which is the exact failure class that let the slice-3 command-tier gap survive three slices. If the checklist and any other doc disagree, the checklist wins; flag the disagreement.
 
-## The rules you enforce
+## Modes
 
-1. **4-layer discipline.** Handlers orchestrate → domain systems decide → core systems compute → components hold data. Higher layers may call lower; never reverse. See [docs/architecture/01-layers.md](../../docs/architecture/01-layers.md).
-2. **Components are pure data.** No methods, no event subscriptions, no references to other components. See [docs/architecture/02-ecs.md](../../docs/architecture/02-ecs.md).
-3. **Services return results; handlers publish events.** A domain or core system calling `eventBus.Publish` is a violation. See [docs/architecture/03-events.md](../../docs/architecture/03-events.md).
-4. **No inheritance type checks on entities.** `entity is Player`, `as Mob`, etc. must be replaced with `entityService.HasComponent<T>(id)`.
-5. **Event payload discipline.** Past-tense names. Thin payloads unless state is captured-at-publish-time.
-6. **Core systems never depend on domain systems.**
-7. **Infrastructure-discipline parity (CLAUDE.md ground rule 9).** A slice may not introduce a new player-facing surface (commands, prompts, output formats, content schemas) that bypasses an existing framework, nor may it repeat a hand-rolled pattern ≥3 times across the diff without promotion to a framework. The use-case doc's "Cross-cutting surfaces stressed" section is the structural check; verify it was filled honestly and that any "gap exposed" item resolved before this PR.
-8. **Canonical flows stay current.** If the diff changes any runtime flow that's specified in [docs/architecture/06-flows.md](../../docs/architecture/06-flows.md) — startup ordering, command lifecycle, persistence flush, content reload, player connection — the diff must update that doc to match. New recurring flows that the slice introduces must be added to `06-flows.md`. Drift between code and `06-flows.md` is doc-drift and blocks the review.
+Determine the mode from the invocation. If unclear, ask which mode before proceeding — never half-review.
 
-## Your workflow
+### Spec-review mode (input: a use-case doc, before implementation)
 
-1. Identify the diff scope: `git diff master...HEAD --stat` or equivalent.
-2. For each changed file in `Core/`:
-   - Read the full file (not just the diff) — violations often span the diff boundary.
-   - Check each rule against the file's contents.
-3. For cross-cutting checks, grep the whole repo:
-   - New `eventBus.Publish` inside files under `Systems/` → violation of rule 3
-   - New `entity is SomeType` / `as SomeType` patterns where the target should be `entityService.HasComponent<T>` / `TryGet<T>` → violation of rule 4
-4. **Cross-cutting-surface audit (rule 7).** Read the use-case doc's "Cross-cutting surfaces stressed" section. For each surface marked "Adequate," spot-check the diff: did any new file under `Core/` hand-roll a pattern that the named surface should have absorbed? For each surface marked "Gap exposed," confirm the framework work landed in this PR (or in a prerequisite already-merged PR). For each "Acknowledged debt," confirm the backlog entry exists.
-5. **Pattern-repetition sweep (rule 7).** Grep the diff for hand-rolled patterns that appear in ≥3 new or modified files. Common candidates: per-file `Trim()`/`Split()` for argument parsing, per-file privilege checks, per-file `session.SendLineAsync` formatting, per-file `[Persistent]`-iteration loops. Flag each as a candidate for framework promotion.
-6. **Flows-doc audit (rule 8).** Read the use-case doc's "Flows introduced or modified" section. For each flow listed, open `docs/architecture/06-flows.md` and verify the corresponding section reflects the as-built code. Flag any flow that the diff materially changes but the doc doesn't reflect.
-7. Verify general doc-code coherence:
-   - If a new event is added, check it's in [docs/architecture/03-events.md](../../docs/architecture/03-events.md)'s catalog.
-   - If a new system/handler/component is added, check it's in the matching `docs/reference/` file.
-   - If a use case is implemented, confirm its doc is updated (status, deviations).
+The point of this mode is to catch architecture violations **before code exists**, when they are cheap to fix. The reviewer that only sees code is structurally too late for spec-level contradictions.
+
+1. Read [checklist.md](../../docs/architecture/checklist.md) in full.
+2. Read the target use-case doc in full.
+3. Read the architecture explanation docs any of its Main-Flow steps touch (`01-layers.md`, `03-events.md`, `06-flows.md`, etc.) and any skill it relies on (`.claude/skills/`, e.g. `add-command`).
+4. For each `INV-n`, apply its **Spec** check (where the checklist gives a spec-specific signal). Then apply every **SR-n** spec-review failure mode in the checklist:
+   - SR-1 spec directs a layer to violate an INV
+   - SR-2 spec preserves a pre-existing violation without calling it out
+   - SR-3 spec contradicts an established skill/convention
+   - SR-4 a referenced flow / catalog entry doesn't exist or won't be updated
+   - SR-5 a load-bearing open question is being deferred
+5. Cross-check the doc's **Cross-cutting surfaces stressed** and **Flows introduced or modified** sections: are they honest and complete given what the spec actually describes? A surface the spec clearly exercises but doesn't list is itself a finding.
+
+A spec-mode review blocks `implement-use-case` until blocking findings are resolved in the doc.
+
+### Code-review mode (input: a diff, before merge)
+
+1. Read [checklist.md](../../docs/architecture/checklist.md) in full.
+2. Identify diff scope: `git diff master...HEAD --stat` (or the range the user names).
+3. For each changed file under `Core/`, read the **full file** (violations span diff boundaries) and apply each `INV-n`'s **Code** check.
+4. Repo-wide greps:
+   - `IEventBus`/`PublishAsync` inside a file under `Systems/` → INV-5
+   - `is SomeType` / `as SomeType` on entities where `HasComponent<T>`/`TryGet<T>` is meant → INV-4
+   - direct `session.SendLineAsync` in a command body or dispatcher branch after slice 3 → INV-11
+5. **Cross-cutting-surface audit (INV-19).** For each surface in the use-case doc: "Adequate" → spot-check no new file hand-rolled what the surface should absorb; "Gap exposed" → confirm the framework landed here or in a merged prerequisite; "Acknowledged debt" → confirm the backlog entry exists.
+6. **Pattern-repetition sweep (INV-19).** Any hand-rolled pattern in ≥3 new/modified files (arg parsing, privilege checks, output formatting, `[Persistent]` loops) → framework-promotion finding.
+7. **Flows-doc audit (INV-17).** For each flow in the doc's "Flows introduced or modified," open `06-flows.md` and verify body **and** mermaid match the as-built code.
+8. **Catalog audit (INV-16).** New/changed component, system, handler, event → matching `docs/reference/*.md` updated; use-case status/deviations updated.
 
 ## Output format
 
-Return a concise report:
-
 ```
-## Architecture review: <short scope description>
+## Architecture review (<spec|code>): <scope>
 
-### Violations (blocking)
-- <file:line> — rule broken — one-line reason
+### Verdict
+<APPROVE | APPROVE WITH NITS | NEEDS CHANGES>
 
-### Smells (non-blocking)
-- <file:line> — concern — one-line reason
+### Blocking
+- <INV-n | SR-n> — <doc§ or file:line> — one-line reason + the fix
 
-### Doc drift
-- <doc path> — what's out of date
+### Non-blocking
+- <id> — <where> — concern
+
+### Doc/flow drift
+- <doc path> — what's stale
 
 ### OK
-- brief list of changes that passed
+- brief list of what passed (only genuinely notable)
 ```
 
-No violations? Say so in one sentence. Do not pad. Do not re-explain rules unless the reviewer is asking *why* something is wrong.
+Lead with one of the three verdict words verbatim so the caller can branch on it. No violations: say so in one sentence. Do not pad. Do not re-explain a rule unless asked *why*.
 
 ## What you are NOT
 
-- Not a style reviewer (formatting, naming conventions beyond the event-naming rule).
-- Not a correctness reviewer (test logic, edge cases that aren't architectural).
-- Not a performance reviewer (unless it's a hot-path call through an event bus that should be direct).
+- Not a style/naming reviewer (beyond INV-6 event naming).
+- Not a correctness/test-logic reviewer.
+- Not a performance reviewer (unless a hot path bypasses or abuses the bus).
 
-When in doubt, point the user at the specific `docs/architecture/` paragraph the rule comes from.
+When in doubt, cite the `INV-n` and the explanation doc section it links to. If you believe an invariant itself is wrong, say so explicitly as a separate "checklist gap" note — do not silently review against your own opinion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,12 @@ Read these in order the first time:
 
 ## Ground rules when writing code
 
+> The authoritative, numbered list of every architectural invariant is [`docs/architecture/checklist.md`](docs/architecture/checklist.md). The ground rules below are the day-to-day summary; the checklist is what the `architecture-reviewer` agent and the per-slice gates enforce. If the two ever disagree, the checklist wins and the loser gets fixed.
+
 1. **Match the idealized API.** `docs/architecture/` and `docs/use-cases/` describe the **target**. New code is written against the target on first attempt. If the target needs to change, update the doc first.
 2. **4-layer discipline.** Handlers orchestrate → domain systems decide → core systems compute → components hold data. Never skip layers upward. See [`docs/architecture/01-layers.md`](docs/architecture/01-layers.md).
 3. **Component queries, not `is`/`as`.** `entityService.HasComponent<PlayerComponent>(id)` — never `entity is Player`.
-4. **Services return results; handlers publish events.** Systems are pure where possible.
+4. **Systems return results; Initiators and Handlers publish events.** Domain & core systems never touch the event bus (INV-5). Commands and the scheduled heartbeat are *Initiators* — the entry-point tier that, like handlers, may publish. See [`docs/architecture/01-layers.md`](docs/architecture/01-layers.md#initiators--entry-points).
 5. **One world model.** Every live entity lives in `EntityService`. Authored content is spawned via `TemplateRegistry`; bespoke entities are built with `EntityService.CreateEntity()` + `AddComponent` by the owning feature that needs them.
 6. **Entity identity is a wrapper.** `readonly record struct Entity(uint Id)` — the `uint` is authoritative; `Entity` is for flavour at call sites. Components still store `uint` ids when referencing other entities.
 7. **Persistence is per-component.** Tag a component type with `[Persistent]` and `PersistenceSystem` includes it on save. An entity is persisted if it has any `[Persistent]` component. Effects split into `PersistentEffectsComponent` (saved) and `TransientEffectsComponent` (session-only). **Two serializers, two audiences:** persistence uses `System.Text.Json` for component snapshots (machine round-trip); content authoring uses YAML via `YamlDotNet` for designer-write files under `data/content/`. They do not share serializer code.
@@ -63,6 +65,8 @@ When adding a new feature:
 ## Agent tooling available in this repo
 
 The `.claude/` directory provides Claude-Code-native helpers (skills, subagents, slash commands) tuned for this codebase. See [`.claude/README.md`](.claude/README.md) for the index.
+
+The per-slice loop runs **two** `architecture-reviewer` gates: spec-mode (against the use-case doc, before any code) and code-mode (against the diff, before merge). Both enforce [`docs/architecture/checklist.md`](docs/architecture/checklist.md). The full loop is in [`docs/roadmap/plan.md`](docs/roadmap/plan.md) "Phase 3 ground rules".
 
 ## If docs and code disagree
 

--- a/docs/architecture/00-overview.md
+++ b/docs/architecture/00-overview.md
@@ -74,6 +74,7 @@ Rows marked *(target)* describe locations that are rebuilt as part of Phase 2. T
 | [04-pitfalls.md](04-pitfalls.md) | When tempted to shortcut the layering |
 | [05-configuration.md](05-configuration.md) | Before wiring any setting to `IConfiguration` or adding a constant |
 | [06-flows.md](06-flows.md) | When tracing a runtime call chain (startup, command lifecycle, persistence flush, content reload, …) |
+| [checklist.md](checklist.md) | **The authoritative invariant list.** Cite `INV-n` IDs in reviews. Every other doc explains; this one enforces. |
 | [../reference/systems.md](../reference/systems.md) | Living catalog of every system |
 | [../reference/handlers.md](../reference/handlers.md) | Living catalog of every handler |
 | [../reference/components.md](../reference/components.md) | Living catalog of every component |

--- a/docs/architecture/01-layers.md
+++ b/docs/architecture/01-layers.md
@@ -4,6 +4,72 @@ This document details each layer, its responsibilities, and how layers interact.
 
 > Code in this doc uses the **idealized API** — the target the codebase is being rebuilt against. See [../roadmap/plan.md](../roadmap/plan.md) for phase sequencing.
 
+> The consolidated, authoritative list of every architectural invariant is [checklist.md](checklist.md). This document is the *explanation*; the checklist is the *enforcement list* the `architecture-reviewer` agent and the per-slice gates run against.
+
+---
+
+## The shape: initiators feed a processing stack
+
+The four numbered layers below (Handlers → Domain Systems → Core Systems → Components) are the **processing stack**: dependencies flow strictly downward through them. But something has to *start* a chain of processing. Those entry points are **Initiators**, and they are a distinct tier that sits above the stack and feeds its top.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Initiators / Entry Points                                │
+│  Commands (external input) · Scheduled ticks (heartbeat)  │
+│  Thin. Gather context → call a domain system → publish    │
+│  the resulting event(s). No game rules.                   │
+└───────────────────────────┬──────────────────────────────┘
+                            │ publish events
+                            ▼
+┌──────────────────────────────────────────────────────────┐
+│  Layer 1  Event Handlers      (orchestrate)               │
+│  Layer 2  Domain Systems      (decide game rules)         │
+│  Layer 3  Core Systems        (compute mechanics)         │
+│  Layer 4  Components / World   (hold data)                │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Initiators and Handlers are the only two tiers permitted to publish events.** Domain and Core systems compute and return; they never touch the event bus. This is the precise statement of the "services return results; handlers publish events" rule — it constrains *systems*, not the orchestration boundary. See [03-events.md](03-events.md).
+
+---
+
+## Initiators / Entry Points
+
+**Purpose:** Begin an event chain. An initiator gathers the context for one unit of work, asks a domain system to do it, and publishes the past-tense event(s) describing what happened. It contains **no game rules** — it is the thinnest possible glue between a trigger and the processing stack.
+
+**Two kinds (more may be added; the tier is open):**
+
+| Kind | Trigger | Cardinality | Examples |
+|---|---|---|---|
+| **Command** | External — a player or admin sends input | one input → one chain | `look`, `say`, `north`, `@spawn`, `@reload` |
+| **Scheduled tick / heartbeat** | Internal — a timer fires | one fire → many chains (iterates entities, publishes per-entity events) | combat round, regen pulse, mob wander, effect expiry, mob respawn |
+
+**Characteristics:**
+- Thin. A command is **≤ 30 lines**; if it grows, the logic belongs in a domain system.
+- No gameplay logic, no multi-step branching. "Publish A, then call system X, then conditionally publish B" is a *handler*, not an initiator — move it.
+- Parses/gathers input, resolves targets via domain-system lookups (`InventorySystem.FindByName`, `LocationSystem.FindInRoom`), calls the relevant domain system, publishes the resulting event(s).
+- May publish events. This is the tier's defining permission, shared only with Handlers.
+
+**The no-chain variant.** An initiator whose work is a closed mechanical sweep with **no game-rule fan-out** may call a system directly and publish nothing. The existing precedent is `PersistenceFlushTimer` (a scheduled-tick initiator) → `PersistenceSystem.FlushAsync()`, no event — persistence has no downstream chain to notify. Use this only when there is genuinely no chain; the moment another concern needs to react, it becomes an event.
+
+**Where they live:**
+- Commands — `Core/Commands/<X>Command.cs` (cross-cutting like `look`/`who`) or `Core/Modules/<Feature>/Commands/<X>Command.cs` (feature-owned).
+- The command **dispatcher/runtime** (`CommandDispatcher`) is the runtime of the command-initiator tier — *not* a domain or core system despite living under `Core/`. It is permitted to publish the command-lifecycle event (e.g. `CommandExecutedEvent`) because it is the only component that observes every dispatch outcome (success / parse-fail / unauthorized / threw).
+- The scheduler/heartbeat runtime lands with the first slice that needs scheduled work (slice 8, mobs + wandering). It is initiator-tier infrastructure, same publishing permission as the dispatcher.
+
+**Anti-patterns:**
+- Game rules inside a command (`if armor > threshold…`) — belongs in a domain system.
+- Multi-step orchestration inside a command — that's a handler.
+- A domain/core system reaching for the event bus to "save a hop" — forbidden; return a result and let the initiator or a handler publish.
+
+### Heartbeat / scheduled-tick — forward design constraints
+
+The heartbeat is not built until slice 8, but the Initiator tier is shaped now so it plugs in rather than forcing another revision. When it lands it **must** observe:
+
+1. **It is a scheduler, not one global pulse.** Different work ticks at different cadences (combat round ≈ 2s, regen ≈ 10s, wander ≈ 30s, respawn ≈ minutes). Built on `TimeSystem.RegisterTimer(duration, callback)` (see [../reference/systems.md](../reference/systems.md)) — many timers, not a single `Tick()`.
+2. **Intra-tick ordering uses the multi-phase-event pattern.** "All mobs move, then combat resolves, then DoT applies" is expressed as ordered past-tense events, each phase firing the next — see [03-events.md](03-events.md#handler-priorities--ordering). The heartbeat does not contain an ordering `if`-ladder.
+3. **Single-threaded, queue-drained.** The intended concurrency shape is a single-threaded tick that drains an event queue, keeping the bus and handlers lock-free and consistent with the synchronous `EventBus`. Do not introduce locks ad hoc; revisit only if profiling forces it (tracked in [../roadmap/backlog.md](../roadmap/backlog.md)).
+
 ---
 
 ## Layer 1: Event Handlers
@@ -183,24 +249,29 @@ See [02-ecs.md](02-ecs.md) for ECS patterns, component design, template spawning
 ## Cross-Layer Dependency Rules
 
 ```
-Handlers    →  Domain Systems  →  Core Systems  →  Components/World
-    ↓              ↓                    ↓
-    └──────────────┴────────────────────┴──────────────→ Components/World
+Initiators  →  (publish events)  →  Handlers  →  Domain Systems  →  Core Systems  →  Components/World
+                                        ↓              ↓                  ↓
+                                        └──────────────┴──────────────────┴────────→ Components/World
 ```
 
 **Allowed:**
+- Initiators → Domain Systems (resolve targets, do the work)
+- Initiators → Event Bus (publish the resulting event)
 - Handlers → Domain Systems
 - Handlers → Core Systems (rarely, for trivial lookups)
+- Handlers → Event Bus (publish follow-on events)
 - Domain Systems → Domain Systems (same or lower level in the graph)
 - Domain Systems → Core Systems
 - Core Systems → Core Systems
-- Any layer → Components/World (read/write components)
+- Any tier → Components/World (read/write components)
 
 **Forbidden:**
 - Components → Any system (components are pure data)
 - Core Systems → Domain Systems
 - Domain Systems → Handlers
-- Any system → Event Bus directly (services return results; handlers publish events)
+- **Domain & Core Systems → Event Bus directly** (systems compute and return; only Initiators and Handlers publish). This is the exact scope of the rule — it constrains systems, *not* the orchestration boundary. An initiator or handler publishing is correct and expected.
+- Initiators → Handlers directly (an initiator publishes an event; it never calls a handler)
+- Game rules inside an Initiator (parse/resolve/call/publish only)
 
 ---
 

--- a/docs/architecture/03-events.md
+++ b/docs/architecture/03-events.md
@@ -133,7 +133,7 @@ public class EventBus : IEventBus
 
 ## Services return results; handlers publish events
 
-**Rule:** Services compute and return. Handlers decide what (if any) events to raise.
+**Rule ([checklist.md](checklist.md) INV-5):** *Systems* compute and return — they never touch the event bus. The tiers permitted to publish are **Initiators** (commands, scheduled ticks) and **Handlers**. This rule constrains domain & core systems specifically; it is *not* a prohibition on the orchestration boundary. A command or the heartbeat publishing its outcome event is correct and expected — see [01-layers.md](01-layers.md#initiators--entry-points). The example below uses a "Service" to show the *system* anti-pattern.
 
 ```csharp
 // ❌ Service raises events directly — hidden side effects

--- a/docs/architecture/checklist.md
+++ b/docs/architecture/checklist.md
@@ -1,0 +1,81 @@
+# Architecture Invariant Checklist
+
+> **This is the single authoritative list of every architectural invariant in Hedron.** It is the *enforcement list* — terse, numbered, checkable. The *explanations* live in [00-overview.md](00-overview.md) through [06-flows.md](06-flows.md); the *workflow obligations* live in [`CLAUDE.md`](../../CLAUDE.md) ground rules and [`../roadmap/plan.md`](../roadmap/plan.md). Those documents must not restate invariants in their own words — they link here.
+>
+> **Consumers of this list:** the `architecture-reviewer` agent (both spec-review and code-review modes), the `use-case-planner` agent's ground-rule-9 audit, and the future on-demand debt-sweep agent. A rule change lands *here once*; every consumer picks it up. No agent prompt carries a private copy.
+>
+> Each invariant has a stable ID (`INV-n`). Cite the ID in reviews (e.g. "INV-7 violated at `Foo.cs:42`"). "How to check" distinguishes **spec mode** (reviewing a use-case doc before implementation) from **code mode** (reviewing a diff) only where the technique differs.
+
+---
+
+## A. Layering & dependency direction
+
+**INV-1 — Downward-only dependencies through the processing stack.** Handlers → Domain Systems → Core Systems → Components. Higher may call lower; never the reverse. Explanation: [01-layers.md](01-layers.md#cross-layer-dependency-rules).
+- *Spec:* does any Main-Flow step describe a system calling a handler, or a core system calling a domain system?
+- *Code:* import/call graph in changed `Core/` files.
+
+**INV-2 — Core Systems never depend on Domain Systems.** A `Core/Systems/` type may not reference any `Core/Modules/<Feature>/` type. Explanation: [01-layers.md](01-layers.md), [00-overview.md](00-overview.md).
+
+**INV-3 — Components are pure data.** No methods that do work, no event subscriptions, no references to other components or systems. Explanation: [02-ecs.md](02-ecs.md).
+
+**INV-4 — Component queries, not type checks.** Never `entity is Player` / `as Mob`. Use `entityService.HasComponent<T>(id)` / `TryGet<T>`. Explanation: [02-ecs.md](02-ecs.md).
+
+## B. Events & the orchestration boundary
+
+**INV-5 — Only Initiators and Handlers publish events.** Domain & Core systems compute and return; they never touch `IEventBus`. This is the exact scope of "services return results; handlers publish events" — it constrains *systems*, not the orchestration boundary. An Initiator (command, scheduled tick) or a Handler publishing is correct. Explanation: [03-events.md](03-events.md#services-return-results-handlers-publish-events), [01-layers.md](01-layers.md#initiators--entry-points).
+- *Spec:* does any step direct a domain/core system to publish? Does it direct a non-system (command/dispatcher/handler) to publish — that's allowed, not a violation.
+- *Code:* `IEventBus`/`PublishAsync` injected or called inside a file under `Systems/`.
+
+**INV-6 — Events are past-tense, thin facts.** Named for what happened (`PlayerMovedEvent`, not `MovePlayerEvent`). Payload is minimal unless point-in-time capture is required for correctness. Explanation: [03-events.md](03-events.md).
+
+**INV-7 — Intra-event ordering via priority or multi-phase events, never a god-handler.** Multiple handlers on one event use explicit `Priority`; sequenced phases use ordered past-tense events. No single handler that calls every system in sequence. Explanation: [03-events.md](03-events.md#handler-priorities--ordering), [04-pitfalls.md](04-pitfalls.md).
+
+## C. Initiators (commands & heartbeat)
+
+**INV-8 — Initiators are thin and rule-free.** Parse/gather → resolve target via a domain-system lookup → call the domain system → publish the resulting event(s). A command is ≤ 30 lines. No gameplay rules, no multi-step branching (that's a handler). Explanation: [01-layers.md](01-layers.md#initiators--entry-points).
+
+**INV-9 — Initiators never call Handlers directly.** An initiator publishes an event; the bus routes it. Explanation: [01-layers.md](01-layers.md).
+
+**INV-10 — The no-chain variant is the only exception to "publish your outcome."** An initiator whose work is a closed mechanical sweep with no game-rule fan-out (e.g. `PersistenceFlushTimer` → `FlushAsync`) may call a system directly and publish nothing. The moment another concern must react, it becomes an event. Explanation: [01-layers.md](01-layers.md#initiators--entry-points).
+
+**INV-11 — No direct `session.SendLineAsync` from command bodies once the command framework lands (slice 3+).** Output goes through the output writer / typed messages. Until slice 3 merges this is aspirational; after, it is enforced — including dispatcher-internal call sites (e.g. the unknown-command branch). Explanation: [command-framework.md](../use-cases/command-framework.md).
+
+## D. One world, templates, identity, persistence
+
+**INV-12 — One live world.** Every live entity is in `EntityService`. Authored content spawns via `TemplateRegistry`; bespoke entities are built by the owning feature. Explanation: [02-ecs.md](02-ecs.md), [00-overview.md](00-overview.md).
+
+**INV-13 — Entity identity is `uint`, wrapped as `Entity(uint Id)` at call sites.** Components store `uint` ids when referencing other entities. Explanation: [02-ecs.md](02-ecs.md).
+
+**INV-14 — Persistence is per-component.** `[Persistent]` marks a component for save; an entity persists iff it has ≥1 `[Persistent]` component. Persistence uses `System.Text.Json`; content authoring uses YAML (`YamlDotNet`). The two serializers do not share code. Explanation: [02-ecs.md](02-ecs.md), [05-configuration.md](05-configuration.md), CLAUDE.md ground rule 7.
+
+## E. Idealized-API & documentation discipline
+
+**INV-15 — Idealized-API first.** New code is written against the documented target on first attempt. If the target is wrong, fix the doc *first*, in the same change. Explanation: CLAUDE.md ground rule 1, [00-overview.md](00-overview.md).
+
+**INV-16 — Reference catalogs stay current.** A new/changed component, system, or handler updates the matching `docs/reference/*.md` in the same PR. Explanation: [../reference/](../reference/).
+
+**INV-17 — Canonical flows stay current.** Any change to a runtime flow specified in [06-flows.md](06-flows.md) updates that file (body *and* mermaid) in the same PR. A new recurring flow is added there. Drift blocks the review. Explanation: [06-flows.md](06-flows.md), CLAUDE.md ground rule 9.
+
+## F. Slice discipline (ground rules 8 & 9)
+
+**INV-18 — Content-tooling discipline.** A slice adding gameplay state ships the tooling to author and inspect it (data-file shape, admin commands, `TemplateRegistry` entries). The use-case doc's **Content tooling impact** section is the check. Explanation: CLAUDE.md ground rule 8, [../roadmap/plan.md](../roadmap/plan.md).
+
+**INV-19 — Infrastructure-discipline parity.** A slice introducing a new player-facing surface (commands, prompts, output formats, content schemas), or repeating a hand-rolled pattern ≥3 times, lands the supporting framework in the same or an adjacent slice. The use-case doc's **Cross-cutting surfaces stressed** section is the check; gap-exposed surfaces resolve before merge; "acknowledged debt" requires a backlog entry with rationale. Explanation: CLAUDE.md ground rule 9.
+
+---
+
+## Spec-review failure modes (code-mode reviewers: skip)
+
+When reviewing a use-case doc *before* implementation, beyond the per-INV spec checks above, flag:
+
+- **SR-1 — The spec directs a layer to violate an INV.** e.g. "the dispatcher computes damage," "this domain system publishes the event." The spec must be corrected before code is written.
+- **SR-2 — The spec preserves a pre-existing violation without calling it out.** "Continues to work as today" is not acceptable if "today" violates an INV. The spec must either fix it or explicitly record it as acknowledged debt with a backlog pointer.
+- **SR-3 — The spec contradicts an established skill or convention.** e.g. it specifies a command shape that the `add-command` skill forbids. One of them is wrong; resolve before implementation.
+- **SR-4 — A referenced flow or catalog entry doesn't exist or won't be updated.** The "Flows introduced or modified" / "Cross-cutting surfaces stressed" sections name flows/surfaces; verify each is real and that the spec commits to updating it.
+- **SR-5 — An open question is load-bearing.** If a deferred decision determines whether an INV is satisfiable, it is not deferrable — it blocks implementation.
+
+---
+
+## Maintenance
+
+Add an invariant here when a new architectural rule is established (typically when a slice's architecture-review surfaces a gap, as INV-5/INV-8–11 did from the slice-3 command-tier gap). Update the explanation doc in the same change and link back here. Never let an invariant live only in an agent prompt or only in CLAUDE.md — those point here.

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -38,6 +38,14 @@ If a web client becomes a goal, unify telnet sessions and web sessions behind th
 
 Acknowledged debt from Phase 3 slice 4 ([`../use-cases/output-framework.md`](../use-cases/output-framework.md)). Slice 4's broadcast expansion ships room-scope-with-audience-filter and system-wide `SendToAllAsync`, but **channel mode** (global/newbie chat membership) is deferred: it requires per-entity channel-membership state that no slice has introduced yet. Lands with whichever later slice introduces channel membership (likely alongside or after account / character creation, slice 5). The `IBroadcastSystem` interface shaped in slice 4 should accommodate a `SendToChannelAsync` addition without breaking the room/system modes.
 
+### 🔵 Command-arg log redaction (acknowledged debt from slice 3)
+
+`CommandExecutedEvent.ArgsSummary` ([`../use-cases/command-framework.md`](../use-cases/command-framework.md)) logs parsed args in plaintext. Slice 3 ships with no redaction — acceptable only because the sole free-text verb is `say` and the logger is local. **Prerequisite for any retained/forwarded log sink.** Proposed fix: a per-command `[NoLogArgs]` / `RedactArgs` declaration the dispatcher honors before building `ArgsSummary`. Lands with whichever slice first adds a non-local logging sink, an auth-bearing verb (`password`, account linking), or `tell`/private channels — whichever comes first.
+
+### 🔵 CommandPipeline middleware refactor (deferred smell from slice 3)
+
+`CommandDispatcher` carries five injected dependencies and owns authorization, parsing, output, event publication, and exception trapping (spec-mode review smell S1). A middleware/pipeline chain would isolate these concerns. Deferred from slice 3 to avoid ballooning the 12-command refactor. Revisit when a sixth concern would be added to the dispatcher, or if testing the dispatcher becomes painful.
+
 ### 🔵 Archetype catalogue refresh
 
 The archetype list in [`../reference/archetypes.md`](../reference/archetypes.md) was written against the old component shapes. Re-audit once a few Phase 3 slices have landed real components.

--- a/docs/roadmap/plan.md
+++ b/docs/roadmap/plan.md
@@ -34,20 +34,24 @@ For the per-slice ledger of completed work, read [`done.md`](done.md).
 
 ## Current focus
 
-**Phase 3 slice 3 — command framework.** Use case planned: [`../use-cases/command-framework.md`](../use-cases/command-framework.md). Slice 4 (output framework, [`../use-cases/output-framework.md`](../use-cases/output-framework.md)) follows immediately and discharges the minimal-output-seam debt slice 3 leaves. Implementation via `implement-use-case`; review via `architecture-reviewer` before merge.
+**Phase 3 slice 3 — command framework.** Use case planned: [`../use-cases/command-framework.md`](../use-cases/command-framework.md). Slice 4 (output framework, [`../use-cases/output-framework.md`](../use-cases/output-framework.md)) follows immediately and discharges the minimal-output-seam debt slice 3 leaves. The spec was corrected after a spec-mode `architecture-reviewer` pass exposed the command-tier gap (now resolved in [`../architecture/01-layers.md`](../architecture/01-layers.md) — Initiators tier); implementation via `implement-use-case` against the corrected spec, then code-mode review before merge.
 
 The per-slice spec is the single source of truth for "what is being built right now" — this file deliberately does not duplicate it.
 
 ## Phase 3 ground rules
 
-Each slice:
+Each slice runs this loop. There are **two** `architecture-reviewer` gates — one before code exists, one before merge. The spec gate exists because spec-level violations (a plan that directs a layer to break an invariant, or preserves a latent one) are invisible to a code-only reviewer until implementation is already built on the flaw — the failure that produced the slice-3 command-tier rework.
 
 1. Pick the next use-case file from [`../use-cases/`](../use-cases/), or author a new one (`new-use-case` skill).
-2. Plan via the `use-case-planner` agent — produces the component / system / handler / event list and file plan.
-3. Implement.
-4. Review via the `architecture-reviewer` agent before merge.
-5. Update [`done.md`](done.md) and add a `completed/<slice>.md` note when the slice merges.
-6. Ship green.
+2. Plan via the `use-case-planner` agent — produces the component / system / handler / event list and file plan, and fills the use-case doc's **Cross-cutting surfaces stressed** and **Flows introduced or modified** sections.
+3. Resolve open questions with the user.
+4. **Spec-review gate** — `architecture-reviewer` in **spec mode** against the use-case doc. Blocking findings are fixed *in the doc* before any code is written. Re-run until the verdict is clean.
+5. Implement (`implement-use-case`) against the corrected spec.
+6. **Code-review gate** — `architecture-reviewer` in **code mode** against the diff, before merge.
+7. Update [`done.md`](done.md) and add a `completed/<slice>.md` note when the slice merges.
+8. Ship green.
+
+Both gates run against [`../architecture/checklist.md`](../architecture/checklist.md) — the single authoritative invariant list. A rule change lands there once; both gates and the planner pick it up.
 
 ## Slice queue
 

--- a/docs/use-cases/command-framework.md
+++ b/docs/use-cases/command-framework.md
@@ -36,6 +36,7 @@ The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `@spawn`, 
 ## Postconditions
 
 - Every existing command implements the new `ICommand` shape: declares `Category`, `ShortDescription`, `LongDescription`, `Usage`, `RequiredPrivileges`, an `ArgumentSchema`, and an `ExecuteAsync(CommandContext)` body. None call `session.SendLineAsync(...)` directly; output goes through `CommandContext.Output`.
+- **No `session.SendLineAsync` survives anywhere on the dispatch path, including the dispatcher's own branches.** The existing unknown-verb call site at `Core/Commands/CommandDispatcher.cs:43` (`session.SendLineAsync($"Unknown command: {verb}")`) and any parse-error / unauthorized / exception output the dispatcher emits are routed through an `IOutputWriter` obtained via `IOutputWriterFactory.Create(session)`. This call site is named explicitly in the refactor checklist (Main Flow step 8) so it is not missed — it is *not* one of the 12 command files and would otherwise survive the refactor and break this postcondition on day one (INV-11).
 - Argument parsing is performed by a shared `ICommandArgumentParser` against each command's declarative schema. Commands no longer call `Trim()` / `Split()` in their bodies. Double-quoted arguments are supported. Enum-prefix matching works from day one (`n`/`no`/`nor` resolves to `north`).
 - Admin commands no longer call `IAdminAuthorizer.IsPrivileged` as their first line. Privilege is enforced structurally by `CommandDispatcher` consulting each command's `RequiredPrivileges` and an injected `IAuthorizationChecker`. Forgetting the gate is impossible — `RequiredPrivileges` is a required interface member; empty list = public.
 - `help` and `help <verb>` are usable from any session. `help` lists every command visible to the caller (admin commands hidden when authorization fails), grouped by `Category`, rendered via typed `HelpIndexMessage`. `help <verb>` shows `LongDescription` and `Usage` via `HelpEntryMessage`. The required `@reload` long-form wording from slice 2 is emitted by `help @reload`.
@@ -62,7 +63,8 @@ The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `@spawn`, 
 
 7. **`help` / `commands`.** `HelpCommand` enumerates DI-collected `IEnumerable<ICommand>`, filters by visibility (admin commands hidden when their `RequiredPrivileges` are unsatisfied for the caller — checked via `IAuthorizationChecker`), groups by `Category`, and writes `HelpIndexMessage` (no arg) or `HelpEntryMessage` (with `<verb>`). `CommandsCommand` is a thinner shortcut to the same index.
 
-8. **Refactor pass.** Every existing command moves to the new shape:
+8. **Refactor pass.** The dispatcher's own internal output call sites move first, then every existing command:
+   - **`CommandDispatcher` internals** — the unknown-verb branch (`CommandDispatcher.cs:43`), the parse-error response, the unauthorized response, and the exception-trap response all write through an `IOutputWriter` (via `IOutputWriterFactory.Create(session)`), never `session.SendLineAsync`. This is the V3 fix from the spec-mode review; it is a checklist item, not an implied consequence of the command refactor.
    - **`look`** — Category `Player`, empty `RequiredPrivileges`, no args. Writes whatever room-description output the command currently produces via `IBroadcastSystem` (broadcast body is untouched this slice; slice 4 reworks it).
    - **`say`** — Category `Player`, one `RestOfLine` `string` arg ("message"), publishes `PlayerSaidEvent` unchanged.
    - **`MoveCommand` (×6)** — Category `Player`, no args, publishes `PlayerMovedEvent` unchanged. Failure path writes a `PlainMessage`.
@@ -94,7 +96,7 @@ Success | ParseFailed | Unauthorized | Threw
 
 ### `ArgsSummary` content
 
-A short normalized rendering of the parsed args for log readability — e.g. `@dig east room.crossroads` summarizes to `east room.crossroads`. Dispatcher truncates at 200 characters. No PII filtering this slice; `say` content is logged plain. A follow-up slice may add a per-command `[NoLogArgs]` attribute if it becomes an operational concern. Partial-success vs command-success is a layer above and stays inside the command body — it does not affect `Outcome`.
+A short normalized rendering of the parsed args for log readability — e.g. `@dig east room.crossroads` summarizes to `east room.crossroads`. Dispatcher truncates at 200 characters. **Known operational gap (spec-mode S4):** there is no argument-redaction mechanism this slice, so `say` content (and any future `tell` / `password` / auth-bearing verb) is written to logs in plaintext. This is acceptable for slice 3 because the only verb with free-text args is `say` and the logger is local, but it **must not** ship to any environment with retained/forwarded logs without redaction. Tracked as an explicit acknowledged-debt item in [`../roadmap/backlog.md`](../roadmap/backlog.md) ("Command-arg log redaction") with the proposed fix (a per-command `[NoLogArgs]` / `RedactArgs` declaration honored by the dispatcher before it builds `ArgsSummary`). It is a prerequisite for any non-local logging sink. Partial-success vs command-success is a layer above and stays inside the command body — it does not affect `Outcome`.
 
 ---
 
@@ -135,6 +137,8 @@ public sealed record CommandContext(
 ### ICommandDispatcher (existing — extended)
 
 Same interface signature (`Task DispatchAsync(ISession session, string input)`). Implementation gains: privilege gate (`IAuthorizationChecker`), parse step (`ICommandArgumentParser`), `CommandContext` construction, exception trap, `CommandExecutedEvent` publish. Constructor gains `IAuthorizationChecker`, `ICommandArgumentParser`, `IOutputWriterFactory`, `IEventBus`, `ILogger<CommandDispatcher>`. It does not know admin policy or output transport — it asks the injected abstractions.
+
+**Layer classification (resolves spec-mode V1).** `CommandDispatcher` is the **runtime of the command-Initiator tier**, not a domain or core system, despite living under `Core/`. Per [`../architecture/01-layers.md`](../architecture/01-layers.md#initiators--entry-points) and [`../architecture/checklist.md`](../architecture/checklist.md) INV-5, Initiators and Handlers are the tiers permitted to publish events; systems are not. The dispatcher publishing `CommandExecutedEvent` is therefore correct by the architecture — it is the only component that observes every dispatch outcome (success / parse-fail / unauthorized / threw), so the event cannot be sourced anywhere else. This was flagged as a violation by the spec-mode review *against the pre-Initiators `01-layers.md`*; the architecture doc was the thing that was wrong (it never named the command tier) and has been corrected. No code change implied — the spec was right; the doc caught up.
 
 ### ICommandArgumentParser (new — core utility)
 
@@ -237,7 +241,7 @@ Per ground rule 8: this slice introduces no new gameplay state; the tooling it a
 
 - **Replaces Flow 3 — Player command lifecycle** ([`../architecture/06-flows.md`](../architecture/06-flows.md)). The current Flow 3 is marked "slice 3 will replace this flow." Slice 3's PR rewrites Flow 3 to the framework-driven trace: input → verb lookup → **authorization gate (`IAuthorizationChecker` over `RequiredPrivileges`)** → **argument parse (`ICommandArgumentParser` over `ArgumentSchema`)** → `CommandContext` construction → `ExecuteAsync(context)` → output via the minimal `IOutputWriter` (stringify-and-forward) → exception trap → `CommandExecutedEvent` publish → priority-ordered handlers (`CommandLoggingHandler` at 80). The "What's hand-rolled today" subsection is deleted; replaced with the structural guarantees. The mermaid diagram is re-drawn. Slice 4 will modify the output leg of this same flow again.
 - **No new canonical flow introduced.** The command lifecycle is the replacement of an existing flow, not a new recurring chain. (Output rendering becomes its own flow in slice 4.)
-- **Flow 5 (`@reload`) note touched, not re-traced.** `ReloadCommand`'s in-body `IsPrivileged` call moves to the dispatcher gate; the slice-3 PR updates Flow 5's step 2 prose to point at the structural gate instead of the per-command check. The reload mechanics (steps 3–10) are unchanged.
+- **Flow 5 (`@reload`) — mermaid re-draw + prose, not prose-only.** `ReloadCommand`'s in-body `IsPrivileged` call moves to the dispatcher gate. Flow 5's current mermaid diagram has an explicit `RC->>Auth: IsPrivileged` participant interaction and an `alt not privileged` branch *inside the command*; those must be **removed and re-drawn** so the gate sits in the dispatcher before `ReloadCommand` is invoked — a prose-only edit would leave the diagram contradicting the code (spec-mode S2/D5). The reload mechanics (steps 3–10) are unchanged. The slice-3 PR re-draws the Flow 5 diagram and rewrites its step 2.
 
 ---
 
@@ -250,14 +254,30 @@ Per ground rule 8: this slice introduces no new gameplay state; the tooling it a
 - **`help` dogfoods typed output.** `HelpIndexMessage` / `HelpEntryMessage` are real `IOutputMessage` shapes even though the slice-3 writer only stringifies them. This sets the documentation-during-development bar and gives slice 4 a real consumer to render with color on day one.
 - **Minimal output seam is deliberately incomplete.** The owed-to-slice-4 list is enumerated in the `IOutputMessage` section above so the split is auditable. Slice 4 replaces the writer impl, not the interface.
 - **No exception leaks.** The dispatcher wraps `ExecuteAsync` in try/catch; uncaught exceptions log a stack trace at `Error` and emit `PlainMessage("Something went wrong. The error has been logged.", Error)`. `CommandOutcome.Threw` flags the event.
-- **Docs to author alongside the implementation slice (not this planning step).** `docs/architecture/06-commands.md` (command framework design); `docs/reference/commands.md` (living command catalog, parallel to `systems.md`/`handlers.md`); update `docs/architecture/00-overview.md` to link them; update `CLAUDE.md` ground rules so every command lives in the framework (arg parsing, help, and privilege are not hand-rolled); rewrite Flow 3 in `06-flows.md`; update Flow 5's privilege-step prose.
+- **Sanctioned by the Initiators tier (resolves spec-mode V2).** The six commands that publish events (`SayCommand`, `MoveCommand`, the four admin commands) are *Initiators*, not systems — INV-5/INV-8 explicitly permit them to publish. The spec preserving "slice-2 events still published unchanged" is correct, not a carried-forward violation; the pre-Initiators `01-layers.md` simply had no tier for commands. Recorded here so it is not re-flagged.
+- **`CommandDispatcher` dependency count is a known smell (spec-mode S1), deferred.** Five injected dependencies plus authorization/parsing/output/publish/exception-trap responsibilities trend toward a god-class. A `CommandPipeline` middleware chain would isolate these. Deferred deliberately: introducing a middleware framework inside slice 3 would balloon scope and risk the 12-command refactor. Tracked in [`../roadmap/backlog.md`](../roadmap/backlog.md); revisit if a sixth concern is added to the dispatcher.
+- **Docs to author alongside the implementation slice (not this planning step).** `docs/architecture/06-commands.md` (command framework design); `docs/reference/commands.md` (living command catalog, parallel to `systems.md`/`handlers.md`); update `docs/architecture/00-overview.md` to link them; update `CLAUDE.md` ground rules so every command lives in the framework (arg parsing, help, and privilege are not hand-rolled); rewrite Flow 3 in `06-flows.md` (body + re-drawn mermaid); **re-draw Flow 5's mermaid** and rewrite its step 2 (the privilege participant moves out of the command into the dispatcher gate — diagram change, not prose-only).
 - **Out of scope for this slice.** All output formatting/color (slice 4). Broadcast expansion (slice 4). Tab completion. Verb-prefix matching. Entity-name argument resolution. Output streaming/paging. Prompt customization. i18n templates.
 
 ---
 
 ## Open Questions
 
-None new. The seven planning-round questions (argument schema shape, privilege gate seam, `CommandContext` vs shim, `CommandExecutedEvent` granularity, `help` typed-output dogfooding, broadcast model, slice numbering) were resolved by the user and are baked into this doc. The broadcast model and color-DSL syntax are slice-4 concerns (see [`output-framework.md`](output-framework.md)).
+None. The seven planning-round questions were resolved by the user and are baked in. The broadcast model and color-DSL syntax are slice-4 concerns (see [`output-framework.md`](output-framework.md)).
+
+## Spec-review provenance
+
+This spec passed a **spec-mode `architecture-reviewer`** pass (the first run of the new pre-implementation gate). Findings and disposition:
+
+- **V1** (dispatcher publishes `CommandExecutedEvent`) — *root cause: the architecture doc, not the spec.* `01-layers.md` had no tier for commands, so "only handlers publish" read as if it banned the dispatcher. Resolved by adding the **Initiators** tier to `01-layers.md` and `checklist.md` (INV-5/INV-8–11). Spec unchanged; classification recorded in the `ICommandDispatcher` section.
+- **V2** (six commands publish directly) — same root cause; sanctioned by INV-5/INV-8. Recorded in Design Notes; spec unchanged.
+- **V3** (`CommandDispatcher.cs:43` survives the refactor) — *real spec gap.* Fixed: the dispatcher's own output call sites are now an explicit postcondition + Main-Flow step 8 checklist item.
+- **S1** (dispatcher god-class) — accepted for slice 3, middleware refactor deferred to backlog.
+- **S2/D3/D5** (Flow 3/5 mermaid re-draw) — spec wording corrected to require diagram re-draw, not prose-only.
+- **S4** (arg-log PII) — promoted from vague "may" to a tracked acknowledged-debt backlog item gating non-local logging.
+- **S3** (command layer ambiguity) — was the root cause of V1/V2; resolved by the Initiators tier.
+
+This section is the audit trail for why the spec is shaped as it is; it is not an open-items list.
 
 ---
 


### PR DESCRIPTION
## Summary

Markdown-only. Closes the architecture-doc gap the slice-3 spec-mode review exposed, and installs the process change that catches this class of error before implementation.

**Root cause:** `01-layers.md` defined a 4-layer model (Handlers/Domain/Core/Components) that never named commands, while the `add-command` skill and the codebase have treated commands as a thin event-publishing tier since Phase 2. "Only handlers publish events" therefore read as if it banned commands and the dispatcher — it doesn't, it constrains *systems*. Three slices ran without anyone catching it because no gate compared spec-or-code against the doc's text until post-implementation review.

## What changed

**`docs/architecture/01-layers.md`** — new **Initiators / Entry Points** tier above the processing stack. Commands (external input) + scheduled heartbeat (internal/temporal) are its members; Initiators and Handlers are the only tiers permitted to publish events. Documents the no-chain variant (`PersistenceFlushTimer`), classifies `CommandDispatcher` as initiator-tier runtime, records heartbeat forward-design constraints (so slice 8 plugs in cleanly), and rescopes the Forbidden list to "Domain & Core Systems → Event Bus."

**`docs/architecture/checklist.md`** (new) — single authoritative invariant list (`INV-1..19` + spec-review failure modes `SR-1..5`). The `architecture-reviewer` (both modes), the `use-case-planner` ground-rule-9 audit, and the future debt-sweep all read this. No agent prompt carries a private rule copy — that duplication was the drift source that hid the command-tier gap. `00-overview.md` / `03-events.md` / `CLAUDE.md` now point here as the index.

**`.claude/agents/architecture-reviewer.md`** — inline rules removed (reads the checklist); explicit **spec|code mode** selector. Spec mode reviews a use-case doc *before* implementation; code mode reviews a diff before merge.

**Per-slice cadence** (`plan.md` + `CLAUDE.md`) — inserted the spec-review gate: planner → resolve open questions → **architecture-reviewer (spec mode)** → implement → **architecture-reviewer (code mode)** → ship.

**`docs/use-cases/command-framework.md`** — spec fixes from the spec-mode review:
- **V3**: dispatcher's own output call sites (incl. `CommandDispatcher.cs:43`) added as explicit postcondition + refactor checklist item
- **V1/V2**: dispatcher/command publishing recorded as sanctioned by the Initiators tier (spec was right; the doc caught up)
- **S1**: dispatcher god-class accepted for slice 3, middleware refactor → backlog
- **S2/D5**: Flow 3/5 wording corrected to require mermaid re-draw, not prose-only
- **S4**: arg-log PII promoted to a tracked acknowledged-debt backlog item
- new "Spec-review provenance" section as the audit trail

**`docs/roadmap/backlog.md`** — command-arg log redaction (S4) and CommandPipeline middleware refactor (S1) added as deferred items.

## Why this matters

This is the same class of fix as the ground-rule-9 hardening: a structural gate so the failure can't silently recur. The slice-3 implementation built on the old branch is scrapped; it will be re-run against this corrected, self-consistent spec under the new two-gate cadence.

## Test plan

- [x] Markdown only — no code, no build impact
- [x] Cross-references resolve (01-layers ↔ checklist ↔ 03-events ↔ 00-overview ↔ CLAUDE.md)
- [ ] Reviewer sanity-check: does the Initiators tier reading of INV-5 hold for the existing `MoveCommand`/`SayCommand`/admin commands? (it does — they're Initiators, publishing is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)