### PR TITLE
Phase 3 slice 3: command framework (typed context, structural auth, declarative parsing, help)

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -1,52 +1,98 @@
 ---
 name: add-command
-description: Use when adding a new player or admin command (wear, drink, cast, craft, buy, etc.). Covers parsing, the thin-command rule (parse -> call system -> publish event), and how it connects to the handler pipeline. Invoke when the user asks to add a command, wire up a verb, or extend the command dispatcher.
+description: Use when adding a new player or admin command (wear, drink, cast, craft, buy, etc.). Covers the ICommand shape, argument schema, privilege declaration, output via IOutputWriter, and how it connects to the dispatcher and event pipeline. Invoke when the user asks to add a command, wire up a verb, or extend the command dispatcher.
 ---
 
 # Add a Command
 
-A command is the thinnest possible layer: it parses player input, resolves a target from the world, and asks a domain system to do the work. It does **not** contain gameplay logic.
+A command is the thinnest possible layer: it declares its argument schema and privilege requirements, then delegates to a domain system or publishes an event. It does **not** contain gameplay logic and does **not** call `session.SendLineAsync` directly.
 
-Authoritative rules: [docs/architecture/01-layers.md](../../../docs/architecture/01-layers.md) · command pipeline rule: [docs/architecture/03-events.md](../../../docs/architecture/03-events.md) · avoid god commands: [docs/architecture/04-pitfalls.md](../../../docs/architecture/04-pitfalls.md).
+Authoritative rules: [`docs/architecture/06-commands.md`](../../../docs/architecture/06-commands.md) · layer discipline: [`docs/architecture/01-layers.md`](../../../docs/architecture/01-layers.md) · avoid god commands: [`docs/architecture/04-pitfalls.md`](../../../docs/architecture/04-pitfalls.md).
 
 ## Shape
 
 ```csharp
-public class DrinkCommand : ICommand
+public sealed class DrinkCommand : ICommand
 {
-    private readonly IInventorySystem _inv;
     private readonly IPotionSystem _potions;
-    private readonly IEventBus _bus;
+    private readonly IEventBus _eventBus;
 
-    public void Execute(uint playerId, string args)
+    public string Name => "drink";
+    public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+    public CommandCategory Category => CommandCategory.Player;
+    public string ShortDescription => "Drink a potion from your inventory.";
+    public string LongDescription => "Consumes a potion by name from your inventory, applying its effect immediately.";
+    public string Usage => "drink <itemName>";
+    public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+        Array.Empty<IAuthorizationRequirement>(); // empty = public
+    public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
     {
-        var potionId = _inv.FindByName(playerId, args);
-        if (potionId == 0) { _bus.Publish(new CommandFailedEvent(playerId, "You don't have that.")); return; }
-        var result = _potions.Drink(playerId, potionId);
-        _bus.Publish(new ItemDestroyedEvent(potionId));
-        // further events per result
+        new CommandArgument("itemName", typeof(string), CommandArgumentKind.Token,
+            Required: true, "Name of the potion to drink."),
+    });
+
+    public DrinkCommand(IPotionSystem potions, IEventBus eventBus)
+    {
+        _potions = potions;
+        _eventBus = eventBus;
+    }
+
+    public async Task ExecuteAsync(CommandContext context)
+    {
+        var itemName = context.Args.Get<string>("itemName");
+
+        var result = _potions.Drink(context.InvokerEntityId, itemName);
+        if (!result.Success)
+        {
+            await context.Output.WriteAsync(
+                new PlainMessage(result.ErrorMessage ?? "You don't have that.", OutputSeverity.Error))
+                .ConfigureAwait(false);
+            return;
+        }
+
+        await context.Output.WriteAsync(
+            new PlainMessage($"You drink the {itemName}.", OutputSeverity.Confirmation))
+            .ConfigureAwait(false);
+
+        await _eventBus.PublishAsync(new PotionConsumedEvent(context.InvokerEntityId, result.ItemId))
+            .ConfigureAwait(false);
     }
 }
 ```
 
-Target size: **≤ 30 lines**. If it grows, the logic belongs in a system, not in the command.
+Target size: **≤ 40 lines of body**. If it grows, the logic belongs in a domain system, not in the command.
 
 ## Steps
 
-1. File location: `Core/Modules/<Feature>/Commands/<X>Command.cs` (feature-owned) or `Core/Commands/<X>Command.cs` (cross-cutting like `look` or `who`).
-2. Register the verb + aliases with the command dispatcher.
-3. Parse args; resolve target IDs via `InventorySystem.FindByName`, `LocationSystem.FindInRoom`, etc.
-4. Call the relevant domain system (`PotionSystem.Drink`, `EquipmentSystem.Equip`, `CombatSystem.InitiateCombat`).
-5. Publish the resulting events (see **add-event** skill for payload shape).
-6. If the command implements a use case, add the use-case file's "Main flow" step that invokes this command.
+1. **File location:** `Core/Modules/<Feature>/Commands/<X>Command.cs` (feature-owned) or `Core/Commands/<X>Command.cs` (cross-cutting like `look` or `who`).
+2. **Implement `ICommand`** — all eight interface members. Use `CommandArgumentSchema.Empty` for no-arg commands.
+3. **Argument kinds:**
+   - `Token` — single whitespace-delimited token (or double-quoted group). Works for strings, ints, uints, and enums.
+   - `RestOfLine` — everything after previous tokens. Use for `say`, `tell`, multi-word freeform input.
+   - `Quantified` — leading count + token. Deferred; not yet used.
+4. **Privilege:**
+   - Public command: `RequiredPrivileges = Array.Empty<IAuthorizationRequirement>()`
+   - Admin command: `RequiredPrivileges = new IAuthorizationRequirement[] { new AdminRequirement() }`
+   - **Never** call `IAdminAuthorizer.IsPrivileged` inside the command body — the dispatcher handles it.
+5. **Output:** always write via `context.Output.WriteAsync(IOutputMessage)`. Use `PlainMessage` for text. Use `OutputSeverity.Error` for failures, `Confirmation` for success, `System` for neutral messages.
+6. **Register** in the feature module: `services.AddSingleton<ICommand, DrinkCommand>();`
+7. **Subscribe** the handler that consumes the event the command publishes (if any) in `Server/Program.cs`.
+8. **Docs:** add a row to `docs/reference/commands.md`.
+
+## Admin commands
+
+```csharp
+public string Name => "grant";
+public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+    new IAuthorizationRequirement[] { new AdminRequirement() };
+```
+
+No `IsPrivileged` call in the body. Privilege is enforced by the dispatcher before `ExecuteAsync` is called. The compiler forces you to declare `RequiredPrivileges` (it is a required interface member); empty list = public.
 
 ## What NOT to do
 
-- **Don't put gameplay rules in the command.** Rules live in the domain system.
-- **Don't do multi-step orchestration inside a command.** If you're publishing event A, then calling system X, then publishing event B conditional on a second system — you're writing a handler, not a command. Move it.
-- **Don't bypass the event bus for "simple" cross-cutting effects.** Notifications, persistence, AI updates all listen on events; a command that skips the bus will skip those.
-- **Don't duplicate parsing logic across commands.** Share resolvers like `InventorySystem.FindByName`.
-
-## Access control
-
-Commands that mutate restricted state (admin verbs, container access) must call `AccessControlSystem.CanAccess` **before** any mutation.
+- **No `session.SendLineAsync` calls.** Use `context.Output.WriteAsync(new PlainMessage(...))`.
+- **No gameplay rules in the command.** Rules live in the domain system.
+- **No multi-step orchestration inside a command.** If you're publishing event A, calling system X, then publishing event B — that's a handler, not a command. Move the orchestration out.
+- **No `IAdminAuthorizer.IsPrivileged` calls.** Declare `RequiredPrivileges`; the dispatcher checks it.
+- **No argument parsing by hand.** Declare `CommandArgumentSchema` and read via `context.Args.Get<T>(name)`.

--- a/Core/Commands/Authorization/AdminRequirement.cs
+++ b/Core/Commands/Authorization/AdminRequirement.cs
@@ -1,0 +1,5 @@
+namespace Hedron.Core.Commands.Authorization
+{
+    /// <summary>Requires the caller to be a privileged admin session.</summary>
+    public sealed record AdminRequirement : IAuthorizationRequirement;
+}

--- a/Core/Commands/Authorization/AuthorizationChecker.cs
+++ b/Core/Commands/Authorization/AuthorizationChecker.cs
@@ -1,0 +1,25 @@
+using Hedron.Core.Modules.Admin.Systems;
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Commands.Authorization
+{
+    /// <summary>
+    /// Default checker: pattern-matches the requirement type. <see cref="AdminRequirement"/>
+    /// delegates to the existing <see cref="IAdminAuthorizer"/>. Future requirement types
+    /// extend this without touching the dispatcher.
+    /// </summary>
+    public sealed class AuthorizationChecker : IAuthorizationChecker
+    {
+        private readonly IAdminAuthorizer _adminAuthorizer;
+
+        public AuthorizationChecker(IAdminAuthorizer adminAuthorizer)
+            => _adminAuthorizer = adminAuthorizer;
+
+        public bool IsSatisfied(IAuthorizationRequirement requirement, ISession session)
+            => requirement switch
+            {
+                AdminRequirement => _adminAuthorizer.IsPrivileged(session),
+                _ => false,
+            };
+    }
+}

--- a/Core/Commands/Authorization/IAuthorizationChecker.cs
+++ b/Core/Commands/Authorization/IAuthorizationChecker.cs
@@ -1,0 +1,14 @@
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Commands.Authorization
+{
+    /// <summary>
+    /// Evaluates whether a session satisfies a single <see cref="IAuthorizationRequirement"/>.
+    /// The dispatcher iterates <see cref="ICommand.RequiredPrivileges"/> and calls this for
+    /// each — decoupling policy from dispatch.
+    /// </summary>
+    public interface IAuthorizationChecker
+    {
+        bool IsSatisfied(IAuthorizationRequirement requirement, ISession session);
+    }
+}

--- a/Core/Commands/Authorization/IAuthorizationRequirement.cs
+++ b/Core/Commands/Authorization/IAuthorizationRequirement.cs
@@ -1,0 +1,8 @@
+namespace Hedron.Core.Commands.Authorization
+{
+    /// <summary>
+    /// Marker for a single privilege requirement. Commands declare which requirements a
+    /// caller must satisfy via <see cref="ICommand.RequiredPrivileges"/>.
+    /// </summary>
+    public interface IAuthorizationRequirement { }
+}

--- a/Core/Commands/CommandArgument.cs
+++ b/Core/Commands/CommandArgument.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>Declares one positional argument in a command's argument schema.</summary>
+    public sealed record CommandArgument(
+        string Name,
+        Type ClrType,
+        CommandArgumentKind Kind,
+        bool Required,
+        string? HelpText,
+        IArgumentResolver? Resolver = null);
+}

--- a/Core/Commands/CommandArgumentKind.cs
+++ b/Core/Commands/CommandArgumentKind.cs
@@ -1,0 +1,13 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>How a single argument consumes tokens from the raw input tail.</summary>
+    public enum CommandArgumentKind
+    {
+        /// <summary>Consumes exactly one whitespace-delimited token (or double-quoted group).</summary>
+        Token,
+        /// <summary>Consumes everything from the current position to end-of-line.</summary>
+        RestOfLine,
+        /// <summary>Reads a leading count token followed by a second token (e.g. "3 coins").</summary>
+        Quantified,
+    }
+}

--- a/Core/Commands/CommandArgumentParser.cs
+++ b/Core/Commands/CommandArgumentParser.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Default argument parser: single-pass, whitespace + double-quoted tokenization,
+    /// enum-prefix matching. <see cref="IArgumentResolver"/> seam is null this slice.
+    /// </summary>
+    public sealed class CommandArgumentParser : ICommandArgumentParser
+    {
+        public ParseResult Parse(CommandArgumentSchema schema, string rawTail)
+        {
+            if (!schema.Arguments.Any())
+                return new ParseResult.Success(ParsedArguments.Empty);
+
+            var values = new Dictionary<string, object?>();
+            var pos = 0;
+
+            SkipWhitespace(rawTail, ref pos);
+
+            foreach (var arg in schema.Arguments)
+            {
+                switch (arg.Kind)
+                {
+                    case CommandArgumentKind.Token:
+                    {
+                        if (pos >= rawTail.Length)
+                        {
+                            if (arg.Required)
+                                return new ParseResult.Failure($"Missing required argument '{arg.Name}'.");
+                            break;
+                        }
+
+                        var token = ReadToken(rawTail, ref pos);
+                        var coerced = Coerce(token, arg.ClrType);
+                        if (coerced is null)
+                            return new ParseResult.Failure(
+                                $"'{token}' is not a valid {arg.ClrType.Name} for '{arg.Name}'.");
+                        values[arg.Name] = coerced;
+                        SkipWhitespace(rawTail, ref pos);
+                        break;
+                    }
+
+                    case CommandArgumentKind.RestOfLine:
+                    {
+                        if (pos >= rawTail.Length)
+                        {
+                            if (arg.Required)
+                                return new ParseResult.Failure($"Missing required argument '{arg.Name}'.");
+                            break;
+                        }
+                        values[arg.Name] = rawTail[pos..].TrimEnd();
+                        pos = rawTail.Length;
+                        break;
+                    }
+
+                    case CommandArgumentKind.Quantified:
+                        // Deferred — not used in slice 3.
+                        break;
+                }
+            }
+
+            return new ParseResult.Success(new ParsedArguments(values));
+        }
+
+        private static string ReadToken(string input, ref int pos)
+        {
+            if (input[pos] == '"')
+            {
+                pos++; // skip opening quote
+                var start = pos;
+                while (pos < input.Length && input[pos] != '"') pos++;
+                var token = input[start..pos];
+                if (pos < input.Length) pos++; // skip closing quote
+                return token;
+            }
+            else
+            {
+                var start = pos;
+                while (pos < input.Length && !char.IsWhiteSpace(input[pos])) pos++;
+                return input[start..pos];
+            }
+        }
+
+        private static void SkipWhitespace(string input, ref int pos)
+        {
+            while (pos < input.Length && char.IsWhiteSpace(input[pos])) pos++;
+        }
+
+        private static object? Coerce(string token, Type clrType)
+        {
+            if (clrType == typeof(string)) return token;
+            if (clrType == typeof(int)) return int.TryParse(token, out var i) ? (object)i : null;
+            if (clrType == typeof(uint)) return uint.TryParse(token, out var u) ? (object)u : null;
+            if (clrType.IsEnum) return TryParseEnumPrefix(token, clrType);
+            return null;
+        }
+
+        private static object? TryParseEnumPrefix(string token, Type enumType)
+        {
+            if (Enum.TryParse(enumType, token, ignoreCase: true, out var exact)) return exact;
+
+            string? matched = null;
+            foreach (var name in Enum.GetNames(enumType))
+            {
+                if (!name.StartsWith(token, StringComparison.OrdinalIgnoreCase)) continue;
+                if (matched is not null) return null; // ambiguous prefix
+                matched = name;
+            }
+            return matched is null ? null : Enum.Parse(enumType, matched, ignoreCase: true);
+        }
+    }
+}

--- a/Core/Commands/CommandArgumentSchema.cs
+++ b/Core/Commands/CommandArgumentSchema.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>Declares the full argument list for one command.</summary>
+    public sealed record CommandArgumentSchema(IReadOnlyList<CommandArgument> Arguments)
+    {
+        public static readonly CommandArgumentSchema Empty =
+            new(Array.Empty<CommandArgument>());
+    }
+}

--- a/Core/Commands/CommandCategory.cs
+++ b/Core/Commands/CommandCategory.cs
@@ -1,0 +1,10 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>Groups commands for help display and visibility filtering.</summary>
+    public enum CommandCategory
+    {
+        Player,
+        Admin,
+        System,
+    }
+}

--- a/Core/Commands/CommandContext.cs
+++ b/Core/Commands/CommandContext.cs
@@ -1,0 +1,17 @@
+using System;
+using Hedron.Core.Output;
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Passed to every <see cref="ICommand.ExecuteAsync"/> invocation. Replaces the old
+    /// <c>(ISession, string)</c> pair with typed parsed arguments and a typed output writer.
+    /// </summary>
+    public sealed record CommandContext(
+        ISession Session,
+        uint InvokerEntityId,
+        ParsedArguments Args,
+        IOutputWriter Output,
+        IServiceProvider Services);
+}

--- a/Core/Commands/CommandDispatcher.cs
+++ b/Core/Commands/CommandDispatcher.cs
@@ -1,22 +1,49 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.Commands.Events;
+using Hedron.Core.Events;
+using Hedron.Core.Output;
 using Hedron.Core.Sessions;
+using Microsoft.Extensions.Logging;
 
 namespace Hedron.Core.Commands
 {
     /// <summary>
-    /// Default <see cref="ICommandDispatcher"/>: builds a verb → command map from the
-    /// DI-registered set of <see cref="ICommand"/>s at construction.
+    /// Runtime of the command-Initiator tier. Builds a verb → command map at construction,
+    /// then for each dispatch: checks authorization, parses arguments, constructs a
+    /// <see cref="CommandContext"/>, calls <see cref="ICommand.ExecuteAsync"/>, and
+    /// publishes <see cref="CommandExecutedEvent"/> on every outcome.
     /// </summary>
     public class CommandDispatcher : ICommandDispatcher
     {
         private readonly Dictionary<string, ICommand> _byVerb =
             new(StringComparer.OrdinalIgnoreCase);
 
-        public CommandDispatcher(IEnumerable<ICommand> commands)
+        private readonly IAuthorizationChecker _authorizationChecker;
+        private readonly ICommandArgumentParser _argumentParser;
+        private readonly IOutputWriterFactory _outputWriterFactory;
+        private readonly IEventBus _eventBus;
+        private readonly ILogger<CommandDispatcher> _logger;
+        private readonly IServiceProvider _services;
+
+        public CommandDispatcher(
+            IEnumerable<ICommand> commands,
+            IAuthorizationChecker authorizationChecker,
+            ICommandArgumentParser argumentParser,
+            IOutputWriterFactory outputWriterFactory,
+            IEventBus eventBus,
+            ILogger<CommandDispatcher> logger,
+            IServiceProvider services)
         {
             if (commands is null) throw new ArgumentNullException(nameof(commands));
+            _authorizationChecker = authorizationChecker ?? throw new ArgumentNullException(nameof(authorizationChecker));
+            _argumentParser = argumentParser ?? throw new ArgumentNullException(nameof(argumentParser));
+            _outputWriterFactory = outputWriterFactory ?? throw new ArgumentNullException(nameof(outputWriterFactory));
+            _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _services = services ?? throw new ArgumentNullException(nameof(services));
 
             foreach (var command in commands)
             {
@@ -26,29 +53,88 @@ namespace Hedron.Core.Commands
             }
         }
 
-        public Task DispatchAsync(ISession session, string input)
+        public async Task DispatchAsync(ISession session, string input)
         {
             if (session is null) throw new ArgumentNullException(nameof(session));
-            if (string.IsNullOrWhiteSpace(input))
-                return Task.CompletedTask;
+            if (string.IsNullOrWhiteSpace(input)) return;
 
+            var output = _outputWriterFactory.Create(session);
             var trimmed = input.Trim();
             var splitAt = trimmed.IndexOf(' ');
             var verb = splitAt < 0 ? trimmed : trimmed[..splitAt];
-            var args = splitAt < 0 ? string.Empty : trimmed[(splitAt + 1)..].Trim();
+            var rawTail = splitAt < 0 ? string.Empty : trimmed[(splitAt + 1)..].TrimStart();
 
-            if (_byVerb.TryGetValue(verb, out var command))
-                return command.ExecuteAsync(session, args);
+            if (!_byVerb.TryGetValue(verb, out var command))
+            {
+                await output.WriteAsync(new PlainMessage(
+                    $"Unknown command: {verb}. Type 'help' for a list.", OutputSeverity.Error))
+                    .ConfigureAwait(false);
+                await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.ParseFailed)
+                    .ConfigureAwait(false);
+                return;
+            }
 
-            return session.SendLineAsync($"Unknown command: {verb}");
+            // Privilege gate
+            foreach (var req in command.RequiredPrivileges)
+            {
+                if (!_authorizationChecker.IsSatisfied(req, session))
+                {
+                    await output.WriteAsync(new PlainMessage(
+                        "You are not authorized to use that command.", OutputSeverity.Error))
+                        .ConfigureAwait(false);
+                    await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.Unauthorized)
+                        .ConfigureAwait(false);
+                    return;
+                }
+            }
+
+            // Argument parse
+            var parseResult = _argumentParser.Parse(command.ArgumentSchema, rawTail);
+            if (parseResult is ParseResult.Failure failure)
+            {
+                await output.WriteAsync(new PlainMessage(
+                    $"{failure.Reason} Type 'help {verb}' for usage.", OutputSeverity.Error))
+                    .ConfigureAwait(false);
+                await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.ParseFailed)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            var parsedArgs = ((ParseResult.Success)parseResult).Args;
+            var argsSummary = BuildArgsSummary(rawTail);
+            var context = new CommandContext(session, session.PlayerEntityId, parsedArgs, output, _services);
+
+            try
+            {
+                await command.ExecuteAsync(context).ConfigureAwait(false);
+                await PublishExecutedAsync(session.PlayerEntityId, verb, argsSummary, CommandOutcome.Success)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Command {Verb} threw for entity {EntityId}", verb, session.PlayerEntityId);
+                await output.WriteAsync(new PlainMessage(
+                    "Something went wrong. The error has been logged.", OutputSeverity.Error))
+                    .ConfigureAwait(false);
+                await PublishExecutedAsync(session.PlayerEntityId, verb, argsSummary, CommandOutcome.Threw)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        private Task PublishExecutedAsync(uint entityId, string verb, string argsSummary, CommandOutcome outcome)
+            => _eventBus.PublishAsync(new CommandExecutedEvent(entityId, verb, argsSummary, outcome));
+
+        private static string BuildArgsSummary(string rawTail)
+        {
+            const int MaxLength = 200;
+            return rawTail.Length <= MaxLength ? rawTail : rawTail[..MaxLength];
         }
 
         private void Register(string verb, ICommand command)
         {
             if (string.IsNullOrWhiteSpace(verb))
                 throw new ArgumentException(
-                    $"Command '{command.GetType().Name}' declared a blank verb.",
-                    nameof(command));
+                    $"Command '{command.GetType().Name}' declared a blank verb.", nameof(command));
 
             if (_byVerb.TryGetValue(verb, out var existing))
                 throw new InvalidOperationException(

--- a/Core/Commands/CommandOutcome.cs
+++ b/Core/Commands/CommandOutcome.cs
@@ -1,0 +1,11 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>Result classification published on every <c>CommandExecutedEvent</c>.</summary>
+    public enum CommandOutcome
+    {
+        Success,
+        ParseFailed,
+        Unauthorized,
+        Threw,
+    }
+}

--- a/Core/Commands/Events/CommandExecutedEvent.cs
+++ b/Core/Commands/Events/CommandExecutedEvent.cs
@@ -1,0 +1,21 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Commands.Events
+{
+    /// <summary>
+    /// Published by <see cref="CommandDispatcher"/> after every dispatch — success,
+    /// parse-fail, unauthorized, or threw. Provides a low-fidelity command trace
+    /// controllable via log level; <c>AdminAuditHandler</c> uses the richer slice-2
+    /// admin events instead.
+    /// </summary>
+    public record CommandExecutedEvent(
+        uint InvokerEntityId,
+        string Verb,
+        string ArgsSummary,
+        CommandOutcome Outcome) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Commands/IArgumentResolver.cs
+++ b/Core/Commands/IArgumentResolver.cs
@@ -1,0 +1,8 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Seam for future dynamic entity-name resolution (e.g. "orc" → nearest orc entity id).
+    /// Null this slice — the parser skips this field when it is null.
+    /// </summary>
+    public interface IArgumentResolver { }
+}

--- a/Core/Commands/ICommand.cs
+++ b/Core/Commands/ICommand.cs
@@ -1,12 +1,13 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Hedron.Core.Sessions;
+using Hedron.Core.Commands.Authorization;
 
 namespace Hedron.Core.Commands
 {
     /// <summary>
-    /// A single player-facing verb. Thin — parses its argument string and calls a domain
-    /// system (or publishes an event) to do the actual work.
+    /// A single player-facing verb. Thin — declares its schema and calls a domain
+    /// system (or publishes an event) to do the actual work. Argument parsing,
+    /// privilege gating, and help text are all structural — no per-command boilerplate.
     /// </summary>
     public interface ICommand
     {
@@ -16,10 +17,32 @@ namespace Hedron.Core.Commands
         /// <summary>Alternate verbs that route to this command ("n" → "north", etc.).</summary>
         IReadOnlyList<string> Aliases { get; }
 
+        /// <summary>Groups the command for help display and admin-visibility filtering.</summary>
+        CommandCategory Category { get; }
+
+        /// <summary>One-line description used in the 'commands' index.</summary>
+        string ShortDescription { get; }
+
+        /// <summary>Multi-paragraph body used in 'help &lt;verb&gt;'.</summary>
+        string LongDescription { get; }
+
+        /// <summary>Formal argument grammar shown at the end of 'help &lt;verb&gt;'.</summary>
+        string Usage { get; }
+
         /// <summary>
-        /// Runs the command against the given session. <paramref name="arguments"/> is the
-        /// raw tail of the input line after the verb, with surrounding whitespace trimmed.
+        /// Requirements a caller must satisfy. Empty list = public (no gate).
+        /// The dispatcher iterates this and calls <see cref="IAuthorizationChecker"/>
+        /// for each — per-command boilerplate privilege checks are no longer needed.
         /// </summary>
-        Task ExecuteAsync(ISession session, string arguments);
+        IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; }
+
+        /// <summary>Declarative argument list. The dispatcher parses against this schema.</summary>
+        CommandArgumentSchema ArgumentSchema { get; }
+
+        /// <summary>
+        /// Runs the command. <paramref name="context"/> carries typed parsed arguments
+        /// and the output writer — do not call <c>session.SendLineAsync</c> directly.
+        /// </summary>
+        Task ExecuteAsync(CommandContext context);
     }
 }

--- a/Core/Commands/ICommandArgumentParser.cs
+++ b/Core/Commands/ICommandArgumentParser.cs
@@ -1,0 +1,10 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Parses the raw tail of a command input line against a command's declarative schema.
+    /// </summary>
+    public interface ICommandArgumentParser
+    {
+        ParseResult Parse(CommandArgumentSchema schema, string rawTail);
+    }
+}

--- a/Core/Commands/ParseResult.cs
+++ b/Core/Commands/ParseResult.cs
@@ -1,0 +1,9 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>Discriminated union returned by <see cref="ICommandArgumentParser"/>.</summary>
+    public abstract record ParseResult
+    {
+        public sealed record Success(ParsedArguments Args) : ParseResult;
+        public sealed record Failure(string Reason) : ParseResult;
+    }
+}

--- a/Core/Commands/ParsedArguments.cs
+++ b/Core/Commands/ParsedArguments.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>Typed argument bag produced by <see cref="ICommandArgumentParser"/>.</summary>
+    public sealed class ParsedArguments
+    {
+        private readonly IReadOnlyDictionary<string, object?> _values;
+
+        internal ParsedArguments(IReadOnlyDictionary<string, object?> values)
+            => _values = values;
+
+        public static readonly ParsedArguments Empty =
+            new(new Dictionary<string, object?>());
+
+        public T Get<T>(string name)
+        {
+            if (!_values.TryGetValue(name, out var value))
+                throw new KeyNotFoundException($"No argument '{name}' in parsed context.");
+            return (T)value!;
+        }
+
+        public bool TryGet<T>(string name, out T value)
+        {
+            if (_values.TryGetValue(name, out var raw) && raw is T typed)
+            {
+                value = typed;
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+        public bool Has(string name) => _values.ContainsKey(name);
+    }
+}

--- a/Core/Handlers/CommandLoggingHandler.cs
+++ b/Core/Handlers/CommandLoggingHandler.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Commands.Events;
+using Hedron.Core.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Hedron.Core.Handlers
+{
+    /// <summary>
+    /// Writes one structured-log line per command dispatch. Priority
+    /// <see cref="HandlerPriority.Notification"/> (80) — deliberately separate from
+    /// <c>AdminAuditHandler</c>, which carries richer slice-2 admin-event payloads.
+    /// Log level controls verbosity; the event fires for every outcome including failures.
+    /// </summary>
+    public sealed class CommandLoggingHandler : IEventHandler<CommandExecutedEvent>
+    {
+        private readonly ILogger<CommandLoggingHandler> _logger;
+
+        public int Priority => HandlerPriority.Notification;
+
+        public CommandLoggingHandler(ILogger<CommandLoggingHandler> logger)
+            => _logger = logger;
+
+        public Task HandleAsync(CommandExecutedEvent e)
+        {
+            _logger.LogInformation(
+                "CommandExecuted | invoker={InvokerEntityId} verb={Verb} args={ArgsSummary} outcome={Outcome}",
+                e.InvokerEntityId, e.Verb, e.ArgsSummary, e.Outcome);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Core/Modules/Admin/AdminModule.cs
+++ b/Core/Modules/Admin/AdminModule.cs
@@ -1,4 +1,5 @@
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.Modules.Admin.Commands;
 using Hedron.Core.Modules.Admin.Handlers;
 using Hedron.Core.Modules.Admin.Systems;
@@ -7,19 +8,15 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Hedron.Core.Modules.Admin
 {
     /// <summary>
-    /// DI composition entry point for the Admin module: authorizer, the four admin commands,
-    /// and the audit handler.
+    /// DI composition entry point for the Admin module: authorizer, authorization checker,
+    /// the four admin commands, and the audit handler.
     /// </summary>
-    /// <remarks>
-    /// Subscriptions for <see cref="AdminAuditHandler"/> are registered against the event bus
-    /// in <c>Server/Program.cs</c> alongside the other handler subscriptions, since the bus
-    /// itself lives in <c>Server</c>.
-    /// </remarks>
     public static class AdminModule
     {
         public static IServiceCollection AddAdminModule(this IServiceCollection services)
         {
             services.AddSingleton<IAdminAuthorizer, AdminAuthorizer>();
+            services.AddSingleton<IAuthorizationChecker, AuthorizationChecker>();
 
             services.AddSingleton<ICommand, SpawnCommand>();
             services.AddSingleton<ICommand, TeleportCommand>();

--- a/Core/Modules/Admin/Commands/DigCommand.cs
+++ b/Core/Modules/Admin/Commands/DigCommand.cs
@@ -2,84 +2,70 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
-using Hedron.Core.Modules.Admin.Systems;
 using Hedron.Core.Modules.World.Templates;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 using Hedron.Core.Systems;
 
 namespace Hedron.Core.Modules.Admin.Commands
 {
     /// <summary>
-    /// Admin verb <c>@dig &lt;direction&gt; &lt;targetRoomBlueprintId&gt;</c>.
-    /// Adds an exit from the invoker's current room to the target room, wires the reverse
-    /// exit on the target by default, and updates the in-memory <see cref="RoomTemplate"/>
-    /// so a same-session <c>@reload</c> won't undo the change.
+    /// Admin verb <c>dig &lt;direction&gt; &lt;targetRoomBlueprintId&gt;</c>.
+    /// Adds an exit and wires the reverse link. Source YAML is not rewritten;
+    /// durability comes from <c>PersistenceSystem</c>. Privilege enforced by dispatcher.
     /// </summary>
-    /// <remarks>
-    /// The source YAML file on disk is <i>not</i> rewritten. Durability of the room shape
-    /// comes from <c>PersistenceSystem</c> saving the live room's <c>[Persistent]</c>
-    /// components on its next timed flush.
-    /// </remarks>
     public sealed class DigCommand : ICommand
     {
         private readonly ITemplateRegistry _templateRegistry;
-        private readonly IAdminAuthorizer _authorizer;
         private readonly EntityService _entityService;
         private readonly IEventBus _eventBus;
 
-        public string Name => "@dig";
-        public IReadOnlyList<string> Aliases { get; } = System.Array.Empty<string>();
+        public string Name => "dig";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Admin;
+        public string ShortDescription => "Dig a new exit from the current room.";
+        public string LongDescription => "Adds an exit from your current room to the target room and wires a reverse link. " +
+            "The source YAML is not rewritten; durability comes from the persistence flush.";
+        public string Usage => "dig <direction> <targetRoomBlueprintId>";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            new IAuthorizationRequirement[] { new AdminRequirement() };
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("direction", typeof(Direction), CommandArgumentKind.Token,
+                Required: true, "Direction to dig (north, south, east, west, up, down)."),
+            new CommandArgument("targetRoomBlueprintId", typeof(string), CommandArgumentKind.Token,
+                Required: true, "Blueprint id of the destination room."),
+        });
 
-        public DigCommand(
-            ITemplateRegistry templateRegistry,
-            IAdminAuthorizer authorizer,
-            EntityService entityService,
-            IEventBus eventBus)
+        public DigCommand(ITemplateRegistry templateRegistry, EntityService entityService, IEventBus eventBus)
         {
             _templateRegistry = templateRegistry;
-            _authorizer = authorizer;
             _entityService = entityService;
             _eventBus = eventBus;
         }
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            if (!_authorizer.IsPrivileged(session))
+            var direction = context.Args.Get<Direction>("direction");
+            var targetBlueprintId = context.Args.Get<string>("targetRoomBlueprintId");
+
+            if (!_entityService.TryGet<LocationComponent>(context.InvokerEntityId, out var location))
             {
-                await session.SendLineAsync("You are not authorized to use that command.")
+                await context.Output.WriteAsync(
+                    new PlainMessage("You have no location.", OutputSeverity.Error))
                     .ConfigureAwait(false);
-                return;
-            }
-
-            var parts = arguments.Trim().Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length < 2)
-            {
-                await session.SendLineAsync("Usage: @dig <direction> <targetRoomBlueprintId>")
-                    .ConfigureAwait(false);
-                return;
-            }
-
-            if (!Enum.TryParse<Direction>(parts[0], ignoreCase: true, out var direction))
-            {
-                await session.SendLineAsync($"Unknown direction: {parts[0]}").ConfigureAwait(false);
-                return;
-            }
-
-            var targetBlueprintId = parts[1];
-            if (!_entityService.TryGet<LocationComponent>(session.PlayerEntityId, out var location))
-            {
-                await session.SendLineAsync("You have no location.").ConfigureAwait(false);
                 return;
             }
 
             var sourceRoomId = location.RoomEntityId;
             if (!_entityService.TryGet<RoomComponent>(sourceRoomId, out var sourceRoom))
             {
-                await session.SendLineAsync("Your current location is not a room.")
+                await context.Output.WriteAsync(
+                    new PlainMessage("Your current location is not a room.", OutputSeverity.Error))
                     .ConfigureAwait(false);
                 return;
             }
@@ -87,17 +73,15 @@ namespace Hedron.Core.Modules.Admin.Commands
             var targetRoomId = ResolveRoomEntityId(targetBlueprintId);
             if (targetRoomId is null)
             {
-                await session.SendLineAsync($"Cannot resolve target room: {targetBlueprintId}")
+                await context.Output.WriteAsync(
+                    new PlainMessage($"Cannot resolve target room: {targetBlueprintId}", OutputSeverity.Error))
                     .ConfigureAwait(false);
                 return;
             }
 
             sourceRoom.Exits[direction] = targetRoomId.Value;
-
-            // Update the in-memory template if we know the source room's blueprint id.
             UpdateTemplate(sourceRoomId, direction, targetBlueprintId);
 
-            // Bidirectional reverse link by default.
             var bidirectional = false;
             var opposite = Opposite(direction);
             if (opposite is not null
@@ -111,13 +95,13 @@ namespace Hedron.Core.Modules.Admin.Commands
                     UpdateTemplate(targetRoomId.Value, opposite.Value, sourceBlueprint.BlueprintId);
             }
 
-            await session.SendLineAsync(
-                $"Dug {direction.ToString().ToLower()} → {targetBlueprintId}"
-                + (bidirectional ? " (reverse exit linked)." : "."))
-                .ConfigureAwait(false);
+            await context.Output.WriteAsync(new PlainMessage(
+                $"Dug {direction.ToString().ToLower()} → {targetBlueprintId}" +
+                (bidirectional ? " (reverse exit linked)." : "."),
+                OutputSeverity.Confirmation)).ConfigureAwait(false);
 
             await _eventBus.PublishAsync(new RoomExitAuthoredByAdminEvent(
-                session.PlayerEntityId,
+                context.InvokerEntityId,
                 sourceRoomId,
                 direction,
                 targetRoomId.Value,
@@ -137,10 +121,8 @@ namespace Hedron.Core.Modules.Admin.Commands
 
         private void UpdateTemplate(uint roomEntityId, Direction direction, string targetBlueprintId)
         {
-            if (!_entityService.TryGet<BlueprintComponent>(roomEntityId, out var blueprint))
-                return;
-            if (!_templateRegistry.TryGet(blueprint.BlueprintId, out var template))
-                return;
+            if (!_entityService.TryGet<BlueprintComponent>(roomEntityId, out var blueprint)) return;
+            if (!_templateRegistry.TryGet(blueprint.BlueprintId, out var template)) return;
             if (template is RoomTemplate roomTemplate)
                 roomTemplate.Exits[direction] = targetBlueprintId;
         }

--- a/Core/Modules/Admin/Commands/ReloadCommand.cs
+++ b/Core/Modules/Admin/Commands/ReloadCommand.cs
@@ -1,57 +1,54 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.Events;
-using Hedron.Core.Modules.Admin.Systems;
 using Hedron.Core.Modules.World.Events;
 using Hedron.Core.Modules.World.Systems;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 
 namespace Hedron.Core.Modules.Admin.Commands
 {
     /// <summary>
-    /// Admin verb <c>@reload</c>. Re-scans the content directory and refreshes the template
+    /// Admin verb <c>reload</c>. Re-scans the content directory and refreshes the template
     /// registry. Newly authored templates with no live counterpart are seeded;
-    /// <b>existing live entities are not modified</b>.
+    /// <b>existing live entities are not modified</b>. Privilege enforced by dispatcher.
     /// </summary>
-    /// <remarks>
-    /// To pick up edits to a live room's description or components, restart the host. Use
-    /// <c>@dig</c> for exit changes that should apply immediately.
-    /// </remarks>
     public sealed class ReloadCommand : ICommand
     {
         private readonly IWorldContentLoader _loader;
-        private readonly IAdminAuthorizer _authorizer;
         private readonly IEventBus _eventBus;
 
-        public string Name => "@reload";
-        public IReadOnlyList<string> Aliases { get; } = System.Array.Empty<string>();
+        public string Name => "reload";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Admin;
+        public string ShortDescription => "Reload the content directory without restart.";
+        public string LongDescription =>
+            "Re-scans the content directory and refreshes the template registry. " +
+            "Newly authored templates with no live counterpart are seeded. " +
+            "Existing live entities are not modified — descriptions, exits, and components on rooms " +
+            "that already exist will not change. " +
+            "To pick up edits to a live room, restart, or use 'dig' for exit changes.";
+        public string Usage => "reload";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            new IAuthorizationRequirement[] { new AdminRequirement() };
+        public CommandArgumentSchema ArgumentSchema => CommandArgumentSchema.Empty;
 
-        public ReloadCommand(
-            IWorldContentLoader loader,
-            IAdminAuthorizer authorizer,
-            IEventBus eventBus)
+        public ReloadCommand(IWorldContentLoader loader, IEventBus eventBus)
         {
             _loader = loader;
-            _authorizer = authorizer;
             _eventBus = eventBus;
         }
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            if (!_authorizer.IsPrivileged(session))
-            {
-                await session.SendLineAsync("You are not authorized to use that command.")
-                    .ConfigureAwait(false);
-                return;
-            }
-
             var result = await _loader.ReloadAsync().ConfigureAwait(false);
 
-            await session.SendLineAsync(
-                $"Reloaded content: {result.TemplatesLoaded} new, {result.TemplatesUnchanged} unchanged, " +
-                $"{result.TemplatesRemoved} removed. Existing live entities were not modified.")
-                .ConfigureAwait(false);
+            await context.Output.WriteAsync(new PlainMessage(
+                $"Reloaded: {result.TemplatesLoaded} new, {result.TemplatesUnchanged} unchanged, " +
+                $"{result.TemplatesRemoved} removed. Existing live entities were not modified.",
+                OutputSeverity.Confirmation)).ConfigureAwait(false);
 
             await _eventBus.PublishAsync(new ContentReloadedEvent(
                 result.TemplatesLoaded,

--- a/Core/Modules/Admin/Commands/SpawnCommand.cs
+++ b/Core/Modules/Admin/Commands/SpawnCommand.cs
@@ -1,87 +1,81 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
-using Hedron.Core.Modules.Admin.Systems;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 using Hedron.Core.Systems;
 
 namespace Hedron.Core.Modules.Admin.Commands
 {
     /// <summary>
-    /// Admin verb <c>@spawn &lt;blueprintId&gt;</c>. Resolves the blueprint via
+    /// Admin verb <c>spawn &lt;blueprintId&gt;</c>. Resolves the blueprint via
     /// <see cref="ITemplateRegistry"/>, spawns a fresh entity, and publishes
-    /// <see cref="EntitySpawnedByAdminEvent"/>.
+    /// <see cref="EntitySpawnedByAdminEvent"/>. Privilege is enforced by the dispatcher.
     /// </summary>
     public sealed class SpawnCommand : ICommand
     {
         private readonly ITemplateRegistry _templateRegistry;
-        private readonly IAdminAuthorizer _authorizer;
         private readonly EntityService _entityService;
         private readonly IEventBus _eventBus;
 
-        public string Name => "@spawn";
-        public IReadOnlyList<string> Aliases { get; } = System.Array.Empty<string>();
+        public string Name => "spawn";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Admin;
+        public string ShortDescription => "Spawn a template entity into the world.";
+        public string LongDescription => "Spawns a templated entity into the current room. " +
+            "Use 'dig' to wire newly spawned rooms into the live world.";
+        public string Usage => "spawn <blueprintId>";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            new IAuthorizationRequirement[] { new AdminRequirement() };
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("blueprintId", typeof(string), CommandArgumentKind.Token,
+                Required: true, "The blueprint id to spawn (e.g. room.crossroads)."),
+        });
 
-        public SpawnCommand(
-            ITemplateRegistry templateRegistry,
-            IAdminAuthorizer authorizer,
-            EntityService entityService,
-            IEventBus eventBus)
+        public SpawnCommand(ITemplateRegistry templateRegistry, EntityService entityService, IEventBus eventBus)
         {
             _templateRegistry = templateRegistry;
-            _authorizer = authorizer;
             _entityService = entityService;
             _eventBus = eventBus;
         }
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            if (!_authorizer.IsPrivileged(session))
-            {
-                await session.SendLineAsync("You are not authorized to use that command.")
-                    .ConfigureAwait(false);
-                return;
-            }
-
-            var blueprintId = arguments.Trim();
-            if (string.IsNullOrEmpty(blueprintId))
-            {
-                await session.SendLineAsync("Usage: @spawn <blueprintId>").ConfigureAwait(false);
-                return;
-            }
+            var blueprintId = context.Args.Get<string>("blueprintId");
 
             if (!_templateRegistry.TryGet(blueprintId, out _))
             {
-                await session.SendLineAsync($"Unknown blueprint: {blueprintId}")
+                await context.Output.WriteAsync(
+                    new PlainMessage($"Unknown blueprint: {blueprintId}", OutputSeverity.Error))
                     .ConfigureAwait(false);
                 return;
             }
 
-            if (!_entityService.TryGet<LocationComponent>(session.PlayerEntityId, out var location))
+            if (!_entityService.TryGet<LocationComponent>(context.InvokerEntityId, out var location))
             {
-                await session.SendLineAsync("You have no location — cannot spawn here.")
+                await context.Output.WriteAsync(
+                    new PlainMessage("You have no location — cannot spawn here.", OutputSeverity.Error))
                     .ConfigureAwait(false);
                 return;
             }
 
             var spawned = _templateRegistry.Spawn(blueprintId);
 
-            // NOTE: Placement-into-the-room is deferred. The only spawnable templates in this
-            // slice are rooms and areas, neither of which warrant placement in the invoker's
-            // current room. Item and mob templates land with their slices (4 and 6) — at that
-            // point this command attaches a LocationComponent (or container reference) to the
-            // newly spawned entity. Until then, spawned rooms/areas are orphan entities; use
-            // @dig to wire a new room into the live world.
+            // NOTE: Placement into a room is deferred until item/mob templates land in slices 4+.
+            // Spawned rooms/areas are orphan entities; use 'dig' to wire a new room in.
 
-            await session.SendLineAsync($"Spawned {blueprintId} (entity #{spawned.Id}).")
+            await context.Output.WriteAsync(
+                new PlainMessage($"Spawned {blueprintId} (entity #{spawned.Id}).", OutputSeverity.Confirmation))
                 .ConfigureAwait(false);
 
             await _eventBus.PublishAsync(new EntitySpawnedByAdminEvent(
-                session.PlayerEntityId,
+                context.InvokerEntityId,
                 spawned.Id,
                 blueprintId,
                 location.RoomEntityId)).ConfigureAwait(false);

--- a/Core/Modules/Admin/Commands/TeleportCommand.cs
+++ b/Core/Modules/Admin/Commands/TeleportCommand.cs
@@ -2,63 +2,58 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
-using Hedron.Core.Modules.Admin.Systems;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 using Hedron.Core.Systems;
 
 namespace Hedron.Core.Modules.Admin.Commands
 {
     /// <summary>
-    /// Admin verb <c>@teleport &lt;target&gt;</c>. Target is either a room blueprint id
-    /// (<c>room.east_end</c>) or a player display name. Updates the invoker's
-    /// <see cref="LocationComponent"/> and publishes <see cref="PlayerTeleportedByAdminEvent"/>.
+    /// Admin verb <c>teleport &lt;target&gt;</c>. Target is a room blueprint id or player name.
+    /// Updates the invoker's <see cref="LocationComponent"/> and publishes
+    /// <see cref="PlayerTeleportedByAdminEvent"/>. Privilege is enforced by the dispatcher.
     /// </summary>
     public sealed class TeleportCommand : ICommand
     {
         private readonly ITemplateRegistry _templateRegistry;
-        private readonly IAdminAuthorizer _authorizer;
         private readonly EntityService _entityService;
         private readonly IEventBus _eventBus;
 
-        public string Name => "@teleport";
-        public IReadOnlyList<string> Aliases { get; } = new[] { "@tp" };
+        public string Name => "teleport";
+        public IReadOnlyList<string> Aliases { get; } = new[] { "tp" };
+        public CommandCategory Category => CommandCategory.Admin;
+        public string ShortDescription => "Teleport yourself to a room or player.";
+        public string LongDescription => "Teleports you to the specified target. " +
+            "Target can be a room blueprint id (e.g. room.crossroads) or a player's display name.";
+        public string Usage => "teleport <roomBlueprintId|playerName>";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            new IAuthorizationRequirement[] { new AdminRequirement() };
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("target", typeof(string), CommandArgumentKind.Token,
+                Required: true, "Room blueprint id or player display name."),
+        });
 
-        public TeleportCommand(
-            ITemplateRegistry templateRegistry,
-            IAdminAuthorizer authorizer,
-            EntityService entityService,
-            IEventBus eventBus)
+        public TeleportCommand(ITemplateRegistry templateRegistry, EntityService entityService, IEventBus eventBus)
         {
             _templateRegistry = templateRegistry;
-            _authorizer = authorizer;
             _entityService = entityService;
             _eventBus = eventBus;
         }
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            if (!_authorizer.IsPrivileged(session))
-            {
-                await session.SendLineAsync("You are not authorized to use that command.")
-                    .ConfigureAwait(false);
-                return;
-            }
+            var target = context.Args.Get<string>("target");
 
-            var target = arguments.Trim();
-            if (string.IsNullOrEmpty(target))
+            if (!_entityService.TryGet<LocationComponent>(context.InvokerEntityId, out var location))
             {
-                await session.SendLineAsync("Usage: @teleport <roomBlueprintId|playerName>")
+                await context.Output.WriteAsync(
+                    new PlainMessage("You have no location.", OutputSeverity.Error))
                     .ConfigureAwait(false);
-                return;
-            }
-
-            if (!_entityService.TryGet<LocationComponent>(session.PlayerEntityId, out var location))
-            {
-                await session.SendLineAsync("You have no location.").ConfigureAwait(false);
                 return;
             }
 
@@ -66,19 +61,21 @@ namespace Hedron.Core.Modules.Admin.Commands
             var resolvedRoomId = ResolveRoomEntityId(target);
             if (resolvedRoomId is null)
             {
-                await session.SendLineAsync($"Cannot resolve teleport target: {target}")
+                await context.Output.WriteAsync(
+                    new PlainMessage($"Cannot resolve teleport target: {target}", OutputSeverity.Error))
                     .ConfigureAwait(false);
                 return;
             }
 
             location.RoomEntityId = resolvedRoomId.Value;
 
-            await session.SendLineAsync($"Teleported to entity #{resolvedRoomId.Value}.")
+            await context.Output.WriteAsync(
+                new PlainMessage($"Teleported to entity #{resolvedRoomId.Value}.", OutputSeverity.Confirmation))
                 .ConfigureAwait(false);
 
             await _eventBus.PublishAsync(new PlayerTeleportedByAdminEvent(
-                session.PlayerEntityId,
-                session.PlayerEntityId,
+                context.InvokerEntityId,
+                context.InvokerEntityId,
                 fromRoomId,
                 resolvedRoomId.Value)).ConfigureAwait(false);
         }

--- a/Core/Modules/Chat/Commands/SayCommand.cs
+++ b/Core/Modules/Chat/Commands/SayCommand.cs
@@ -2,9 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Chat.Events;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 
 namespace Hedron.Core.Modules.Chat.Commands
 {
@@ -14,18 +15,24 @@ namespace Hedron.Core.Modules.Chat.Commands
 
         public string Name => "say";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Player;
+        public string ShortDescription => "Say something to everyone in the room.";
+        public string LongDescription => "Broadcasts a message to all players in your current room.";
+        public string Usage => "say <message>";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            Array.Empty<IAuthorizationRequirement>();
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("message", typeof(string), CommandArgumentKind.RestOfLine,
+                Required: true, "The message to say."),
+        });
 
         public SayCommand(IEventBus eventBus) => _eventBus = eventBus;
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            if (string.IsNullOrWhiteSpace(arguments))
-            {
-                await session.SendLineAsync("Say what?").ConfigureAwait(false);
-                return;
-            }
-
-            await _eventBus.PublishAsync(new PlayerSaidEvent(session.PlayerEntityId, arguments))
+            var message = context.Args.Get<string>("message");
+            await _eventBus.PublishAsync(new PlayerSaidEvent(context.InvokerEntityId, message))
                 .ConfigureAwait(false);
         }
     }

--- a/Core/Modules/Help/Commands/CommandsCommand.cs
+++ b/Core/Modules/Help/Commands/CommandsCommand.cs
@@ -14,7 +14,7 @@ namespace Hedron.Core.Modules.Help.Commands
     /// </summary>
     public sealed class CommandsCommand : ICommand
     {
-        private readonly IEnumerable<ICommand> _allCommands;
+        private readonly Lazy<IEnumerable<ICommand>> _allCommands;
         private readonly IAuthorizationChecker _authorizationChecker;
 
         public string Name => "commands";
@@ -27,7 +27,7 @@ namespace Hedron.Core.Modules.Help.Commands
             Array.Empty<IAuthorizationRequirement>();
         public CommandArgumentSchema ArgumentSchema => CommandArgumentSchema.Empty;
 
-        public CommandsCommand(IEnumerable<ICommand> allCommands, IAuthorizationChecker authorizationChecker)
+        public CommandsCommand(Lazy<IEnumerable<ICommand>> allCommands, IAuthorizationChecker authorizationChecker)
         {
             _allCommands = allCommands;
             _authorizationChecker = authorizationChecker;
@@ -35,7 +35,7 @@ namespace Hedron.Core.Modules.Help.Commands
 
         public async Task ExecuteAsync(CommandContext context)
         {
-            var entries = _allCommands
+            var entries = _allCommands.Value
                 .Where(c => IsVisible(c, context))
                 .OrderBy(c => (int)c.Category).ThenBy(c => c.Name)
                 .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category))

--- a/Core/Modules/Help/Commands/CommandsCommand.cs
+++ b/Core/Modules/Help/Commands/CommandsCommand.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.Output;
+
+namespace Hedron.Core.Modules.Help.Commands
+{
+    /// <summary>
+    /// <c>commands</c> — terser sibling of <c>help</c>; prints a category-grouped one-line
+    /// index without requiring a verb argument. Same visibility filtering.
+    /// </summary>
+    public sealed class CommandsCommand : ICommand
+    {
+        private readonly IEnumerable<ICommand> _allCommands;
+        private readonly IAuthorizationChecker _authorizationChecker;
+
+        public string Name => "commands";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Player;
+        public string ShortDescription => "List available commands.";
+        public string LongDescription => "Lists all commands available to you, grouped by category.";
+        public string Usage => "commands";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            Array.Empty<IAuthorizationRequirement>();
+        public CommandArgumentSchema ArgumentSchema => CommandArgumentSchema.Empty;
+
+        public CommandsCommand(IEnumerable<ICommand> allCommands, IAuthorizationChecker authorizationChecker)
+        {
+            _allCommands = allCommands;
+            _authorizationChecker = authorizationChecker;
+        }
+
+        public async Task ExecuteAsync(CommandContext context)
+        {
+            var entries = _allCommands
+                .Where(c => IsVisible(c, context))
+                .OrderBy(c => (int)c.Category).ThenBy(c => c.Name)
+                .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category))
+                .ToList();
+
+            await context.Output.WriteAsync(new HelpIndexMessage(entries)).ConfigureAwait(false);
+        }
+
+        private bool IsVisible(ICommand command, CommandContext context)
+            => command.RequiredPrivileges.All(r => _authorizationChecker.IsSatisfied(r, context.Session));
+    }
+}

--- a/Core/Modules/Help/Commands/HelpCommand.cs
+++ b/Core/Modules/Help/Commands/HelpCommand.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.Output;
+
+namespace Hedron.Core.Modules.Help.Commands
+{
+    /// <summary>
+    /// <c>help</c> — with no argument lists all visible commands; with a verb shows detailed
+    /// help for that command. Visibility is filtered by <see cref="IAuthorizationChecker"/>.
+    /// </summary>
+    public sealed class HelpCommand : ICommand
+    {
+        private readonly IEnumerable<ICommand> _allCommands;
+        private readonly IAuthorizationChecker _authorizationChecker;
+
+        public string Name => "help";
+        public IReadOnlyList<string> Aliases { get; } = new[] { "?" };
+        public CommandCategory Category => CommandCategory.Player;
+        public string ShortDescription => "Show command help.";
+        public string LongDescription =>
+            "With no argument, lists all commands available to you grouped by category. " +
+            "With a verb argument, shows detailed help for that command.";
+        public string Usage => "help [<verb>]";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            Array.Empty<IAuthorizationRequirement>();
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("verb", typeof(string), CommandArgumentKind.Token,
+                Required: false, "Command verb to look up."),
+        });
+
+        public HelpCommand(IEnumerable<ICommand> allCommands, IAuthorizationChecker authorizationChecker)
+        {
+            _allCommands = allCommands;
+            _authorizationChecker = authorizationChecker;
+        }
+
+        public async Task ExecuteAsync(CommandContext context)
+        {
+            if (context.Args.TryGet<string>("verb", out var verb))
+            {
+                var command = _allCommands
+                    .Where(c => IsVisible(c, context))
+                    .FirstOrDefault(c =>
+                        string.Equals(c.Name, verb, StringComparison.OrdinalIgnoreCase)
+                        || c.Aliases.Any(a => string.Equals(a, verb, StringComparison.OrdinalIgnoreCase)));
+
+                if (command is null)
+                {
+                    await context.Output.WriteAsync(
+                        new PlainMessage($"No help found for '{verb}'.", OutputSeverity.System))
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                await context.Output.WriteAsync(
+                    new HelpEntryMessage(command.Name, command.LongDescription, command.Usage))
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                var entries = BuildIndex(context);
+                await context.Output.WriteAsync(new HelpIndexMessage(entries)).ConfigureAwait(false);
+            }
+        }
+
+        private IReadOnlyList<HelpIndexEntry> BuildIndex(CommandContext context)
+            => _allCommands
+                .Where(c => IsVisible(c, context))
+                .OrderBy(c => (int)c.Category).ThenBy(c => c.Name)
+                .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category))
+                .ToList();
+
+        private bool IsVisible(ICommand command, CommandContext context)
+            => command.RequiredPrivileges.All(r => _authorizationChecker.IsSatisfied(r, context.Session));
+    }
+}

--- a/Core/Modules/Help/Commands/HelpCommand.cs
+++ b/Core/Modules/Help/Commands/HelpCommand.cs
@@ -14,7 +14,7 @@ namespace Hedron.Core.Modules.Help.Commands
     /// </summary>
     public sealed class HelpCommand : ICommand
     {
-        private readonly IEnumerable<ICommand> _allCommands;
+        private readonly Lazy<IEnumerable<ICommand>> _allCommands;
         private readonly IAuthorizationChecker _authorizationChecker;
 
         public string Name => "help";
@@ -33,7 +33,7 @@ namespace Hedron.Core.Modules.Help.Commands
                 Required: false, "Command verb to look up."),
         });
 
-        public HelpCommand(IEnumerable<ICommand> allCommands, IAuthorizationChecker authorizationChecker)
+        public HelpCommand(Lazy<IEnumerable<ICommand>> allCommands, IAuthorizationChecker authorizationChecker)
         {
             _allCommands = allCommands;
             _authorizationChecker = authorizationChecker;
@@ -43,7 +43,7 @@ namespace Hedron.Core.Modules.Help.Commands
         {
             if (context.Args.TryGet<string>("verb", out var verb))
             {
-                var command = _allCommands
+                var command = _allCommands.Value
                     .Where(c => IsVisible(c, context))
                     .FirstOrDefault(c =>
                         string.Equals(c.Name, verb, StringComparison.OrdinalIgnoreCase)
@@ -69,7 +69,7 @@ namespace Hedron.Core.Modules.Help.Commands
         }
 
         private IReadOnlyList<HelpIndexEntry> BuildIndex(CommandContext context)
-            => _allCommands
+            => _allCommands.Value
                 .Where(c => IsVisible(c, context))
                 .OrderBy(c => (int)c.Category).ThenBy(c => c.Name)
                 .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category))

--- a/Core/Modules/Help/HelpModule.cs
+++ b/Core/Modules/Help/HelpModule.cs
@@ -1,0 +1,21 @@
+using Hedron.Core.Commands;
+using Hedron.Core.Modules.Help.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hedron.Core.Modules.Help
+{
+    /// <summary>
+    /// DI composition entry point for the Help module: the <c>help</c> and <c>commands</c>
+    /// commands. Depends on <c>IEnumerable&lt;ICommand&gt;</c> and
+    /// <c>IAuthorizationChecker</c> being registered before this is resolved.
+    /// </summary>
+    public static class HelpModule
+    {
+        public static IServiceCollection AddHelpModule(this IServiceCollection services)
+        {
+            services.AddSingleton<ICommand, HelpCommand>();
+            services.AddSingleton<ICommand, CommandsCommand>();
+            return services;
+        }
+    }
+}

--- a/Core/Modules/Help/HelpModule.cs
+++ b/Core/Modules/Help/HelpModule.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Hedron.Core.Commands;
 using Hedron.Core.Modules.Help.Commands;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +15,12 @@ namespace Hedron.Core.Modules.Help
     {
         public static IServiceCollection AddHelpModule(this IServiceCollection services)
         {
+            // Lazy breaks the IEnumerable<ICommand> → HelpCommand → IEnumerable<ICommand> cycle:
+            // the factory is captured at construction but the collection is only resolved on first
+            // command execution, by which point the DI container is fully built.
+            services.AddSingleton(sp =>
+                new Lazy<IEnumerable<ICommand>>(() => sp.GetServices<ICommand>()));
+
             services.AddSingleton<ICommand, HelpCommand>();
             services.AddSingleton<ICommand, CommandsCommand>();
             return services;

--- a/Core/Modules/Movement/Commands/MoveCommand.cs
+++ b/Core/Modules/Movement/Commands/MoveCommand.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Movement.Events;
 using Hedron.Core.Modules.Movement.Systems;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 
 namespace Hedron.Core.Modules.Movement.Commands
 {
@@ -20,6 +22,13 @@ namespace Hedron.Core.Modules.Movement.Commands
 
         public string Name { get; }
         public IReadOnlyList<string> Aliases { get; }
+        public CommandCategory Category => CommandCategory.Player;
+        public string ShortDescription { get; }
+        public string LongDescription { get; }
+        public string Usage { get; }
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            Array.Empty<IAuthorizationRequirement>();
+        public CommandArgumentSchema ArgumentSchema => CommandArgumentSchema.Empty;
 
         public MoveCommand(Direction direction, IMovementSystem movementSystem, IEventBus eventBus)
         {
@@ -28,20 +37,24 @@ namespace Hedron.Core.Modules.Movement.Commands
             _eventBus = eventBus;
             Name = direction.ToString().ToLower();
             Aliases = ShortAlias(direction);
+            ShortDescription = $"Move {direction.ToString().ToLower()}.";
+            LongDescription = $"Move in the {direction.ToString().ToLower()} direction if an exit exists.";
+            Usage = direction.ToString().ToLower();
         }
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            var result = _movementSystem.TryMove(session.PlayerEntityId, _direction);
+            var result = _movementSystem.TryMove(context.InvokerEntityId, _direction);
             if (!result.Success)
             {
-                await session.SendLineAsync(result.ErrorMessage ?? "You cannot go that way.")
+                await context.Output.WriteAsync(
+                    new PlainMessage(result.ErrorMessage ?? "You cannot go that way.", OutputSeverity.System))
                     .ConfigureAwait(false);
                 return;
             }
 
             await _eventBus.PublishAsync(new PlayerMovedEvent(
-                session.PlayerEntityId,
+                context.InvokerEntityId,
                 result.FromRoomEntityId,
                 result.ToRoomEntityId,
                 _direction)).ConfigureAwait(false);
@@ -55,7 +68,7 @@ namespace Hedron.Core.Modules.Movement.Commands
             Direction.West  => new[] { "w" },
             Direction.Up    => new[] { "u" },
             Direction.Down  => new[] { "d" },
-            _               => System.Array.Empty<string>(),
+            _               => Array.Empty<string>(),
         };
     }
 }

--- a/Core/Modules/World/Commands/LookCommand.cs
+++ b/Core/Modules/World/Commands/LookCommand.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
-using Hedron.Core.Sessions;
+using Hedron.Core.Output;
 using Hedron.Core.Systems;
 
 namespace Hedron.Core.Modules.World.Commands
@@ -15,6 +17,13 @@ namespace Hedron.Core.Modules.World.Commands
 
         public string Name => "look";
         public IReadOnlyList<string> Aliases { get; } = new[] { "l" };
+        public CommandCategory Category => CommandCategory.Player;
+        public string ShortDescription => "Look at the current room.";
+        public string LongDescription => "Displays a description of your current location, including visible exits and other players present.";
+        public string Usage => "look";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            Array.Empty<IAuthorizationRequirement>();
+        public CommandArgumentSchema ArgumentSchema => CommandArgumentSchema.Empty;
 
         public LookCommand(EntityService entityService, IBroadcastSystem broadcast)
         {
@@ -22,15 +31,18 @@ namespace Hedron.Core.Modules.World.Commands
             _broadcast = broadcast;
         }
 
-        public async Task ExecuteAsync(ISession session, string arguments)
+        public async Task ExecuteAsync(CommandContext context)
         {
-            if (!_entityService.TryGet<LocationComponent>(session.PlayerEntityId, out var location))
+            if (!_entityService.TryGet<LocationComponent>(context.InvokerEntityId, out var location))
             {
-                await session.SendLineAsync("You are floating in the void.").ConfigureAwait(false);
+                await context.Output.WriteAsync(
+                    new PlainMessage("You are floating in the void.", OutputSeverity.System))
+                    .ConfigureAwait(false);
                 return;
             }
 
-            await _broadcast.SendRoomDescriptionAsync(session.PlayerEntityId, location.RoomEntityId)
+            // BroadcastSystem writes directly to the session — broadcast body unchanged until slice 4.
+            await _broadcast.SendRoomDescriptionAsync(context.InvokerEntityId, location.RoomEntityId)
                 .ConfigureAwait(false);
         }
     }

--- a/Core/Output/HelpEntryMessage.cs
+++ b/Core/Output/HelpEntryMessage.cs
@@ -1,0 +1,8 @@
+namespace Hedron.Core.Output
+{
+    /// <summary>Detailed help for a single verb (the 'help &lt;verb&gt;' output).</summary>
+    public sealed record HelpEntryMessage(string Verb, string LongDescription, string Usage) : IOutputMessage
+    {
+        public OutputCategory Category => OutputCategory.Help;
+    }
+}

--- a/Core/Output/HelpIndexEntry.cs
+++ b/Core/Output/HelpIndexEntry.cs
@@ -1,0 +1,7 @@
+using Hedron.Core.Commands;
+
+namespace Hedron.Core.Output
+{
+    /// <summary>One row in a help index listing.</summary>
+    public sealed record HelpIndexEntry(string Verb, string ShortDescription, CommandCategory Category);
+}

--- a/Core/Output/HelpIndexMessage.cs
+++ b/Core/Output/HelpIndexMessage.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Hedron.Core.Output
+{
+    /// <summary>Category-grouped command listing (the 'help' and 'commands' output).</summary>
+    public sealed record HelpIndexMessage(IReadOnlyList<HelpIndexEntry> Entries) : IOutputMessage
+    {
+        public OutputCategory Category => OutputCategory.Help;
+    }
+}

--- a/Core/Output/IOutputMessage.cs
+++ b/Core/Output/IOutputMessage.cs
@@ -1,0 +1,8 @@
+namespace Hedron.Core.Output
+{
+    /// <summary>Typed message emitted by a command or system. Slice 4 routes through a formatter.</summary>
+    public interface IOutputMessage
+    {
+        OutputCategory Category { get; }
+    }
+}

--- a/Core/Output/IOutputWriter.cs
+++ b/Core/Output/IOutputWriter.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace Hedron.Core.Output
+{
+    /// <summary>
+    /// Sends a typed <see cref="IOutputMessage"/> to a recipient.
+    /// Slice-3 impl: stringify-and-forward via <c>ISession.SendLineAsync</c>.
+    /// Slice 4 replaces the implementation with a formatter-backed one.
+    /// </summary>
+    public interface IOutputWriter
+    {
+        Task WriteAsync(IOutputMessage message);
+    }
+}

--- a/Core/Output/IOutputWriterFactory.cs
+++ b/Core/Output/IOutputWriterFactory.cs
@@ -1,0 +1,10 @@
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Output
+{
+    /// <summary>Creates an <see cref="IOutputWriter"/> bound to a session.</summary>
+    public interface IOutputWriterFactory
+    {
+        IOutputWriter Create(ISession session);
+    }
+}

--- a/Core/Output/OutputCategory.cs
+++ b/Core/Output/OutputCategory.cs
@@ -1,0 +1,11 @@
+namespace Hedron.Core.Output
+{
+    /// <summary>Broad category carried by every <see cref="IOutputMessage"/>.</summary>
+    public enum OutputCategory
+    {
+        System,
+        Help,
+        Chat,
+        Info,
+    }
+}

--- a/Core/Output/OutputSeverity.cs
+++ b/Core/Output/OutputSeverity.cs
@@ -1,0 +1,11 @@
+namespace Hedron.Core.Output
+{
+    /// <summary>Semantic tone of a <see cref="PlainMessage"/> (for future color/formatting).</summary>
+    public enum OutputSeverity
+    {
+        System,
+        Error,
+        Confirmation,
+        Chat,
+    }
+}

--- a/Core/Output/OutputWriter.cs
+++ b/Core/Output/OutputWriter.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Output
+{
+    /// <summary>
+    /// Slice-3 implementation: stringifies each message and forwards via
+    /// <see cref="ISession.SendLineAsync"/>. Slice 4 replaces this with a
+    /// formatter-backed implementation.
+    /// </summary>
+    internal sealed class OutputWriter : IOutputWriter
+    {
+        private readonly ISession _session;
+
+        public OutputWriter(ISession session) => _session = session;
+
+        public Task WriteAsync(IOutputMessage message)
+        {
+            var text = message switch
+            {
+                PlainMessage m     => m.Text,
+                HelpEntryMessage m => RenderEntry(m),
+                HelpIndexMessage m => RenderIndex(m),
+                _                  => message.ToString() ?? string.Empty,
+            };
+            return _session.SendLineAsync(text);
+        }
+
+        private static string RenderEntry(HelpEntryMessage m)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"[{m.Verb}]");
+            sb.AppendLine(m.LongDescription);
+            if (!string.IsNullOrEmpty(m.Usage))
+            {
+                sb.AppendLine();
+                sb.Append($"Usage: {m.Usage}");
+            }
+            return sb.ToString();
+        }
+
+        private static string RenderIndex(HelpIndexMessage m)
+        {
+            var sb = new StringBuilder();
+            var groups = m.Entries
+                .GroupBy(e => e.Category)
+                .OrderBy(g => (int)g.Key);
+
+            var first = true;
+            foreach (var group in groups)
+            {
+                if (!first) sb.AppendLine();
+                first = false;
+                sb.AppendLine($"=== {group.Key} ===");
+                foreach (var entry in group.OrderBy(e => e.Verb))
+                    sb.AppendLine($"  {entry.Verb,-14} {entry.ShortDescription}");
+            }
+            return sb.ToString().TrimEnd();
+        }
+    }
+}

--- a/Core/Output/OutputWriterFactory.cs
+++ b/Core/Output/OutputWriterFactory.cs
@@ -1,0 +1,10 @@
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Output
+{
+    /// <summary>Creates <see cref="OutputWriter"/> instances bound to a session.</summary>
+    public sealed class OutputWriterFactory : IOutputWriterFactory
+    {
+        public IOutputWriter Create(ISession session) => new OutputWriter(session);
+    }
+}

--- a/Core/Output/PlainMessage.cs
+++ b/Core/Output/PlainMessage.cs
@@ -1,0 +1,8 @@
+namespace Hedron.Core.Output
+{
+    /// <summary>A plain-text message with a severity hint for future formatting.</summary>
+    public sealed record PlainMessage(string Text, OutputSeverity Severity) : IOutputMessage
+    {
+        public OutputCategory Category => OutputCategory.System;
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -1,5 +1,7 @@
 using Hedron.Core;
 using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.Commands.Events;
 using Hedron.Core.ECS;
 using Hedron.Core.Events;
 using Hedron.Core.Handlers;
@@ -9,6 +11,7 @@ using Hedron.Core.Modules.Admin.Handlers;
 using Hedron.Core.Modules.Chat.Commands;
 using Hedron.Core.Modules.Chat.Events;
 using Hedron.Core.Modules.Chat.Handlers;
+using Hedron.Core.Modules.Help;
 using Hedron.Core.Modules.Movement.Commands;
 using Hedron.Core.Modules.Movement.Events;
 using Hedron.Core.Modules.Movement.Handlers;
@@ -18,6 +21,7 @@ using Hedron.Core.Modules.Session.Events;
 using Hedron.Core.Modules.Session.Handlers;
 using Hedron.Core.Modules.World;
 using Hedron.Core.Modules.World.Events;
+using Hedron.Core.Output;
 using Hedron.Core.Sessions;
 using Hedron.Core.Systems;
 using Hedron.Server.Sessions;
@@ -36,8 +40,7 @@ public static class Program
         var host = Host.CreateDefaultBuilder(args)
             .ConfigureServices(services =>
             {
-                // ECS world — singleton, shared between the static EcsManager bridge and
-                // any DI-injected consumer.
+                // ECS world
                 var world = new EntityService();
                 EcsManager.SetWorld(world);
                 services.AddSingleton(world);
@@ -45,6 +48,10 @@ public static class Program
                 services.AddSingleton<IEventBus, EventBus>();
                 services.AddSingleton<ICommandDispatcher, CommandDispatcher>();
                 services.AddSingleton<ISessionManager, SessionManager>();
+
+                // Command framework — argument parser and output writer factory
+                services.AddSingleton<ICommandArgumentParser, CommandArgumentParser>();
+                services.AddSingleton<IOutputWriterFactory, OutputWriterFactory>();
 
                 // Systems
                 services.AddSingleton<IBroadcastSystem, BroadcastSystem>();
@@ -58,6 +65,7 @@ public static class Program
                 services.AddSingleton<PlayerSessionHandler>();
                 services.AddSingleton<PlayerMovedHandler>();
                 services.AddSingleton<PlayerSaidHandler>();
+                services.AddSingleton<CommandLoggingHandler>();
 
                 // Player-facing commands
                 services.AddSingleton<ICommand, SayCommand>();
@@ -70,16 +78,13 @@ public static class Program
                         sp.GetRequiredService<IEventBus>()));
                 }
 
-                // Modules — World registers TemplateRegistry, ContentSerializer, ContentLoader,
-                // and the LookCommand. Admin registers the authorizer, four admin commands,
-                // and the audit handler.
+                // Modules — World, Admin (registers IAuthorizationChecker), Help
                 services.AddPersistenceModule();
                 services.AddWorldModule();
                 services.AddAdminModule();
+                services.AddHelpModule();
 
-                // Hosted services — order matters. PersistenceBootstrap loads persisted entities
-                // and publishes WorldLoadedEvent; WorldContentBootstrap then registers authored
-                // templates and seeds any missing entities; TelnetServer accepts connections last.
+                // Hosted services — order matters.
                 services.AddHostedService<PersistenceBootstrap>();
                 services.AddHostedService<WorldContentBootstrap>();
                 services.AddHostedService<PersistenceFlushTimer>();
@@ -104,6 +109,9 @@ public static class Program
         var persistenceHandler = host.Services.GetRequiredService<PersistenceHandler>();
         bus.Subscribe<EntitySpawnedByAdminEvent>(persistenceHandler);
         bus.Subscribe<RoomExitAuthoredByAdminEvent>(persistenceHandler);
+
+        var commandLogging = host.Services.GetRequiredService<CommandLoggingHandler>();
+        bus.Subscribe<CommandExecutedEvent>(commandLogging);
 
         await host.RunAsync();
     }

--- a/docs/architecture/00-overview.md
+++ b/docs/architecture/00-overview.md
@@ -73,8 +73,10 @@ Rows marked *(target)* describe locations that are rebuilt as part of Phase 2. T
 | [03-events.md](03-events.md) | Before defining a new event or subscription |
 | [04-pitfalls.md](04-pitfalls.md) | When tempted to shortcut the layering |
 | [05-configuration.md](05-configuration.md) | Before wiring any setting to `IConfiguration` or adding a constant |
+| [06-commands.md](06-commands.md) | Command framework design: `ICommand` shape, argument schema, privilege gate, output, help |
 | [06-flows.md](06-flows.md) | When tracing a runtime call chain (startup, command lifecycle, persistence flush, content reload, …) |
 | [checklist.md](checklist.md) | **The authoritative invariant list.** Cite `INV-n` IDs in reviews. Every other doc explains; this one enforces. |
+| [../reference/commands.md](../reference/commands.md) | Living catalog of every command |
 | [../reference/systems.md](../reference/systems.md) | Living catalog of every system |
 | [../reference/handlers.md](../reference/handlers.md) | Living catalog of every handler |
 | [../reference/components.md](../reference/components.md) | Living catalog of every component |

--- a/docs/architecture/06-commands.md
+++ b/docs/architecture/06-commands.md
@@ -1,0 +1,148 @@
+# Command Framework
+
+> Introduced in Phase 3 slice 3. Authoritative implementation: `Core/Commands/`. See also [`06-flows.md`](06-flows.md) Flow 3 for the runtime call chain.
+
+---
+
+## Overview
+
+Every player-facing verb is an `ICommand` implementation. The command framework provides:
+
+1. **Declarative argument parsing** — each command declares its argument schema; `ICommandArgumentParser` handles tokenization, type coercion, and enum-prefix matching.
+2. **Structural privilege gate** — commands declare `RequiredPrivileges`; the dispatcher calls `IAuthorizationChecker` for each requirement before invoking the command body. Forgetting a gate is impossible — `RequiredPrivileges` is a required interface member.
+3. **Typed output** — output goes through `IOutputWriter.WriteAsync(IOutputMessage)`, never `session.SendLineAsync`. Slice 4 replaces the writer implementation with a formatter-backed one.
+4. **Universal audit** — `CommandExecutedEvent` is published for every dispatch outcome (success, parse-fail, unauthorized, threw). `CommandLoggingHandler` writes one structured-log line per command.
+5. **Built-in help** — `help` and `commands` enumerate DI-collected `IEnumerable<ICommand>` with visibility filtering. Every command's `LongDescription` and `Usage` are surfaced automatically.
+
+---
+
+## ICommand shape
+
+```csharp
+public interface ICommand
+{
+    string Name { get; }
+    IReadOnlyList<string> Aliases { get; }
+    CommandCategory Category { get; }              // Player | Admin | System
+    string ShortDescription { get; }               // one-liner for 'commands'
+    string LongDescription { get; }                // multi-line body for 'help <verb>'
+    string Usage { get; }                          // formal grammar
+    IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } // empty = public
+    CommandArgumentSchema ArgumentSchema { get; }
+    Task ExecuteAsync(CommandContext context);
+}
+```
+
+`CommandContext`:
+
+```csharp
+public sealed record CommandContext(
+    ISession Session,
+    uint InvokerEntityId,
+    ParsedArguments Args,
+    IOutputWriter Output,
+    IServiceProvider Services);
+```
+
+Read typed args: `context.Args.Get<Direction>("direction")`. Write output: `context.Output.WriteAsync(new PlainMessage(...))`. Publish events via the `IEventBus` injected into the command constructor. `Services` is an escape hatch — prefer constructor injection.
+
+---
+
+## Argument schema
+
+```csharp
+public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+{
+    new CommandArgument("direction", typeof(Direction), CommandArgumentKind.Token,
+        Required: true, "Direction to move."),
+    new CommandArgument("message", typeof(string), CommandArgumentKind.RestOfLine,
+        Required: true, "The text to say."),
+});
+```
+
+`CommandArgumentKind` values:
+- `Token` — one whitespace-delimited token (or double-quoted group)
+- `RestOfLine` — everything from current position to end-of-line
+- `Quantified` — leading count + token (deferred; not used in slice 3)
+
+Type coercion supports `string`, `int`, `uint`, and any `enum`. Enum coercion uses prefix matching (`n` → `North`, `s` → `South`). No-arg commands use `CommandArgumentSchema.Empty`.
+
+---
+
+## Privilege gate
+
+```csharp
+// Public command — no gate
+public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+    Array.Empty<IAuthorizationRequirement>();
+
+// Admin command — structural gate
+public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+    new IAuthorizationRequirement[] { new AdminRequirement() };
+```
+
+The dispatcher iterates `RequiredPrivileges` and calls `IAuthorizationChecker.IsSatisfied(req, session)` for each before invoking `ExecuteAsync`. Never put `IAdminAuthorizer.IsPrivileged` calls inside a command body — that is the pre-slice-3 convention this framework replaced.
+
+Future requirement types (guild-leader, zone-owner, faction-rank) register new implementations of `IAuthorizationRequirement` and extend `AuthorizationChecker` without touching the dispatcher.
+
+---
+
+## Output
+
+```csharp
+// Plain text (error, confirmation, system message)
+await context.Output.WriteAsync(new PlainMessage("Spawned entity #42.", OutputSeverity.Confirmation));
+
+// Help display (used by HelpCommand / CommandsCommand — but commands can use these too)
+await context.Output.WriteAsync(new HelpEntryMessage(verb, longDesc, usage));
+await context.Output.WriteAsync(new HelpIndexMessage(entries));
+```
+
+`OutputSeverity` values: `System | Error | Confirmation | Chat`. Slice 4 will use these to apply color / ANSI formatting. For now the writer stringifies and forwards via `session.SendLineAsync`.
+
+---
+
+## File placement
+
+```
+Core/Modules/<Feature>/Commands/<X>Command.cs   # feature-owned
+Core/Commands/<X>Command.cs                     # cross-cutting (look, who, etc.)
+```
+
+Use the `add-command` skill (`.claude/skills/add-command/SKILL.md`) for step-by-step guidance.
+
+---
+
+## Registration
+
+Register in the feature module:
+
+```csharp
+services.AddSingleton<ICommand, MyCommand>();
+```
+
+The dispatcher resolves all `IEnumerable<ICommand>` at construction and builds the verb map. Duplicate verbs throw at startup.
+
+---
+
+## CommandExecutedEvent
+
+```csharp
+public record CommandExecutedEvent(
+    uint InvokerEntityId,
+    string Verb,
+    string ArgsSummary,     // truncated at 200 chars; plaintext — see backlog for redaction
+    CommandOutcome Outcome) : IEvent;
+```
+
+`CommandOutcome`: `Success | ParseFailed | Unauthorized | Threw`. Published by `CommandDispatcher` for every dispatch. `CommandLoggingHandler` (priority 80) writes one structured-log line per dispatch. `AdminAuditHandler` does **not** subscribe to this event — it uses the richer slice-2 admin events.
+
+---
+
+## Related
+
+- [`06-flows.md` Flow 3](06-flows.md#flow-3--player-command-lifecycle) — runtime call chain
+- [`../reference/commands.md`](../reference/commands.md) — living command catalog
+- [`../use-cases/command-framework.md`](../use-cases/command-framework.md) — slice 3 spec
+- [`01-layers.md`](01-layers.md) — Initiators tier (commands and dispatcher may publish events)
+- [`checklist.md`](checklist.md) — INV-8 through INV-11 govern the command tier

--- a/docs/architecture/06-flows.md
+++ b/docs/architecture/06-flows.md
@@ -14,7 +14,7 @@
 | 2 | [Player connection](#flow-2--player-connection) | TCP client connects on the configured port | Phase 2 |
 | 3 | [Player command lifecycle](#flow-3--player-command-lifecycle) | Player sends a line of input | Phase 2 (replaced by slice 3 command framework; output leg re-traced again by slice 4) |
 | 4 | [Persistence flush cycle](#flow-4--persistence-flush-cycle) | `PersistenceFlushTimer` ticks, or shutdown | Phase 3 slice 1 |
-| 5 | [Content reload](#flow-5--content-reload-reload) | Privileged session sends `@reload` | Phase 3 slice 2 |
+| 5 | [Content reload](#flow-5--content-reload-reload) | Privileged session sends `reload` | Phase 3 slice 2 (gate moved to dispatcher in slice 3) |
 | 6 | Output rendering | A command/system writes a typed `IOutputMessage` | Phase 3 slice 4 (added by that slice's PR) |
 
 Flows that don't yet exist (combat round, player death, item pickup, mob wander tick, etc.) get added by the slice that introduces them.
@@ -132,9 +132,7 @@ sequenceDiagram
 
 ## Flow 3 — Player command lifecycle
 
-**Summary.** Input bytes become a verb + raw argument string; the dispatcher routes to an `ICommand`; the command parses its own arguments, calls a system, and publishes events; subscribed handlers run in priority order; output is written via the session.
-
-> **Slice 3 replaces this flow; slice 4 re-traces its output leg.** The current MVP shape (this section) does per-command argument parsing, per-command privilege checks, and per-command output formatting. Slice 3 ([`../use-cases/command-framework.md`](../use-cases/command-framework.md)) introduces a `CommandContext` with parsed arguments, a structural privilege gate (`IAuthorizationChecker` over `RequiredPrivileges`) enforced by the dispatcher, and a `CommandExecutedEvent` covering every dispatch — and ships a minimal stringify-and-forward output writer. Slice 4 ([`../use-cases/output-framework.md`](../use-cases/output-framework.md)) then re-traces only the output leg (formatter-backed, color, capability strip) and adds Flow 6. **Re-trace this flow as part of slice 3's PR** (replace the section below with the framework-driven version) and **update the output step again in slice 4's PR**.
+**Summary.** Input bytes become a verb + raw tail; the dispatcher checks authorization via `IAuthorizationChecker`, parses arguments via `ICommandArgumentParser`, constructs a `CommandContext`, calls `ICommand.ExecuteAsync(context)`, and publishes `CommandExecutedEvent` for every outcome. Output goes through the minimal `IOutputWriter` (stringify-and-forward); slice 4 replaces the writer with a formatter-backed implementation.
 
 **Trigger.** A line of input arrives on a session's read stream.
 
@@ -143,53 +141,57 @@ sequenceDiagram
     participant Client
     participant Sess as TelnetSession
     participant CD as CommandDispatcher
+    participant Auth as IAuthorizationChecker
+    participant Parser as ICommandArgumentParser
     participant Cmd as ICommand impl
-    participant Sys as Domain system
     participant Bus as IEventBus
-    participant Hndlr as Handlers (priority order)
 
     Client->>Sess: input line
     Sess->>CD: DispatchAsync(session, input)
-    CD->>CD: trim + split first whitespace → verb, args
+    CD->>CD: trim + split → verb, rawTail
     alt verb unknown
-        CD->>Sess: SendLineAsync("Unknown command: …")
+        CD->>Sess: WriteAsync(PlainMessage "Unknown command…")
+        CD->>Bus: Publish(CommandExecutedEvent ParseFailed)
     else verb known
-        CD->>Cmd: ExecuteAsync(session, args)
-        Cmd->>Cmd: parse args (per-command, ad hoc)
-        Cmd->>Sys: domain call
-        Sys-->>Cmd: result
-        opt admin commands
-            Cmd->>Cmd: IAdminAuthorizer.IsPrivileged (per-command convention)
+        loop RequiredPrivileges
+            CD->>Auth: IsSatisfied(req, session)
         end
-        Cmd->>Bus: Publish past-tense event
-        loop priority order
-            Bus->>Hndlr: HandleAsync
+        alt unauthorized
+            CD->>Sess: WriteAsync(PlainMessage "Not authorized")
+            CD->>Bus: Publish(CommandExecutedEvent Unauthorized)
+        else authorized
+            CD->>Parser: Parse(ArgumentSchema, rawTail)
+            alt parse failed
+                CD->>Sess: WriteAsync(PlainMessage reason + help hint)
+                CD->>Bus: Publish(CommandExecutedEvent ParseFailed)
+            else parsed
+                CD->>Cmd: ExecuteAsync(CommandContext)
+                Cmd->>Cmd: domain call / event publish
+                Cmd->>Sess: WriteAsync(IOutputMessage) via IOutputWriter
+                CD->>Bus: Publish(CommandExecutedEvent Success)
+                Bus->>Bus: priority-ordered handlers (20 → 80 → 90 → 95)
+            end
         end
-        Cmd->>Sess: SendLineAsync (per-command formatting)
     end
 ```
 
-**Steps (current MVP shape).**
+**Steps.**
 
 1. `TelnetSession` reads a line and calls `CommandDispatcher.DispatchAsync(session, input)`.
-2. The dispatcher trims input, splits on the first whitespace into verb + argument string, and looks the verb up case-insensitively. Unknown verbs produce `"Unknown command: <verb>"` and the dispatch returns.
-3. The matched `ICommand.ExecuteAsync(session, arguments)` runs. The command is responsible for parsing `arguments` itself — there is no shared parser in this slice.
-4. **Admin commands** (verbs starting with `@`) call `IAdminAuthorizer.IsPrivileged(session)` as the first line of `ExecuteAsync` and short-circuit with a rejection line for non-privileged sessions. This is convention, not structure — slice 3 promotes it to a dispatcher-enforced gate.
-5. The command body calls a domain system (or core helper), formats output, and publishes any past-tense events.
-6. `IEventBus` invokes subscribed handlers in priority order (`HandlerPriority.State` 10 → `Domain` 20 → `Notification` 80 → `Persistence` 90 → `Ai` 95).
-7. Output is written via `session.SendLineAsync` (or `IBroadcastSystem` for room-wide messages).
-
-**What's hand-rolled today (slice 3 promotes each).**
-
-- Argument parsing — every command does its own `Trim()`/`Split()`.
-- Privilege checks — convention, not structure.
-- Help text — currently lives only as the rejection-branch usage line.
-- Output formatting — bespoke per command.
-- Audit logging — only admin events publish; player-facing verbs (`look`, `say`, movement) publish nothing.
+2. The dispatcher trims input and splits on the first whitespace into verb + raw tail. Unknown verbs write `PlainMessage("Unknown command: <verb>. Type 'help' for a list.")` via `IOutputWriter`, publish `CommandExecutedEvent(ParseFailed)`, and return.
+3. **Privilege gate.** The dispatcher iterates `command.RequiredPrivileges` and calls `IAuthorizationChecker.IsSatisfied(req, session)` for each. The checker is the sole policy seam — `AdminRequirement` delegates to the existing `IAdminAuthorizer`. Any unsatisfied requirement writes a rejection `PlainMessage` via `IOutputWriter` and publishes `CommandExecutedEvent(Unauthorized)`.
+4. **Argument parse.** `ICommandArgumentParser.Parse(command.ArgumentSchema, rawTail)` does single-pass tokenization (whitespace + double-quoted groups), walks the declarative argument list, and coerces each token to its CLR type (`string`, `int`, `uint`, `Direction`). Enum-prefix matching works from day one (`n`/`no`/`nor` → `North`). On failure: the reason + `"Type 'help <verb>' for usage."` is written via `IOutputWriter`; `CommandExecutedEvent(ParseFailed)` is published.
+5. **Execute.** The dispatcher constructs `CommandContext(Session, InvokerEntityId, ParsedArguments, IOutputWriter, IServiceProvider)` and calls `command.ExecuteAsync(context)`. The body reads typed args via `context.Args.Get<T>(name)`, calls domain systems or publishes events via injected `IEventBus`, and writes all output via `context.Output.WriteAsync(IOutputMessage)`. No `session.SendLineAsync` in command bodies.
+6. **Minimal output seam.** `IOutputWriter.WriteAsync` stringifies the message (`PlainMessage` → its text; `HelpIndexMessage` / `HelpEntryMessage` → plain-text rendering) and calls `session.SendLineAsync`. Slice 4 replaces this implementation with a formatter-backed one.
+7. **Exception trap.** Any uncaught exception is caught, logged at `Error` with a full stack trace, a `PlainMessage("Something went wrong. The error has been logged.")` is written, and `CommandExecutedEvent(Threw)` is published. No stack trace reaches the session.
+8. **`CommandExecutedEvent`.** Published on every dispatch path — success, parse-fail, unauthorized, threw. `CommandLoggingHandler` (priority 80) writes one structured-log line per command via `ILogger`. `AdminAuditHandler` keeps subscribing to the four richer slice-2 admin events and does **not** subscribe to `CommandExecutedEvent`.
 
 **Cross-references.**
 - [`Core/Commands/CommandDispatcher.cs`](../../Core/Commands/CommandDispatcher.cs), [`Core/Commands/ICommand.cs`](../../Core/Commands/ICommand.cs)
-- [`docs/use-cases/command-framework.md`](../use-cases/command-framework.md) — slice 3 spec (rewrites this flow); [`docs/use-cases/output-framework.md`](../use-cases/output-framework.md) — slice 4 spec (re-traces the output leg, adds Flow 6)
+- [`Core/Commands/Authorization/IAuthorizationChecker.cs`](../../Core/Commands/Authorization/IAuthorizationChecker.cs), [`Core/Commands/CommandArgumentParser.cs`](../../Core/Commands/CommandArgumentParser.cs)
+- [`Core/Output/OutputWriter.cs`](../../Core/Output/OutputWriter.cs), [`Core/Handlers/CommandLoggingHandler.cs`](../../Core/Handlers/CommandLoggingHandler.cs)
+- [`docs/architecture/06-commands.md`](06-commands.md) — command framework design
+- [`docs/use-cases/command-framework.md`](../use-cases/command-framework.md) — slice 3 spec; [`docs/use-cases/output-framework.md`](../use-cases/output-framework.md) — slice 4 spec (re-traces output leg, adds Flow 6)
 - [`docs/reference/handlers.md`](../reference/handlers.md) — handler priority tiers
 
 ---
@@ -243,29 +245,29 @@ sequenceDiagram
 
 ---
 
-## Flow 5 — Content reload (`@reload`)
+## Flow 5 — Content reload (`reload`)
 
 **Summary.** A privileged session re-scans the content directory and refreshes the template registry. Templates with no live counterpart are seeded; **existing live entities are not mutated**. The pass is additive only.
 
-**Trigger.** Privileged session sends `@reload`.
+**Trigger.** Privileged session sends `reload`.
 
 ```mermaid
 sequenceDiagram
     participant Session
     participant CD as CommandDispatcher
+    participant Auth as IAuthorizationChecker
     participant RC as ReloadCommand
-    participant Auth as IAdminAuthorizer
     participant WCL as WorldContentLoader
     participant Reg as ITemplateRegistry
     participant Bus as IEventBus
     participant Audit as AdminAuditHandler
 
-    Session->>CD: "@reload"
-    CD->>RC: ExecuteAsync
-    RC->>Auth: IsPrivileged
-    alt not privileged
-        RC->>Session: rejection line
-    else privileged
+    Session->>CD: "reload"
+    CD->>Auth: IsSatisfied(AdminRequirement, session)
+    alt unauthorized
+        CD->>Session: rejection (via IOutputWriter)
+    else authorized
+        CD->>RC: ExecuteAsync(CommandContext)
         RC->>WCL: ReloadAsync
         WCL->>Reg: snapshot previous ids
         WCL->>Reg: Clear
@@ -274,7 +276,7 @@ sequenceDiagram
         WCL->>WCL: SpawnMissingEntities (skip-on-conflict)
         WCL->>WCL: LinkRoomExits (new entities only)
         WCL-->>RC: ContentReloadResult{ loaded, unchanged, removed }
-        RC->>Session: confirmation line
+        RC->>Session: confirmation (via IOutputWriter)
         RC->>Bus: Publish(ContentReloadedEvent)
         Bus->>Audit: HandleAsync (structured log)
     end
@@ -282,18 +284,18 @@ sequenceDiagram
 
 **Steps.**
 
-1. `CommandDispatcher` routes `@reload` to `ReloadCommand`.
-2. `ReloadCommand.ExecuteAsync` calls `IAdminAuthorizer.IsPrivileged(session)` first. Non-privileged sessions get a one-line rejection and the command body returns.
+1. `CommandDispatcher` routes `reload` to `ReloadCommand`.
+2. **Authorization gate.** The dispatcher calls `IAuthorizationChecker.IsSatisfied(AdminRequirement, session)` **before** invoking `ReloadCommand`. Non-privileged sessions receive a rejection `PlainMessage` via `IOutputWriter` and `CommandExecutedEvent(Unauthorized)`; `ReloadCommand.ExecuteAsync` never runs. This is the slice-3 structural replacement for slice-2's per-command `IsPrivileged` convention.
 3. The command calls `IWorldContentLoader.ReloadAsync(ct)`.
 4. The loader snapshots the previous template ids, clears the registry, and re-scans `World:ContentDirectory`. Each YAML file is re-deserialized via the cross-cutting `IContentSerializer` → kind-specific `ITemplateDeserializer` and re-registered.
 5. Loaded / unchanged / removed counts are computed by set difference against the previous snapshot.
 6. `BuildLiveBlueprintMap` enumerates every entity that has a `BlueprintComponent`. For each registered template that has no entry in the map, `SpawnMissingEntities` calls `TemplateRegistry.Spawn(blueprintId)` (which allocates an entity, attaches `BlueprintComponent`, and runs `IEntityTemplate.Apply`).
 7. `LinkRoomExits` populates `RoomComponent.Exits` for the newly spawned entities only — existing live rooms are not touched.
 8. `ReloadAsync` returns `ContentReloadResult { loaded, unchanged, removed }`.
-9. The command writes a confirmation line to the invoker and publishes `ContentReloadedEvent` (thin payload — the three counts).
+9. The command writes a confirmation `PlainMessage` via `CommandContext.Output` (`IOutputWriter`) and publishes `ContentReloadedEvent` (thin payload — the three counts).
 10. `AdminAuditHandler` (priority `HandlerPriority.Notification` = 80) writes one structured-log entry with stable event name `AdminCommandExecuted`.
 
-**Constraint.** Live entities are never mutated by reload. To pick up edits to a live room's description or components, restart the host; or use `@dig` for exit changes that should apply immediately.
+**Constraint.** Live entities are never mutated by reload. To pick up edits to a live room's description or components, restart the host; or use `dig` for exit changes that should apply immediately.
 
 **Cross-references.**
 - [`Core/Modules/Admin/Commands/ReloadCommand.cs`](../../Core/Modules/Admin/Commands/ReloadCommand.cs), [`Core/Modules/World/Systems/WorldContentLoader.cs`](../../Core/Modules/World/Systems/WorldContentLoader.cs)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,173 @@
+# Commands Reference
+
+Living catalog of every registered command. Commands are the thinnest layer — they declare a schema and delegate to domain systems or events. See [`../architecture/06-commands.md`](../architecture/06-commands.md) for the framework design.
+
+**Grouping:** by `CommandCategory`. Within each category, alphabetical by primary verb.
+
+---
+
+## Player commands
+
+### `commands`
+
+**Aliases:** none  
+**Location:** `Core/Modules/Help/Commands/CommandsCommand.cs`  
+**Description:** Prints a category-grouped one-line index of all commands visible to the caller. Same visibility filtering as `help` (admin commands hidden when their `RequiredPrivileges` are unsatisfied).  
+**Usage:** `commands`  
+**Schema:** no arguments  
+**Events:** none
+
+---
+
+### `down` / `d`
+
+**Aliases:** `d`  
+**Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
+**Description:** Move down if an exit exists.  
+**Usage:** `down`  
+**Schema:** no arguments  
+**Events:** `PlayerMovedEvent`
+
+---
+
+### `east` / `e`
+
+**Aliases:** `e`  
+**Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
+**Description:** Move east if an exit exists.  
+**Usage:** `east`  
+**Schema:** no arguments  
+**Events:** `PlayerMovedEvent`
+
+---
+
+### `help` / `?`
+
+**Aliases:** `?`  
+**Location:** `Core/Modules/Help/Commands/HelpCommand.cs`  
+**Description:** With no argument, lists all commands visible to the caller grouped by category. With a verb argument, shows `LongDescription` and `Usage` for that command.  
+**Usage:** `help [<verb>]`  
+**Schema:** optional `Token string "verb"`  
+**Events:** none
+
+---
+
+### `look` / `l`
+
+**Aliases:** `l`  
+**Location:** `Core/Modules/World/Commands/LookCommand.cs`  
+**Description:** Displays the current room description, visible exits, and other players present. Delegates to `IBroadcastSystem.SendRoomDescriptionAsync`; output is not yet routed through the `IOutputWriter` formatter (deferred to slice 4).  
+**Usage:** `look`  
+**Schema:** no arguments  
+**Events:** none
+
+---
+
+### `north` / `n`
+
+**Aliases:** `n`  
+**Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
+**Description:** Move north if an exit exists.  
+**Usage:** `north`  
+**Schema:** no arguments  
+**Events:** `PlayerMovedEvent`
+
+---
+
+### `say`
+
+**Aliases:** none  
+**Location:** `Core/Modules/Chat/Commands/SayCommand.cs`  
+**Description:** Broadcasts a message to all players in the current room.  
+**Usage:** `say <message>`  
+**Schema:** `RestOfLine string "message"` (required)  
+**Events:** `PlayerSaidEvent`
+
+---
+
+### `south` / `s`
+
+**Aliases:** `s`  
+**Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
+**Description:** Move south if an exit exists.  
+**Usage:** `south`  
+**Schema:** no arguments  
+**Events:** `PlayerMovedEvent`
+
+---
+
+### `up` / `u`
+
+**Aliases:** `u`  
+**Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
+**Description:** Move up if an exit exists.  
+**Usage:** `up`  
+**Schema:** no arguments  
+**Events:** `PlayerMovedEvent`
+
+---
+
+### `west` / `w`
+
+**Aliases:** `w`  
+**Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
+**Description:** Move west if an exit exists.  
+**Usage:** `west`  
+**Schema:** no arguments  
+**Events:** `PlayerMovedEvent`
+
+---
+
+## Admin commands
+
+All admin commands require `AdminRequirement`. The dispatcher enforces this via `IAuthorizationChecker`; no per-command `IsPrivileged` call is needed or permitted.
+
+---
+
+### `dig`
+
+**Aliases:** none  
+**Location:** `Core/Modules/Admin/Commands/DigCommand.cs`  
+**Description:** Adds an exit from the current room to the target room and wires the reverse link by default. Updates the in-memory `RoomTemplate` so a same-session `reload` won't undo the change. The source YAML file is not rewritten; durability comes from `PersistenceSystem`.  
+**Usage:** `dig <direction> <targetRoomBlueprintId>`  
+**Schema:** `Token Direction "direction"` (required), `Token string "targetRoomBlueprintId"` (required)  
+**Events:** `RoomExitAuthoredByAdminEvent`
+
+---
+
+### `reload`
+
+**Aliases:** none  
+**Location:** `Core/Modules/Admin/Commands/ReloadCommand.cs`  
+**Description:** Re-scans the content directory and refreshes the template registry. Newly authored templates with no live counterpart are seeded. **Existing live entities are not modified** — descriptions, exits, and components on rooms that already exist will not change. To pick up edits to a live room, restart, or use `dig` for exit changes.  
+**Usage:** `reload`  
+**Schema:** no arguments  
+**Events:** `ContentReloadedEvent`
+
+---
+
+### `spawn`
+
+**Aliases:** none  
+**Location:** `Core/Modules/Admin/Commands/SpawnCommand.cs`  
+**Description:** Spawns a templated entity into the world. In slice 3 this creates an orphan entity (rooms/areas); use `dig` to wire a new room in. Item and mob placement land with their slices.  
+**Usage:** `spawn <blueprintId>`  
+**Schema:** `Token string "blueprintId"` (required)  
+**Events:** `EntitySpawnedByAdminEvent`
+
+---
+
+### `teleport` / `tp`
+
+**Aliases:** `tp`  
+**Location:** `Core/Modules/Admin/Commands/TeleportCommand.cs`  
+**Description:** Teleports the invoker to a target room (by blueprint id) or to a player's current room (by display name).  
+**Usage:** `teleport <roomBlueprintId|playerName>`  
+**Schema:** `Token string "target"` (required)  
+**Events:** `PlayerTeleportedByAdminEvent`
+
+---
+
+## Adding a new command
+
+Use the `add-command` skill (`.claude/skills/add-command/SKILL.md`) for step-by-step guidance on the new `ICommand` shape, argument schema, privilege declaration, and output.

--- a/docs/reference/handlers.md
+++ b/docs/reference/handlers.md
@@ -96,11 +96,12 @@ Ask:
 **Responsibilities:** trigger NPC behavior; aggro/threat management; decision trees; patrol/wander patterns.
 **Uses:** `IAISystem`, `ICombatSystem`, `IMovementSystem`, `IVisibilitySystem`
 
-### CommandHandler
-**Events:** `CommandReceivedEvent`
-**Responsibilities:** parse text input; validate syntax; route to executors; aliases; help/error messages.
-**Uses:** `ICommandParserService`, domain systems per-command
-> Entry point from player input. Parses, then raises more specific events.
+### CommandLoggingHandler
+**Events:** `CommandExecutedEvent` (Phase 3 slice 3)
+**Priority:** 80 (`HandlerPriority.Notification`)
+**Responsibilities:** writes one structured-log line per command dispatch via `ILogger<CommandLoggingHandler>`. Fires for every outcome (Success, ParseFailed, Unauthorized, Threw). Deliberately separate from `AdminAuditHandler` — command logging is low-fidelity and log-level-controllable; admin audit carries richer slice-2 event payloads.
+**Location:** `Core/Handlers/CommandLoggingHandler.cs`
+**Uses:** `ILogger<CommandLoggingHandler>`
 
 ---
 
@@ -112,9 +113,8 @@ Core/Modules/<Feature>/Handlers/   # feature-owned handlers
   Magic/Handlers/SpellHandler.cs
 
 Core/Handlers/                     # cross-cutting handlers
-  NotificationHandler.cs
   PersistenceHandler.cs
-  CommandHandler.cs
+  CommandLoggingHandler.cs
 ```
 
 Within a module, handlers sit alongside their events and domain systems — see [../architecture/01-layers.md#modules-feature-cohesion](../architecture/01-layers.md#modules-feature-cohesion).

--- a/docs/use-cases/command-framework.md
+++ b/docs/use-cases/command-framework.md
@@ -8,7 +8,7 @@
 
 ## Description
 
-Pure-infrastructure slice that closes the command-framework gap surfaced after [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) merged. The slice-2 `ICommand` shape (`Name`, `Aliases`, `ExecuteAsync(ISession, string)`) forces every command author to roll their own argument parsing, privilege gate, and help-text wording. The four slice-2 admin commands demonstrate the cost: each duplicates `Trim()`/`Split()`, reimplements the privilege check by convention, and emits one-off rejection usage strings. There is no `help` command, no `commands` index, and the required `@reload` long-form help wording from slice 2 has nowhere to live.
+Pure-infrastructure slice that closes the command-framework gap surfaced after [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) merged. The slice-2 `ICommand` shape (`Name`, `Aliases`, `ExecuteAsync(ISession, string)`) forces every command author to roll their own argument parsing, privilege gate, and help-text wording. The four slice-2 admin commands demonstrate the cost: each duplicates `Trim()`/`Split()`, reimplements the privilege check by convention, and emits one-off rejection usage strings. There is no `help` command, no `commands` index, and the required `reload` long-form help wording from slice 2 has nowhere to live.
 
 This slice introduces a first-class **command framework**:
 
@@ -20,7 +20,7 @@ This slice introduces a first-class **command framework**:
 
 It also lands the **bare-minimum output seam** so commands have a typed sink and `help` can dogfood typed output: `IOutputMessage`, `PlainMessage`, `HelpEntryMessage`, `HelpIndexMessage`, and a stringify-and-forward `IOutputWriter`. **No formatter, no color, no `RoomDescription`/`Movement`/`Combat`/`PlayerInformation` shapes, no SignalR seam** — those are explicitly slice 4 ([`output-framework.md`](output-framework.md)). Slice 3 leaves these as named stubs so the slice-4 planner knows precisely what is owed.
 
-The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `@spawn`, `@teleport`/`@tp`, `@dig`, `@reload`) are refactored onto the new shape. No gameplay change. This is an **infrastructure slice**, like [`persistence-substrate.md`](persistence-substrate.md); it introduces no new player-facing verbs beyond `help` and `commands`, and the slice-2 smoke still passes.
+The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `spawn`, `teleport`/`tp`, `dig`, `reload`) are refactored onto the new shape. No gameplay change. This is an **infrastructure slice**, like [`persistence-substrate.md`](persistence-substrate.md); it introduces no new player-facing verbs beyond `help` and `commands`, and the slice-2 smoke still passes.
 
 ---
 
@@ -39,7 +39,7 @@ The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `@spawn`, 
 - **No `session.SendLineAsync` survives anywhere on the dispatch path, including the dispatcher's own branches.** The existing unknown-verb call site at `Core/Commands/CommandDispatcher.cs:43` (`session.SendLineAsync($"Unknown command: {verb}")`) and any parse-error / unauthorized / exception output the dispatcher emits are routed through an `IOutputWriter` obtained via `IOutputWriterFactory.Create(session)`. This call site is named explicitly in the refactor checklist (Main Flow step 8) so it is not missed — it is *not* one of the 12 command files and would otherwise survive the refactor and break this postcondition on day one (INV-11).
 - Argument parsing is performed by a shared `ICommandArgumentParser` against each command's declarative schema. Commands no longer call `Trim()` / `Split()` in their bodies. Double-quoted arguments are supported. Enum-prefix matching works from day one (`n`/`no`/`nor` resolves to `north`).
 - Admin commands no longer call `IAdminAuthorizer.IsPrivileged` as their first line. Privilege is enforced structurally by `CommandDispatcher` consulting each command's `RequiredPrivileges` and an injected `IAuthorizationChecker`. Forgetting the gate is impossible — `RequiredPrivileges` is a required interface member; empty list = public.
-- `help` and `help <verb>` are usable from any session. `help` lists every command visible to the caller (admin commands hidden when authorization fails), grouped by `Category`, rendered via typed `HelpIndexMessage`. `help <verb>` shows `LongDescription` and `Usage` via `HelpEntryMessage`. The required `@reload` long-form wording from slice 2 is emitted by `help @reload`.
+- `help` and `help <verb>` are usable from any session. `help` lists every command visible to the caller (admin commands hidden when authorization fails), grouped by `Category`, rendered via typed `HelpIndexMessage`. `help <verb>` shows `LongDescription` and `Usage` via `HelpEntryMessage`. The required `reload` long-form wording from slice 2 is emitted by `help reload`.
 - `commands` (alias none) prints a terser category-grouped one-line index, same visibility filtering.
 - Every dispatch — success, parse-fail, unauthorized, threw — publishes a `CommandExecutedEvent`. `CommandLoggingHandler` (priority 80) writes one structured-log line per command. `AdminAuditHandler` continues to subscribe to its four slice-2 admin events; it does **not** subscribe to `CommandExecutedEvent`.
 - The rejection-branch usage strings inside the four admin commands are removed; malformed input is routed to `help <verb>` by the dispatcher's parse-error response. Slice-2 admin events still fire with identical payloads.
@@ -68,7 +68,7 @@ The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `@spawn`, 
    - **`look`** — Category `Player`, empty `RequiredPrivileges`, no args. Writes whatever room-description output the command currently produces via `IBroadcastSystem` (broadcast body is untouched this slice; slice 4 reworks it).
    - **`say`** — Category `Player`, one `RestOfLine` `string` arg ("message"), publishes `PlayerSaidEvent` unchanged.
    - **`MoveCommand` (×6)** — Category `Player`, no args, publishes `PlayerMovedEvent` unchanged. Failure path writes a `PlainMessage`.
-   - **`@spawn` / `@teleport` / `@dig` / `@reload`** — Category `Admin`, `RequiredPrivileges = [AdminRequirement]`, declarative schemas (`@spawn`: one `Token` `string`; `@teleport`: one `Token` `string`; `@dig`: one `Token` `Direction`, one `Token` `string`; `@reload`: none). Slice-2 admin events still published unchanged. In-body `IsPrivileged` calls and rejection usage strings removed.
+   - **`spawn` / `teleport` / `dig` / `reload`** — Category `Admin`, `RequiredPrivileges = [AdminRequirement]`, declarative schemas (`spawn`: one `Token` `string`; `teleport`: one `Token` `string`; `dig`: one `Token` `Direction`, one `Token` `string`; `reload`: none). Slice-2 admin events still published unchanged. In-body `IsPrivileged` calls and rejection usage strings removed.
 
 9. **Audit hand-off.** `AdminAuditHandler` (existing) keeps subscribing to its four slice-2 admin events for the rich payload. `CommandLoggingHandler` (new, priority 80) consumes `CommandExecutedEvent` for a low-fidelity command trace controllable via log level.
 
@@ -83,10 +83,10 @@ The 12 existing commands (`look`, `say`, six `MoveCommand` instances, `@spawn`, 
 | `CommandExecutedEvent(uint InvokerEntityId, string Verb, string ArgsSummary, CommandOutcome Outcome)` | `CommandDispatcher` | Every dispatch (success, parse-fail, unauthorized, threw) | Cross-cutting audit/logging seam. Future telemetry subscribes without per-command code. |
 | `PlayerSaidEvent` (existing — `Core/Modules/Chat/Events/`) | `SayCommand` | Per `say` | Unchanged — refactor preserves payload exactly. |
 | `PlayerMovedEvent` (existing — `Core/Modules/Movement/Events/`) | `MoveCommand` | Per successful move | Unchanged. |
-| `EntitySpawnedByAdminEvent` (existing — slice 2) | `SpawnCommand` | Per `@spawn` | Unchanged. |
-| `PlayerTeleportedByAdminEvent` (existing — slice 2) | `TeleportCommand` | Per `@teleport` | Unchanged. |
-| `RoomExitAuthoredByAdminEvent` (existing — slice 2) | `DigCommand` | Per `@dig` | Unchanged. |
-| `ContentReloadedEvent` (existing — slice 2) | `ReloadCommand` | Per `@reload` | Unchanged. |
+| `EntitySpawnedByAdminEvent` (existing — slice 2) | `SpawnCommand` | Per `spawn` | Unchanged. |
+| `PlayerTeleportedByAdminEvent` (existing — slice 2) | `TeleportCommand` | Per `teleport` | Unchanged. |
+| `RoomExitAuthoredByAdminEvent` (existing — slice 2) | `DigCommand` | Per `dig` | Unchanged. |
+| `ContentReloadedEvent` (existing — slice 2) | `ReloadCommand` | Per `reload` | Unchanged. |
 
 ### `CommandOutcome` enum
 
@@ -96,7 +96,7 @@ Success | ParseFailed | Unauthorized | Threw
 
 ### `ArgsSummary` content
 
-A short normalized rendering of the parsed args for log readability — e.g. `@dig east room.crossroads` summarizes to `east room.crossroads`. Dispatcher truncates at 200 characters. **Known operational gap (spec-mode S4):** there is no argument-redaction mechanism this slice, so `say` content (and any future `tell` / `password` / auth-bearing verb) is written to logs in plaintext. This is acceptable for slice 3 because the only verb with free-text args is `say` and the logger is local, but it **must not** ship to any environment with retained/forwarded logs without redaction. Tracked as an explicit acknowledged-debt item in [`../roadmap/backlog.md`](../roadmap/backlog.md) ("Command-arg log redaction") with the proposed fix (a per-command `[NoLogArgs]` / `RedactArgs` declaration honored by the dispatcher before it builds `ArgsSummary`). It is a prerequisite for any non-local logging sink. Partial-success vs command-success is a layer above and stays inside the command body — it does not affect `Outcome`.
+A short normalized rendering of the parsed args for log readability — e.g. `dig east room.crossroads` summarizes to `east room.crossroads`. Dispatcher truncates at 200 characters. **Known operational gap (spec-mode S4):** there is no argument-redaction mechanism this slice, so `say` content (and any future `tell` / `password` / auth-bearing verb) is written to logs in plaintext. This is acceptable for slice 3 because the only verb with free-text args is `say` and the logger is local, but it **must not** ship to any environment with retained/forwarded logs without redaction. Tracked as an explicit acknowledged-debt item in [`../roadmap/backlog.md`](../roadmap/backlog.md) ("Command-arg log redaction") with the proposed fix (a per-command `[NoLogArgs]` / `RedactArgs` declaration honored by the dispatcher before it builds `ArgsSummary`). It is a prerequisite for any non-local logging sink. Partial-success vs command-success is a layer above and stays inside the command body — it does not affect `Outcome`.
 
 ---
 
@@ -218,7 +218,7 @@ public interface IOutputWriterFactory { IOutputWriter Create(ISession session); 
 Pure infrastructure. **No new gameplay state, no new authored data files, no new `TemplateRegistry` entries, no new admin commands beyond `help` / `commands` (tooling for the framework itself, not for content).**
 
 - The slice-2 admin commands keep their verbs, effects, and events; bodies refactor onto the framework. Their hand-written rejection-branch `"Usage: ..."` strings retire in favour of `help <verb>`.
-- The `@reload` long-form help wording required by slice 2 moves into `ReloadCommand.LongDescription`, emitted by `help @reload`.
+- The `reload` long-form help wording required by slice 2 moves into `ReloadCommand.LongDescription`, emitted by `help reload`.
 - `Admin:PrivilegedNames` and `Persistence:DataDirectory` keys unchanged. No new config keys this slice (`Output:DefaultColor` belongs to slice 4 — the slice that introduces color).
 
 Per ground rule 8: this slice introduces no new gameplay state; the tooling it adds (`help`, `commands`) inspects the framework itself.
@@ -241,7 +241,7 @@ Per ground rule 8: this slice introduces no new gameplay state; the tooling it a
 
 - **Replaces Flow 3 — Player command lifecycle** ([`../architecture/06-flows.md`](../architecture/06-flows.md)). The current Flow 3 is marked "slice 3 will replace this flow." Slice 3's PR rewrites Flow 3 to the framework-driven trace: input → verb lookup → **authorization gate (`IAuthorizationChecker` over `RequiredPrivileges`)** → **argument parse (`ICommandArgumentParser` over `ArgumentSchema`)** → `CommandContext` construction → `ExecuteAsync(context)` → output via the minimal `IOutputWriter` (stringify-and-forward) → exception trap → `CommandExecutedEvent` publish → priority-ordered handlers (`CommandLoggingHandler` at 80). The "What's hand-rolled today" subsection is deleted; replaced with the structural guarantees. The mermaid diagram is re-drawn. Slice 4 will modify the output leg of this same flow again.
 - **No new canonical flow introduced.** The command lifecycle is the replacement of an existing flow, not a new recurring chain. (Output rendering becomes its own flow in slice 4.)
-- **Flow 5 (`@reload`) — mermaid re-draw + prose, not prose-only.** `ReloadCommand`'s in-body `IsPrivileged` call moves to the dispatcher gate. Flow 5's current mermaid diagram has an explicit `RC->>Auth: IsPrivileged` participant interaction and an `alt not privileged` branch *inside the command*; those must be **removed and re-drawn** so the gate sits in the dispatcher before `ReloadCommand` is invoked — a prose-only edit would leave the diagram contradicting the code (spec-mode S2/D5). The reload mechanics (steps 3–10) are unchanged. The slice-3 PR re-draws the Flow 5 diagram and rewrites its step 2.
+- **Flow 5 (`reload`) — mermaid re-draw + prose, not prose-only.** `ReloadCommand`'s in-body `IsPrivileged` call moves to the dispatcher gate. Flow 5's current mermaid diagram has an explicit `RC->>Auth: IsPrivileged` participant interaction and an `alt not privileged` branch *inside the command*; those must be **removed and re-drawn** so the gate sits in the dispatcher before `ReloadCommand` is invoked — a prose-only edit would leave the diagram contradicting the code (spec-mode S2/D5). The reload mechanics (steps 3–10) are unchanged. The slice-3 PR re-draws the Flow 5 diagram and rewrites its step 2.
 
 ---
 
@@ -290,10 +290,10 @@ This section is the audit trail for why the spec is shaped as it is; it is not a
 
 ## Related
 
-- [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) — slice 2; established the four admin commands, the `@`-prefix convention, `IAdminAuthorizer`, and the convention-only privilege check this slice replaces with a structural gate. Defined the `@reload` help-text wording surfaced here via `help @reload`.
+- [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) — slice 2; established the four admin commands, `IAdminAuthorizer`, and the convention-only privilege check this slice replaces with a structural gate. Defined the `reload` help-text wording surfaced here via `help reload`.
 - [`output-framework.md`](output-framework.md) — slice 4; consumes the minimal output seam shaped here and replaces the stringify-and-forward writer with the formatter-backed implementation. The owed stub list in this doc is its input contract.
 - [`persistence-substrate.md`](persistence-substrate.md) — slice 1; precedent for a pure-infrastructure slice with no gameplay-visible behaviour change.
-- [`admin-privilege-elevation.md`](admin-privilege-elevation.md) — deferred; future `@grant`/`@revoke` will register new `IAuthorizationRequirement` types against this slice's checker rather than be retrofitted.
+- [`admin-privilege-elevation.md`](admin-privilege-elevation.md) — deferred; future `grant`/`revoke` will register new `IAuthorizationRequirement` types against this slice's checker rather than be retrofitted.
 - `account-character-creation.md` — slice 5 (renumbered; was slice 3). Its login-prompt verbs and character-management commands are authored against the framework landed here, not the legacy `(ISession, string)` shape.
 
 **Roadmap impact:** this is **Phase 3 slice 3**. Account / character creation becomes slice 5; downstream slices shift +2. The plan, use-case index, and `06-flows.md` are updated in this slice's PR (the slice-numbering question was resolved: "slice 3 and shift"). For the slice queue, see [`../roadmap/plan.md`](../roadmap/plan.md).

--- a/docs/use-cases/command-framework.md
+++ b/docs/use-cases/command-framework.md
@@ -1,6 +1,6 @@
 # Use Case: Command Framework
 
-**Status:** planned
+**Status:** implemented
 **Actors:** Player, Administrator, System
 **Module:** `Core/Commands/`, `Core/Modules/Help/` (new); refactor touches `Core/Modules/Admin/`, `Core/Modules/Movement/`, `Core/Modules/Chat/`, `Core/Modules/World/`
 

--- a/docs/use-cases/world-content-loading-and-admin-substrate.md
+++ b/docs/use-cases/world-content-loading-and-admin-substrate.md
@@ -8,7 +8,7 @@
 
 ## Description
 
-Replaces the hardcoded three-room MVP world with a YAML-driven content pipeline and lands the in-game admin command framework that designers will use to author and iterate on that content. On startup the world is built from authored area/room files via `TemplateRegistry` (with `PersistenceSystem` hydration winning over blueprint defaults per the blueprint-seeds-world model). At runtime, privileged sessions can spawn templated entities (`@spawn`), move themselves between rooms (`@teleport`), author connections between rooms (`@dig`), and reload the content directory without restart (`@reload`). This slice resolves Ticket B (admin tooling — telnet first, web/desktop UI deferred) and is the substrate every future content-bearing slice (items, mobs, shops) will build on.
+Replaces the hardcoded three-room MVP world with a YAML-driven content pipeline and lands the in-game admin command framework that designers will use to author and iterate on that content. On startup the world is built from authored area/room files via `TemplateRegistry` (with `PersistenceSystem` hydration winning over blueprint defaults per the blueprint-seeds-world model). At runtime, privileged sessions can spawn templated entities (`spawn`), move themselves between rooms (`teleport`), author connections between rooms (`dig`), and reload the content directory without restart (`reload`). This slice resolves Ticket B (admin tooling — telnet first, web/desktop UI deferred) and is the substrate every future content-bearing slice (items, mobs, shops) will build on.
 
 This is an **infrastructure-plus-tooling slice**, not a gameplay slice. It introduces no new player-facing verbs and no combat/inventory/character-progression behaviour. Its value is making every subsequent slice authorable.
 
@@ -29,8 +29,8 @@ This is an **infrastructure-plus-tooling slice**, not a gameplay slice. It intro
 - On host startup, every authored area/room defined under the configured content directory is spawned via `TemplateRegistry` into the live `EntityService`, and `WorldConfiguration.StartingRoomEntityId` resolves to a designer-named blueprint id rather than a hardcoded entity id.
 - An entity persisted in `data/entities/` whose blueprint id matches an authored template wins on conflict — its `[Persistent]` components hydrate first, then the blueprint reseed step skips that entity. Blueprint-only entities (never persisted) are spawned fresh each boot.
 - Authored templates registered with `TemplateRegistry` are addressable by stable string ids (e.g. `room.crossroads`, `area.starter_road`) and can be respawned at any time after startup.
-- `@spawn <templateId> [hereOrTarget]`, `@teleport <playerOrRoomBlueprintId>`, `@dig <direction> <targetRoomBlueprintId>`, and `@reload` are usable from a privileged session and produce visible output to the invoker.
-- `@reload` re-reads the content directory and re-registers templates without restart; existing live entities are not destroyed unless the admin asks for it (out of scope this slice — see Design Notes).
+- `spawn <templateId> [hereOrTarget]`, `teleport <playerOrRoomBlueprintId>`, `dig <direction> <targetRoomBlueprintId>`, and `reload` are usable from a privileged session and produce visible output to the invoker.
+- `reload` re-reads the content directory and re-registers templates without restart; existing live entities are not destroyed unless the admin asks for it (out of scope this slice — see Design Notes).
 - Every admin command is rejected with a clear error if invoked from a non-privileged session.
 - All admin actions emit a past-tense event so handlers (notification, audit logging, persistence dirty-tracking) can react.
 - No regressions to existing player-facing commands (`look`, movement, `say`).
@@ -49,13 +49,13 @@ This is an **infrastructure-plus-tooling slice**, not a gameplay slice. It intro
 
 5. **Runtime — privileged session check.** Each admin `ICommand` calls `IAdminAuthorizer.IsPrivileged(session)` as the first line of its `Execute` body. Non-privileged sessions receive a single rejection line and the command body does not run. Privileged sessions proceed. `CommandDispatcher` itself stays policy-free — it does not inspect command names or route through the authorizer. (See Design Notes for the rationale.)
 
-6. **Runtime — `@spawn <blueprintId>`.** `SpawnCommand` resolves the blueprint via `templateRegistry`, calls `templateRegistry.Spawn(blueprintId)` to create a live entity, then if the spawned archetype warrants placement (item, mob), places it in the invoker's current room via `TransformComponent` / `RoomComponent` containment. Publishes `EntitySpawnedByAdminEvent`. Output: a confirmation line to the invoker.
+6. **Runtime — `spawn <blueprintId>`.** `SpawnCommand` resolves the blueprint via `templateRegistry`, calls `templateRegistry.Spawn(blueprintId)` to create a live entity, then if the spawned archetype warrants placement (item, mob), places it in the invoker's current room via `TransformComponent` / `RoomComponent` containment. Publishes `EntitySpawnedByAdminEvent`. Output: a confirmation line to the invoker.
 
-7. **Runtime — `@teleport <target>`.** `TeleportCommand` parses the target as either a room blueprint id (`room.east_end`) or a player display name. If a room, it resolves to that room's entity id and updates the invoker's `LocationComponent.RoomEntityId`. If a player, it resolves to the player's current room and does the same. Publishes `PlayerTeleportedByAdminEvent` (consumed by `PlayerMovedHandler` for the same downstream behaviour as a normal move — broadcast, look-on-arrival).
+7. **Runtime — `teleport <target>`.** `TeleportCommand` parses the target as either a room blueprint id (`room.east_end`) or a player display name. If a room, it resolves to that room's entity id and updates the invoker's `LocationComponent.RoomEntityId`. If a player, it resolves to the player's current room and does the same. Publishes `PlayerTeleportedByAdminEvent` (consumed by `PlayerMovedHandler` for the same downstream behaviour as a normal move — broadcast, look-on-arrival).
 
-8. **Runtime — `@dig <direction> <targetBlueprintId>`.** `DigCommand` mutates the invoker's current `RoomComponent.Exits` to add an exit in the named direction pointing at the target room's entity id, and (by default) wires the reverse exit on the target room. The corresponding `RoomTemplate` for the invoker's room is also updated *in memory* in the registry so a `@reload` round-trip won't lose the change. **The source content YAML on disk is not rewritten in this slice** — durability of the change comes from `PersistenceSystem` saving the live room's `[Persistent]` components on its next timed flush. Publishes `RoomExitAuthoredByAdminEvent`.
+8. **Runtime — `dig <direction> <targetBlueprintId>`.** `DigCommand` mutates the invoker's current `RoomComponent.Exits` to add an exit in the named direction pointing at the target room's entity id, and (by default) wires the reverse exit on the target room. The corresponding `RoomTemplate` for the invoker's room is also updated *in memory* in the registry so a `reload` round-trip won't lose the change. **The source content YAML on disk is not rewritten in this slice** — durability of the change comes from `PersistenceSystem` saving the live room's `[Persistent]` components on its next timed flush. Publishes `RoomExitAuthoredByAdminEvent`.
 
-9. **Runtime — `@reload`.** `ReloadCommand` calls `WorldContentLoader.ReloadAsync()` which re-scans the content directory, replaces the registry's template set, and (per the conflict model) re-attaches blueprint-side defaults to any entity that hasn't drifted from its blueprint via persistence. **Existing live entities are not mutated.** Only missing entities (templates that have no live counterpart) are seeded. Player sessions are not disrupted. Publishes `ContentReloadedEvent`.
+9. **Runtime — `reload`.** `ReloadCommand` calls `WorldContentLoader.ReloadAsync()` which re-scans the content directory, replaces the registry's template set, and (per the conflict model) re-attaches blueprint-side defaults to any entity that hasn't drifted from its blueprint via persistence. **Existing live entities are not mutated.** Only missing entities (templates that have no live counterpart) are seeded. Player sessions are not disrupted. Publishes `ContentReloadedEvent`.
 
 10. **Audit and notification.** `AdminAuditHandler` subscribes to all admin events at low priority and writes a single structured log line per action via `ILogger<AdminAuditHandler>` (no separate audit file in this slice). `NotificationHandler` (existing) subscribes to `PlayerTeleportedByAdminEvent` so witnesses see the teleport's arrival/departure flavour text.
 
@@ -65,10 +65,10 @@ This is an **infrastructure-plus-tooling slice**, not a gameplay slice. It intro
 
 | Event | Publisher | Scope | Purpose |
 |---|---|---|---|
-| `EntitySpawnedByAdminEvent(uint AdminEntityId, uint SpawnedEntityId, string BlueprintId, uint RoomEntityId)` | `SpawnCommand` | Per `@spawn` invocation | Notifies witnesses; triggers persistence dirty-mark on the new entity if it carries `[Persistent]`; audit log. |
-| `PlayerTeleportedByAdminEvent(uint AdminEntityId, uint TargetEntityId, uint FromRoomEntityId, uint ToRoomEntityId)` | `TeleportCommand` | Per `@teleport` invocation | Drives departure/arrival broadcast and `look`-on-arrival via the existing movement handler; audit log. |
-| `RoomExitAuthoredByAdminEvent(uint AdminEntityId, uint RoomEntityId, Direction Direction, uint TargetRoomEntityId, bool BidirectionalLinkCreated)` | `DigCommand` | Per `@dig` invocation | Persistence dirty-marks the affected room(s); audit log; future hot-reload-aware tooling can pick this up. |
-| `ContentReloadedEvent(int TemplatesLoaded, int TemplatesUnchanged, int TemplatesRemoved)` | `ReloadCommand` (via `WorldContentLoader.ReloadAsync`) | Per `@reload` invocation | Logging; future indexes that cache template ids invalidate. |
+| `EntitySpawnedByAdminEvent(uint AdminEntityId, uint SpawnedEntityId, string BlueprintId, uint RoomEntityId)` | `SpawnCommand` | Per `spawn` invocation | Notifies witnesses; triggers persistence dirty-mark on the new entity if it carries `[Persistent]`; audit log. |
+| `PlayerTeleportedByAdminEvent(uint AdminEntityId, uint TargetEntityId, uint FromRoomEntityId, uint ToRoomEntityId)` | `TeleportCommand` | Per `teleport` invocation | Drives departure/arrival broadcast and `look`-on-arrival via the existing movement handler; audit log. |
+| `RoomExitAuthoredByAdminEvent(uint AdminEntityId, uint RoomEntityId, Direction Direction, uint TargetRoomEntityId, bool BidirectionalLinkCreated)` | `DigCommand` | Per `dig` invocation | Persistence dirty-marks the affected room(s); audit log; future hot-reload-aware tooling can pick this up. |
+| `ContentReloadedEvent(int TemplatesLoaded, int TemplatesUnchanged, int TemplatesRemoved)` | `ReloadCommand` (via `WorldContentLoader.ReloadAsync`) | Per `reload` invocation | Logging; future indexes that cache template ids invalidate. |
 | `WorldLoadedEvent` (existing — published by `PersistenceBootstrap`) | unchanged | Once at startup | Reused: `WorldContentLoader`'s startup spawn pass runs **after** `WorldLoadedEvent` so persistence-vs-blueprint conflict resolution sees the fully hydrated world. |
 
 ### Hydration vs spawn ordering
@@ -118,7 +118,7 @@ IAdminAuthorizer
 **Layered authorization model — settings is the floor, component is the additive layer.**
 
 1. **Bootstrap layer (this slice):** `AdminAuthorizer` reads `Admin:PrivilegedNames` from `IConfiguration` — a string array of player display names that are *always* admin. This allows first-run bootstrap on a fresh save with no persisted state. Anyone in this list is admin even if they have no `AdminPrivilegeComponent`.
-2. **Persisted layer (future slice — see [`admin-privilege-elevation.md`](admin-privilege-elevation.md)):** an `AdminPrivilegeComponent` (`[Persistent]`) attached to a player entity also grants admin rights. Initial admins (from settings) can elevate other players via `@grant` / `@promote`, and the elevation persists across restarts. **This component does not exist in this slice** — `AdminAuthorizer.IsPrivileged` only consults the settings allowlist for now, but the implementation is structured so the component check can be added later without changing the interface.
+2. **Persisted layer (future slice — see [`admin-privilege-elevation.md`](admin-privilege-elevation.md)):** an `AdminPrivilegeComponent` (`[Persistent]`) attached to a player entity also grants admin rights. Initial admins (from settings) can elevate other players via `grant` / `promote`, and the elevation persists across restarts. **This component does not exist in this slice** — `AdminAuthorizer.IsPrivileged` only consults the settings allowlist for now, but the implementation is structured so the component check can be added later without changing the interface.
 
 The settings list is the floor: removing the component never demotes someone whose name is in `Admin:PrivilegedNames`. This guarantees an operator can always recover admin access by editing config.
 
@@ -134,7 +134,7 @@ IWorldContentLoader
 
 Implementation lives at `Core/Modules/World/Systems/WorldContentLoader.cs`. The `IHostedService` wrapper that runs `LoadAndSpawnAsync` at startup lives at `Server/WorldContentBootstrap.cs` (parallel to `PersistenceBootstrap`).
 
-If the content directory is missing or empty at startup, `WorldContentLoader` logs a warning via `ILogger` and seeds a single hardcoded "void" room with no exits so the host stays up and an admin can `@dig` their way out. The host does *not* fail-fast on empty content — that would defeat first-run bootstrap.
+If the content directory is missing or empty at startup, `WorldContentLoader` logs a warning via `ILogger` and seeds a single hardcoded "void" room with no exits so the host stays up and an admin can `dig` their way out. The host does *not* fail-fast on empty content — that would defeat first-run bootstrap.
 
 ### AdminAuditHandler (new — handler, cross-cutting)
 
@@ -156,7 +156,7 @@ Lives at `Core/Modules/Admin/Handlers/AdminAuditHandler.cs`.
 
 ### CommandDispatcher (existing — unchanged)
 
-`CommandDispatcher` is **not** modified by this slice. The privilege check is enforced at the command level: each admin `ICommand.Execute` calls `IAdminAuthorizer.IsPrivileged(session)` as its first line and short-circuits with a rejection line for non-privileged sessions. This keeps the dispatcher policy-free and matches the existing thin-dispatcher style. The alternative — having the dispatcher inspect the `@` prefix and route through the authorizer — was considered and rejected on the grounds that it couples a generic dispatcher to a specific admin policy.
+`CommandDispatcher` is **not** modified by this slice. The privilege check is enforced at the command level: each admin `ICommand.Execute` calls `IAdminAuthorizer.IsPrivileged(session)` as its first line and short-circuits with a rejection line for non-privileged sessions. This keeps the dispatcher policy-free and matches the existing thin-dispatcher style.
 
 ---
 
@@ -177,22 +177,22 @@ A `data/content/README.md` is added describing the schema and where to put new f
 
 | Verb | Purpose | Aliases |
 |---|---|---|
-| `@spawn <blueprintId>` | Spawn an authored template into the invoker's current room | none |
-| `@teleport <roomBlueprintId\|playerName>` | Move the invoker to a target room or player | `@tp` |
-| `@dig <direction> <targetRoomBlueprintId>` | Add an exit from the invoker's current room | none |
-| `@reload` | Re-scan the content directory and re-register templates (does NOT mutate live entities) | none |
+| `spawn <blueprintId>` | Spawn an authored template into the invoker's current room | none |
+| `teleport <roomBlueprintId\|playerName>` | Move the invoker to a target room or player | `tp` |
+| `dig <direction> <targetRoomBlueprintId>` | Add an exit from the invoker's current room | none |
+| `reload` | Re-scan the content directory and re-register templates (does NOT mutate live entities) | none |
 
 Every admin command returns at minimum a one-line confirmation or error to the invoker. Output verbosity past that is deferred.
 
-**`@reload` in-game help text — required wording.** The `help`/usage line for `@reload` must explicitly state the limitation so admins do not expect description hot-reload on existing rooms. Required text (or equivalent):
+**`reload` in-game help text — required wording.** The `help`/usage line for `reload` must explicitly state the limitation so admins do not expect description hot-reload on existing rooms. Required text (or equivalent):
 
-> `@reload` — re-scans the content directory and refreshes the template registry. Newly authored templates with no live counterpart are seeded. **Existing live entities are not modified** — descriptions, exits, and components on rooms that already exist will not change. To pick up edits to a live room, restart, or use `@dig` for exit changes.
+> `reload` — re-scans the content directory and refreshes the template registry. Newly authored templates with no live counterpart are seeded. **Existing live entities are not modified** — descriptions, exits, and components on rooms that already exist will not change. To pick up edits to a live room, restart, or use `dig` for exit changes.
 
 ### TemplateRegistry entries — first-run shape
 
 The hardcoded MVP rooms (`room.west_end`, `room.crossroads`, `room.east_end`, `area.starter_road`) are no longer in code. The old `WorldBootstrap.Initialize` is removed entirely; world assembly is now driven by `WorldContentLoader` against the configured content directory.
 
-**No seed content ships in this PR** (per the gitignore decision below — `data/` is local-only, and a committed `seed-content/` directory is deferred to a future slice). On a fresh clone the loader finds an empty content directory, logs a warning, and falls back to a single hardcoded `room.void` so the host comes up successfully. From there a privileged session can `@dig` outward — or a developer can hand-author YAML files under `data/content/` to seed authored rooms. The MVP three-room flow can be reproduced by authoring those four YAML files locally; this slice deliberately does not commit them.
+**No seed content ships in this PR** (per the gitignore decision below — `data/` is local-only, and a committed `seed-content/` directory is deferred to a future slice). On a fresh clone the loader finds an empty content directory, logs a warning, and falls back to a single hardcoded `room.void` so the host comes up successfully. From there a privileged session can `dig` outward — or a developer can hand-author YAML files under `data/content/` to seed authored rooms. The MVP three-room flow can be reproduced by authoring those four YAML files locally; this slice deliberately does not commit them.
 
 ---
 
@@ -239,13 +239,13 @@ See [`../architecture/05-configuration.md`](../architecture/05-configuration.md)
 ## Design Notes
 
 - **Blueprint-seeds-world conflict model.** Hydration runs first; persisted entities win. The blueprint pass spawns only what wasn't restored. This matches the model deferred from slice 1 (`docs/use-cases/persistence-substrate.md` §"Conflict model").
-- **`BlueprintComponent`** (new, cross-cutting, `[Persistent]`). Stores `BlueprintId : string` on every entity that originated from a template. Lets `WorldContentLoader` skip-on-conflict during reseed and lets `@spawn` distinguish authored vs ad-hoc entities. Adding `[Persistent]` here means every templated entity becomes savable; consumers that don't want persistence on a particular template can omit the component (template author's choice).
-- **`@dig` write-back deferred.** This slice mutates the in-memory template so a same-session `@reload` won't undo the change, but it does **not** rewrite the source `.yaml` file on disk. Durability of admin-authored room shape comes from `PersistenceSystem` saving the live room's `[Persistent]` components on its next timed flush. A follow-up slice (`@save-room` or similar source-file round-trip) is tracked in the backlog.
-- **`@reload` does not destroy or mutate live entities.** The reload pass only refreshes the template registry and reseeds entities that were never spawned. Mutating already-live entities to match new blueprint values is a richer story (does it touch persistence? does it kick players?) and is deferred. Document this limitation in command help.
-- **Empty content directory fallback.** On startup, if `World:ContentDirectory` is missing or empty, `WorldContentLoader` warns via `ILogger`, seeds a single hardcoded "void" room (no exits) with blueprint id `room.void`, and continues. The host does not fail-fast — first-run bootstrap on a fresh clone must succeed without manual intervention.
+- **`BlueprintComponent`** (new, cross-cutting, `[Persistent]`). Stores `BlueprintId : string` on every entity that originated from a template. Lets `WorldContentLoader` skip-on-conflict during reseed and lets `spawn` distinguish authored vs ad-hoc entities. Adding `[Persistent]` here means every templated entity becomes savable; consumers that don't want persistence on a particular template can omit the component (template author's choice).
+- **`dig` write-back deferred.** This slice mutates the in-memory template so a same-session `reload` won't undo the change, but it does **not** rewrite the source `.yaml` file on disk. Durability of admin-authored room shape comes from `PersistenceSystem` saving the live room's `[Persistent]` components on its next timed flush. A follow-up slice (`save-room` or similar source-file round-trip) is tracked in the backlog.
+- **`reload` does not destroy or mutate live entities.** The reload pass only refreshes the template registry and reseeds entities that were never spawned. Mutating already-live entities to match new blueprint values is a richer story (does it touch persistence? does it kick players?) and is deferred. Document this limitation in command help.
+- **Empty content directory fallback.** On startup, if `World:ContentDirectory` is missing or empty, `WorldContentLoader` warns via `ILogger`, seeds a single hardcoded "void" room (no exits) with blueprint id `room.void`, and continues. The host does not fail-fast — first-run bootstrap on a fresh clone must succeed without manual intervention. From there, a privileged session can `dig` outward.
 - **Admin command privilege gate.** `IAdminAuthorizer` is the policy seam. The bootstrap implementation reads `Admin:PrivilegedNames` from `IConfiguration`. The future persisted-component layer (`AdminPrivilegeComponent`) is captured in [`admin-privilege-elevation.md`](admin-privilege-elevation.md) as a deferred slice. The authorizer's interface is stable across that addition.
 - **Audit logging.** `AdminAuditHandler` writes through `ILogger<AdminAuditHandler>` with a stable structured-event name (`AdminCommandExecuted`). No separate audit file in this slice; can be promoted later if ops needs.
-- **Silent spawn vs notification.** Startup spawn is silent (no events) to match the persistence hydration contract. Runtime `@spawn` does publish events because the world is live and other systems need to react.
+- **Silent spawn vs notification.** Startup spawn is silent (no events) to match the persistence hydration contract. Runtime `spawn` does publish events because the world is live and other systems need to react.
 - **No item or mob templates yet.** This slice's `IEntityTemplate` implementations are `RoomTemplate` and `AreaTemplate` only. Mob and item templates land with their respective slices (4, 5, 6) and reuse the same `ITemplateRegistry`.
 - **Module entry-points.** Two new modules: `Core/Modules/World/WorldModule.cs` exposes `AddWorldModule(IServiceCollection, IConfiguration)` (registers `IContentSerializer`, `IWorldContentLoader`, `RoomTemplate`/`AreaTemplate` deserializers, and the existing `LookCommand`); `Core/Modules/Admin/AdminModule.cs` exposes `AddAdminModule(IServiceCollection, IConfiguration)` (registers `IAdminAuthorizer` reading `Admin:PrivilegedNames`, the four admin commands, and `AdminAuditHandler`). `WorldContentBootstrap` is registered as an `IHostedService` from `Server/Program.cs` *between* `PersistenceBootstrap` and `TelnetServer`.
 - **`TemplateRegistry` is cross-cutting, not module-scoped.** It lives at `Core/Systems/TemplateRegistry.cs` because every future content module (mobs, items, shops) will register into it. The `World` module owns the loader and the room/area templates; the registry itself is shared infrastructure.
@@ -261,8 +261,8 @@ For traceability — these were open questions at the start of slice 2 planning,
 |---|---|---|
 | 1 | Content data file format — JSON vs YAML? | **YAML**, via `YamlDotNet`. Persistence stays JSON; both serializers coexist. |
 | 2 | Admin privilege gate mechanism? | **Layered.** Bootstrap layer (this slice): `Admin:PrivilegedNames` allowlist in `appsettings.json`. Persisted layer (future): `AdminPrivilegeComponent` — see [`admin-privilege-elevation.md`](admin-privilege-elevation.md). Settings is the floor. |
-| 3 | `@reload` semantics — destructive or additive? | **Additive only.** Refresh registry, seed missing entities. Live entities are not mutated. |
-| 4 | `@dig` write-back to source files? | **No file round-trip in this slice.** In-memory template is updated; durability comes from `PersistenceSystem` on the next flush. |
+| 3 | `reload` semantics — destructive or additive? | **Additive only.** Refresh registry, seed missing entities. Live entities are not mutated. |
+| 4 | `dig` write-back to source files? | **No file round-trip in this slice.** In-memory template is updated; durability comes from `PersistenceSystem` on the next flush. |
 | 5 | Empty / missing content dir at startup? | **Spawn a single void room and warn via `ILogger`.** Host stays up. Audit sink is `ILogger<AdminAuditHandler>` only — no dedicated audit file. |
 | 6 | Should `data/` be committed? Are paths configurable? | **No on commit; yes on configurable.** `data/` is `.gitignore`d. Both `World:ContentDirectory` and `Persistence:DataDirectory` are configurable; the persistence key already exists from slice 1. |
 
@@ -273,7 +273,7 @@ For traceability — these were open questions at the start of slice 2 planning,
 - [`persistence-substrate.md`](persistence-substrate.md) — slice 1; provides hydration-before-spawn ordering, the `WorldLoadedEvent` startup signal, the `[Persistent]` mechanism this slice's `BlueprintComponent` plugs into, and the existing `Persistence:DataDirectory` config key.
 - [`admin-privilege-elevation.md`](admin-privilege-elevation.md) — deferred / placeholder; future slice that adds the persisted `AdminPrivilegeComponent` layer on top of the bootstrap allowlist.
 - `account-character-creation.md` — slice 3 (next); produces the first user-authored persisted entities that will conflict-resolve against blueprints.
-- `inventory-get-drop.md` — slice 4; reuses `ITemplateRegistry` for item templates and `@spawn` to drop test items into rooms during development.
+- `inventory-get-drop.md` — slice 4; reuses `ITemplateRegistry` for item templates and `spawn` to drop test items into rooms during development.
 - `mob-wandering.md` — slice 6; reuses `ITemplateRegistry` for mob templates and consumes `WorldLoadedEvent` to start wander timers after spawn.
 
 For the slice queue and ordering rationale, see [`../roadmap/plan.md`](../roadmap/plan.md).


### PR DESCRIPTION
## Summary

- **Eliminates `@`-prefix naming convention** from admin command verbs (`spawn`, `teleport`/`tp`, `dig`, `reload`) — privilege is now enforced structurally, not by naming convention
- **Implements Phase 3 slice 3** — the full command framework as specced in `docs/use-cases/command-framework.md`

## What changed

### New framework (`Core/Commands/`, `Core/Output/`)

| Type | Purpose |
|---|---|
| `ICommand` (rewritten) | New shape: `Category`, `ShortDescription`, `LongDescription`, `Usage`, `RequiredPrivileges`, `ArgumentSchema`, `ExecuteAsync(CommandContext)` |
| `CommandContext` | Typed record replacing `(ISession, string)` — carries `ParsedArguments`, `IOutputWriter`, `IServiceProvider` |
| `ICommandArgumentParser` / `CommandArgumentParser` | Single-pass tokenizer: whitespace + double-quoted groups, enum-prefix matching (`n` → `North`), coercion for `string`/`int`/`uint`/enum |
| `IAuthorizationRequirement` / `AdminRequirement` / `IAuthorizationChecker` / `AuthorizationChecker` | Structural privilege gate — dispatcher calls this before invoking any command; policy decoupled from dispatch |
| `IOutputMessage` / `PlainMessage` / `HelpIndexMessage` / `HelpEntryMessage` | Minimal typed output seam (slice 4 adds formatter/color) |
| `IOutputWriter` / `OutputWriter` / `IOutputWriterFactory` | Stringify-and-forward impl; slice 4 replaces |
| `CommandExecutedEvent` + `CommandOutcome` | Published on every dispatch: Success, ParseFailed, Unauthorized, Threw |
| `CommandLoggingHandler` | Priority-80 handler — one structured-log line per dispatch |

### Refactored commands (12 total)

`look`, `say`, `north`/`n`, `south`/`s`, `east`/`e`, `west`/`w`, `up`/`u`, `down`/`d`, `spawn`, `teleport`/`tp`, `dig`, `reload` — all on the new `ICommand` shape:
- Declarative `ArgumentSchema` (no more `Trim()`/`Split()` in bodies)
- `RequiredPrivileges` declaration (no more per-command `IsPrivileged` calls)
- Output via `context.Output.WriteAsync(IOutputMessage)` (no more `session.SendLineAsync` in command files)

### New commands

- `help` / `?` — lists visible commands (filtered by `IAuthorizationChecker`) or shows `LongDescription` + `Usage` for a verb
- `commands` — terser category-grouped index; same visibility filtering

### Docs

- `docs/architecture/06-commands.md` — new: command framework design guide
- `docs/reference/commands.md` — new: living command catalog (14 commands)
- `docs/architecture/06-flows.md` — Flow 3 fully rewritten to framework-driven trace; Flow 5 mermaid redrawn (auth gate moves from inside `ReloadCommand` to the dispatcher)
- `docs/reference/handlers.md` — `CommandLoggingHandler` added; legacy `CommandHandler`/`CommandReceivedEvent` row retired
- `docs/architecture/00-overview.md` — links to two new docs
- `.claude/skills/add-command/SKILL.md` — rewritten for new `ICommand` shape
- `docs/use-cases/command-framework.md` — Status → `implemented`

## Reviewer notes

- **`CommandDispatcher` is an Initiator** (not a domain system) and is explicitly permitted to publish `CommandExecutedEvent` per INV-5/INV-8–11. This was the root cause of V1/V2 in the spec-mode review; `01-layers.md` was updated in the planning round to add the Initiators tier.
- **`LookCommand` still calls `IBroadcastSystem.SendRoomDescriptionAsync`** which internally calls `session.SendLineAsync`. This is the one surviving path where output bypasses `IOutputWriter` — acknowledged in the spec as broadcast-expansion being slice 4's concern.
- **Slice-2 admin events fire unchanged** — same payloads, same publishers, `AdminAuditHandler` subscriptions untouched.
- **Architecture reviewer (code mode) passed** after addressing six blocking doc items (Flow 3 rewrite, Flow 5 mermaid redraw, `handlers.md` update, `commands.md`, `06-commands.md`, skill rewrite). One acknowledged non-blocking note: unknown-verb dispatches use `CommandOutcome.ParseFailed` — a future `UnknownVerb` variant would allow telemetry to distinguish them.

## Test plan

- [ ] `dotnet build Hedron.sln` — green (0 errors, 0 warnings)
- [ ] Telnet connect → login → `look` shows room description
- [ ] `say hello` broadcasts to room; `say` (no args) returns parse error + "Type 'help say' for usage."
- [ ] `north` / `n` moves if exit exists; blocks with error message if not
- [ ] `help` lists all commands grouped by Player / Admin
- [ ] `help reload` shows `ReloadCommand.LongDescription` with the required "existing live entities are not modified" wording
- [ ] `commands` prints the compact index
- [ ] `spawn room.crossroads` from non-admin → "You are not authorized to use that command."
- [ ] `spawn room.crossroads` from admin → confirmation + `EntitySpawnedByAdminEvent` fires
- [ ] `reload` from admin → reload confirmation; `AdminAuditHandler` logs `AdminCommandExecuted`
- [ ] `dig north room.void` from admin → exit linked; `RoomExitAuthoredByAdminEvent` fires
- [ ] `teleport room.void` / `tp room.void` from admin → teleports; `PlayerTeleportedByAdminEvent` fires + arrival broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)