### PR TITLE
Phase 3 slice 5: command prefix matching

### DIFF
--- a/.claude/agents/use-case-planner.md
+++ b/.claude/agents/use-case-planner.md
@@ -72,6 +72,14 @@ Doc: docs/use-cases/<slug>.md
 
 Keep it under ~40 lines of user-facing output. The detail lives in the use-case file you just wrote.
 
+## Mandatory next step — spec-mode architecture review
+
+After returning the plan, explicitly tell the user:
+
+> **Before any implementation begins**, run the `architecture-reviewer` agent in **spec mode** against the new use-case doc. Blocking findings must be resolved in the doc before `implement-use-case` is invoked. This is Phase 3 ground rule 4 — the spec gate exists because spec-level violations are invisible to a code-only reviewer until implementation is already built on the flaw.
+
+Do not leave this implicit. The handoff from planning to implementation is the highest-risk moment for an uncaught invariant violation.
+
 ## What you are NOT
 
 - Not an implementer — you don't write code.

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -20,6 +20,7 @@ public sealed class DrinkCommand : ICommand
     public string Name => "drink";
     public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
     public CommandCategory Category => CommandCategory.Player;
+    public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial; // Partial for player; Full for admin
     public string ShortDescription => "Drink a potion from your inventory.";
     public string LongDescription => "Consumes a potion by name from your inventory, applying its effect immediately.";
     public string Usage => "drink <itemName>";
@@ -70,24 +71,31 @@ Target size: **≤ 40 lines of body**. If it grows, the logic belongs in a domai
    - `Token` — single whitespace-delimited token (or double-quoted group). Works for strings, ints, uints, and enums.
    - `RestOfLine` — everything after previous tokens. Use for `say`, `tell`, multi-word freeform input.
    - `Quantified` — leading count + token. Deferred; not yet used.
-4. **Privilege:**
+4. **Matching mode:**
+   - Player command: `MatchingMode => CommandMatchingMode.Partial` — prefix resolution enabled (e.g. `dr` → `drink`).
+   - Admin command: `MatchingMode => CommandMatchingMode.Full` — exact match required; prevents accidental prefix dispatch of destructive verbs.
+   - This is a required interface member — omitting it is a compile error.
+5. **Privilege:**
    - Public command: `RequiredPrivileges = Array.Empty<IAuthorizationRequirement>()`
    - Admin command: `RequiredPrivileges = new IAuthorizationRequirement[] { new AdminRequirement() }`
    - **Never** call `IAdminAuthorizer.IsPrivileged` inside the command body — the dispatcher handles it.
-5. **Output:** always write via `context.Output.WriteAsync(IOutputMessage)`. Use `PlainMessage` for text. Use `OutputSeverity.Error` for failures, `Confirmation` for success, `System` for neutral messages.
-6. **Register** in the feature module: `services.AddSingleton<ICommand, DrinkCommand>();`
-7. **Subscribe** the handler that consumes the event the command publishes (if any) in `Server/Program.cs`.
-8. **Docs:** add a row to `docs/reference/commands.md`.
+6. **Output:** always write via `context.Output.WriteAsync(IOutputMessage)`. Use `PlainMessage` for text. Use `OutputSeverity.Error` for failures, `Confirmation` for success, `System` for neutral messages.
+7. **Register** in the feature module: `services.AddSingleton<ICommand, DrinkCommand>();`
+8. **Subscribe** the handler that consumes the event the command publishes (if any) in `Server/Program.cs`.
+9. **Docs:** add a row to `docs/reference/commands.md`.
 
 ## Admin commands
 
 ```csharp
 public string Name => "grant";
+public CommandMatchingMode MatchingMode => CommandMatchingMode.Full; // required: exact match for admin commands
 public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
     new IAuthorizationRequirement[] { new AdminRequirement() };
 ```
 
 No `IsPrivileged` call in the body. Privilege is enforced by the dispatcher before `ExecuteAsync` is called. The compiler forces you to declare `RequiredPrivileges` (it is a required interface member); empty list = public.
+
+Admin commands declare `MatchingMode.Full` so they are never accidentally dispatched by a partial prefix — typing `d` reaches `down` (a player command alias), not `dig`.
 
 ## What NOT to do
 

--- a/.claude/skills/implement-use-case/SKILL.md
+++ b/.claude/skills/implement-use-case/SKILL.md
@@ -24,6 +24,7 @@ Your job is to turn those sections into real code without slipping gameplay logi
 6. **Handlers.** One handler per step that orchestrates; subscribe with priorities. See **add-handler**.
 7. **Command (if player-initiated).** Thin; delegates to the first handler. See **add-command**.
 8. **Update the use-case doc** — set Status to `implemented` if fully done, keep `partial` if only some paths are live.
+9. **Code-review gate (mandatory).** Run the `architecture-reviewer` agent in **code mode** against the diff before this branch merges. This is Phase 3 ground rule 6. Do not skip it even for "infrastructure-only" slices — the code gate catches drift between the as-built code and the spec that the spec gate cannot see.
 
 ## Guard the layer discipline
 

--- a/Core/Commands/CommandArgumentParser.cs
+++ b/Core/Commands/CommandArgumentParser.cs
@@ -6,11 +6,15 @@ namespace Hedron.Core.Commands
 {
     /// <summary>
     /// Default argument parser: single-pass, whitespace + double-quoted tokenization,
-    /// enum-prefix matching. <see cref="IArgumentResolver"/> seam is null this slice.
+    /// enum-prefix matching. For <see cref="CommandArgumentKind.Token"/> string arguments
+    /// that declare a non-null <see cref="IArgumentResolver"/>, the resolver is invoked and
+    /// prefix matching is applied against the candidate list. No concrete resolver ships until
+    /// slice 6; the call-site is present but exercises no live resolver in this slice.
     /// </summary>
     public sealed class CommandArgumentParser : ICommandArgumentParser
     {
-        public ParseResult Parse(CommandArgumentSchema schema, string rawTail)
+        public ParseResult Parse(CommandArgumentSchema schema, string rawTail,
+            CommandArgumentResolverContext resolverContext)
         {
             if (!schema.Arguments.Any())
                 return new ParseResult.Success(ParsedArguments.Empty);
@@ -34,7 +38,7 @@ namespace Hedron.Core.Commands
                         }
 
                         var token = ReadToken(rawTail, ref pos);
-                        var coerced = Coerce(token, arg.ClrType);
+                        var coerced = Coerce(token, arg.ClrType, arg.Resolver, resolverContext);
                         if (coerced is null)
                             return new ParseResult.Failure(
                                 $"'{token}' is not a valid {arg.ClrType.Name} for '{arg.Name}'.");
@@ -89,9 +93,42 @@ namespace Hedron.Core.Commands
             while (pos < input.Length && char.IsWhiteSpace(input[pos])) pos++;
         }
 
-        private static object? Coerce(string token, Type clrType)
+        /// <summary>
+        /// Coerces <paramref name="token"/> to <paramref name="clrType"/>.
+        /// For <c>string</c> arguments with a non-null <paramref name="resolver"/>, invokes the
+        /// resolver to get candidates and applies prefix matching:
+        /// <list type="bullet">
+        ///   <item>Resolver returns null → pass token through (not applicable).</item>
+        ///   <item>Exactly one candidate starts with token → substitute canonical form.</item>
+        ///   <item>Zero candidates start with token → pass token through (no match, raw literal).</item>
+        ///   <item>Two or more candidates start with token → return null (ambiguous → parse failure).</item>
+        /// </list>
+        /// </summary>
+        private static object? Coerce(string token, Type clrType,
+            IArgumentResolver? resolver, CommandArgumentResolverContext resolverContext)
         {
-            if (clrType == typeof(string)) return token;
+            if (clrType == typeof(string))
+            {
+                if (resolver is not null)
+                {
+                    var candidates = resolver.GetCandidates(resolverContext);
+                    if (candidates is not null)
+                    {
+                        var matches = candidates
+                            .Where(c => c.StartsWith(token, StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+
+                        return matches.Count switch
+                        {
+                            1 => matches[0],            // unique match → canonical form
+                            > 1 => null,                // ambiguous → parse failure
+                            _ => token,                 // no match → fall through to raw literal
+                        };
+                    }
+                }
+                return token;
+            }
+
             if (clrType == typeof(int)) return int.TryParse(token, out var i) ? (object)i : null;
             if (clrType == typeof(uint)) return uint.TryParse(token, out var u) ? (object)u : null;
             if (clrType.IsEnum) return TryParseEnumPrefix(token, clrType);

--- a/Core/Commands/CommandArgumentResolverContext.cs
+++ b/Core/Commands/CommandArgumentResolverContext.cs
@@ -1,0 +1,17 @@
+using System;
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Minimal context passed to <see cref="IArgumentResolver.GetCandidates"/> at argument-parse
+    /// time. Intentionally separate from <see cref="CommandContext"/> because the resolver runs
+    /// inside <see cref="ICommandArgumentParser"/>, before <c>CommandContext</c> is constructed.
+    /// Resolvers that need room contents or inventory obtain them via <paramref name="Services"/>
+    /// as a last resort; prefer constructor injection on the concrete resolver implementation.
+    /// </summary>
+    public readonly record struct CommandArgumentResolverContext(
+        ISession Session,
+        uint InvokerEntityId,
+        IServiceProvider Services);
+}

--- a/Core/Commands/CommandDispatcher.cs
+++ b/Core/Commands/CommandDispatcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Hedron.Core.Commands.Authorization;
 using Hedron.Core.Commands.Events;
@@ -12,14 +13,20 @@ namespace Hedron.Core.Commands
 {
     /// <summary>
     /// Runtime of the command-Initiator tier. Builds a verb → command map at construction,
-    /// then for each dispatch: checks authorization, parses arguments, constructs a
-    /// <see cref="CommandContext"/>, calls <see cref="ICommand.ExecuteAsync"/>, and
-    /// publishes <see cref="CommandExecutedEvent"/> on every outcome.
+    /// then for each dispatch performs a two-phase verb lookup — exact match first, then prefix
+    /// resolution for commands whose <see cref="CommandMatchingMode"/> is
+    /// <see cref="CommandMatchingMode.Partial"/>. Implements <see cref="IVerbRegistry"/> to
+    /// expose a read-only view of the command namespace to <c>HelpCommand</c> and future
+    /// tab-completion without coupling those consumers to the full dispatcher contract.
     /// </summary>
-    public class CommandDispatcher : ICommandDispatcher
+    public class CommandDispatcher : ICommandDispatcher, IVerbRegistry
     {
+        // Exact-match map: primary names + all aliases → command.
         private readonly Dictionary<string, ICommand> _byVerb =
             new(StringComparer.OrdinalIgnoreCase);
+
+        // One entry per command (not per alias) — used by prefix resolution and AllCommands.
+        private readonly List<ICommand> _allCommands = new();
 
         private readonly IAuthorizationChecker _authorizationChecker;
         private readonly ICommandArgumentParser _argumentParser;
@@ -47,11 +54,28 @@ namespace Hedron.Core.Commands
 
             foreach (var command in commands)
             {
+                _allCommands.Add(command);
                 Register(command.Name, command);
                 foreach (var alias in command.Aliases)
                     Register(alias, command);
             }
         }
+
+        // --- IVerbRegistry -----------------------------------------------------------
+
+        public IReadOnlyCollection<ICommand> AllCommands => _allCommands;
+
+        public bool TryGetExact(string verb, out ICommand? command)
+            => _byVerb.TryGetValue(verb, out command);
+
+        public IReadOnlyList<ICommand> GetPrefixCandidates(string verb)
+            => _allCommands
+                .Where(c => c.MatchingMode == CommandMatchingMode.Partial
+                            && c.Name.StartsWith(verb, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+        // --- ICommandDispatcher ------------------------------------------------------
 
         public async Task DispatchAsync(ISession session, string input)
         {
@@ -64,15 +88,40 @@ namespace Hedron.Core.Commands
             var verb = splitAt < 0 ? trimmed : trimmed[..splitAt];
             var rawTail = splitAt < 0 ? string.Empty : trimmed[(splitAt + 1)..].TrimStart();
 
+            // Phase 1: exact lookup (primary names + aliases).
             if (!_byVerb.TryGetValue(verb, out var command))
             {
-                await output.WriteAsync(new PlainMessage(
-                    $"Unknown command: {verb}. Type 'help' for a list.", OutputSeverity.Error))
-                    .ConfigureAwait(false);
-                await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.ParseFailed)
-                    .ConfigureAwait(false);
-                return;
+                // Phase 2: prefix resolution — delegates to IVerbRegistry so the filter logic
+                // is not duplicated between the dispatcher and HelpCommand.
+                var candidates = GetPrefixCandidates(verb);
+
+                switch (candidates.Count)
+                {
+                    case 0:
+                        await output.WriteAsync(new PlainMessage(
+                            $"Unknown command: {verb}. Type 'help' for a list.", OutputSeverity.Error))
+                            .ConfigureAwait(false);
+                        await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.ParseFailed)
+                            .ConfigureAwait(false);
+                        return;
+
+                    case 1:
+                        command = candidates[0];
+                        break;
+
+                    default:
+                        var names = string.Join(", ", candidates.Select(c => c.Name));
+                        await output.WriteAsync(new PlainMessage(
+                            $"Ambiguous command '{verb}'. Did you mean: {names}?", OutputSeverity.Error))
+                            .ConfigureAwait(false);
+                        await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.ParseFailed)
+                            .ConfigureAwait(false);
+                        return;
+                }
             }
+
+            // Use the canonical name for all downstream operations so log lines are stable.
+            var canonicalVerb = command.Name;
 
             // Privilege gate
             foreach (var req in command.RequiredPrivileges)
@@ -82,20 +131,21 @@ namespace Hedron.Core.Commands
                     await output.WriteAsync(new PlainMessage(
                         "You are not authorized to use that command.", OutputSeverity.Error))
                         .ConfigureAwait(false);
-                    await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.Unauthorized)
+                    await PublishExecutedAsync(session.PlayerEntityId, canonicalVerb, string.Empty, CommandOutcome.Unauthorized)
                         .ConfigureAwait(false);
                     return;
                 }
             }
 
             // Argument parse
-            var parseResult = _argumentParser.Parse(command.ArgumentSchema, rawTail);
+            var resolverCtx = new CommandArgumentResolverContext(session, session.PlayerEntityId, _services);
+            var parseResult = _argumentParser.Parse(command.ArgumentSchema, rawTail, resolverCtx);
             if (parseResult is ParseResult.Failure failure)
             {
                 await output.WriteAsync(new PlainMessage(
-                    $"{failure.Reason} Type 'help {verb}' for usage.", OutputSeverity.Error))
+                    $"{failure.Reason} Type 'help {canonicalVerb}' for usage.", OutputSeverity.Error))
                     .ConfigureAwait(false);
-                await PublishExecutedAsync(session.PlayerEntityId, verb, string.Empty, CommandOutcome.ParseFailed)
+                await PublishExecutedAsync(session.PlayerEntityId, canonicalVerb, string.Empty, CommandOutcome.ParseFailed)
                     .ConfigureAwait(false);
                 return;
             }
@@ -107,19 +157,21 @@ namespace Hedron.Core.Commands
             try
             {
                 await command.ExecuteAsync(context).ConfigureAwait(false);
-                await PublishExecutedAsync(session.PlayerEntityId, verb, argsSummary, CommandOutcome.Success)
+                await PublishExecutedAsync(session.PlayerEntityId, canonicalVerb, argsSummary, CommandOutcome.Success)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Command {Verb} threw for entity {EntityId}", verb, session.PlayerEntityId);
+                _logger.LogError(ex, "Command {Verb} threw for entity {EntityId}", canonicalVerb, session.PlayerEntityId);
                 await output.WriteAsync(new PlainMessage(
                     "Something went wrong. The error has been logged.", OutputSeverity.Error))
                     .ConfigureAwait(false);
-                await PublishExecutedAsync(session.PlayerEntityId, verb, argsSummary, CommandOutcome.Threw)
+                await PublishExecutedAsync(session.PlayerEntityId, canonicalVerb, argsSummary, CommandOutcome.Threw)
                     .ConfigureAwait(false);
             }
         }
+
+        // --- Helpers -----------------------------------------------------------------
 
         private Task PublishExecutedAsync(uint entityId, string verb, string argsSummary, CommandOutcome outcome)
             => _eventBus.PublishAsync(new CommandExecutedEvent(entityId, verb, argsSummary, outcome));

--- a/Core/Commands/CommandMatchingMode.cs
+++ b/Core/Commands/CommandMatchingMode.cs
@@ -1,0 +1,21 @@
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Controls whether the dispatcher resolves this command by prefix or requires a full match.
+    /// Player commands default to <see cref="Partial"/>; admin commands default to <see cref="Full"/>.
+    /// </summary>
+    public enum CommandMatchingMode
+    {
+        /// <summary>
+        /// Prefix resolution enabled. The shortest unambiguous prefix dispatches this command.
+        /// E.g. a player typing "lo" resolves to "look".
+        /// </summary>
+        Partial,
+
+        /// <summary>
+        /// Exact match required. The full command name (or a declared alias) must be typed.
+        /// Use for high-impact admin commands where an accidental prefix match is dangerous.
+        /// </summary>
+        Full,
+    }
+}

--- a/Core/Commands/IArgumentResolver.cs
+++ b/Core/Commands/IArgumentResolver.cs
@@ -1,8 +1,27 @@
+using System.Collections.Generic;
+
 namespace Hedron.Core.Commands
 {
     /// <summary>
-    /// Seam for future dynamic entity-name resolution (e.g. "orc" → nearest orc entity id).
-    /// Null this slice — the parser skips this field when it is null.
+    /// Resolves a typed argument token against a dynamic candidate list, enabling prefix
+    /// matching on game-world strings (entity names, inventory items, room exits, etc.).
+    /// <para>
+    /// Return <see langword="null"/> from <see cref="GetCandidates"/> if prefix matching does
+    /// not apply for this invocation — the parser will pass the raw token through unchanged.
+    /// </para>
+    /// <para>
+    /// Concrete implementations (entity-name lookup, inventory lookup, etc.) are deferred to
+    /// slice 6. This interface and the parser call-site land in this slice; no live command
+    /// registers a non-null resolver until slice 6.
+    /// </para>
     /// </summary>
-    public interface IArgumentResolver { }
+    public interface IArgumentResolver
+    {
+        /// <summary>
+        /// Returns the candidate strings against which the typed token will be prefix-matched,
+        /// or <see langword="null"/> if prefix matching does not apply for this invocation
+        /// (causes the parser to pass the raw token through unchanged).
+        /// </summary>
+        IReadOnlyList<string>? GetCandidates(CommandArgumentResolverContext context);
+    }
 }

--- a/Core/Commands/ICommand.cs
+++ b/Core/Commands/ICommand.cs
@@ -40,6 +40,14 @@ namespace Hedron.Core.Commands
         CommandArgumentSchema ArgumentSchema { get; }
 
         /// <summary>
+        /// Controls whether the dispatcher resolves this command by prefix or requires a full
+        /// exact match. Player commands should return <see cref="CommandMatchingMode.Partial"/>;
+        /// admin commands should return <see cref="CommandMatchingMode.Full"/> to prevent
+        /// accidental invocation from an unintended prefix.
+        /// </summary>
+        CommandMatchingMode MatchingMode { get; }
+
+        /// <summary>
         /// Runs the command. <paramref name="context"/> carries typed parsed arguments
         /// and the output writer — do not call <c>session.SendLineAsync</c> directly.
         /// </summary>

--- a/Core/Commands/ICommandArgumentParser.cs
+++ b/Core/Commands/ICommandArgumentParser.cs
@@ -5,6 +5,15 @@ namespace Hedron.Core.Commands
     /// </summary>
     public interface ICommandArgumentParser
     {
-        ParseResult Parse(CommandArgumentSchema schema, string rawTail);
+        /// <summary>
+        /// Parses <paramref name="rawTail"/> against <paramref name="schema"/>.
+        /// <paramref name="resolverContext"/> is forwarded to any non-null
+        /// <see cref="IArgumentResolver"/> declared on a <see cref="CommandArgument"/>;
+        /// no concrete resolver ships until slice 6, but the call-site is wired.
+        /// </summary>
+        ParseResult Parse(
+            CommandArgumentSchema schema,
+            string rawTail,
+            CommandArgumentResolverContext resolverContext);
     }
 }

--- a/Core/Commands/IVerbRegistry.cs
+++ b/Core/Commands/IVerbRegistry.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace Hedron.Core.Commands
+{
+    /// <summary>
+    /// Read-only view of the registered command namespace. Implemented by
+    /// <see cref="CommandDispatcher"/> and consumed by prefix resolution,
+    /// <c>HelpCommand</c>, and future tab-completion without coupling to the
+    /// full dispatcher contract.
+    /// </summary>
+    public interface IVerbRegistry
+    {
+        /// <summary>
+        /// All registered commands — one entry per command, not per alias.
+        /// Order is not guaranteed; sort at the call site.
+        /// </summary>
+        IReadOnlyCollection<ICommand> AllCommands { get; }
+
+        /// <summary>
+        /// Exact-match lookup by primary verb or alias (case-insensitive).
+        /// Returns <see langword="false"/> if no match is found.
+        /// </summary>
+        bool TryGetExact(string verb, out ICommand? command);
+
+        /// <summary>
+        /// Returns all <see cref="CommandMatchingMode.Partial"/> commands whose
+        /// <see cref="ICommand.Name"/> starts with <paramref name="verb"/>
+        /// (case-insensitive), sorted alphabetically by name.
+        /// <list type="bullet">
+        ///   <item>Empty — no match; caller should write an "unknown command" message.</item>
+        ///   <item>One entry — unique prefix; caller may dispatch or display that command.</item>
+        ///   <item>Two or more entries — ambiguous; caller should write a disambiguation message.</item>
+        /// </list>
+        /// This is the single location for the prefix-filter LINQ. Both
+        /// <see cref="CommandDispatcher"/> and <c>HelpCommand</c> call this method so
+        /// the resolution semantics stay consistent.
+        /// </summary>
+        IReadOnlyList<ICommand> GetPrefixCandidates(string verb);
+    }
+}

--- a/Core/Modules/Admin/Commands/DigCommand.cs
+++ b/Core/Modules/Admin/Commands/DigCommand.cs
@@ -27,6 +27,7 @@ namespace Hedron.Core.Modules.Admin.Commands
         public string Name => "dig";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Admin;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Full;
         public string ShortDescription => "Dig a new exit from the current room.";
         public string LongDescription => "Adds an exit from your current room to the target room and wires a reverse link. " +
             "The source YAML is not rewritten; durability comes from the persistence flush.";

--- a/Core/Modules/Admin/Commands/ReloadCommand.cs
+++ b/Core/Modules/Admin/Commands/ReloadCommand.cs
@@ -23,6 +23,7 @@ namespace Hedron.Core.Modules.Admin.Commands
         public string Name => "reload";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Admin;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Full;
         public string ShortDescription => "Reload the content directory without restart.";
         public string LongDescription =>
             "Re-scans the content directory and refreshes the template registry. " +

--- a/Core/Modules/Admin/Commands/SpawnCommand.cs
+++ b/Core/Modules/Admin/Commands/SpawnCommand.cs
@@ -26,6 +26,7 @@ namespace Hedron.Core.Modules.Admin.Commands
         public string Name => "spawn";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Admin;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Full;
         public string ShortDescription => "Spawn a template entity into the world.";
         public string LongDescription => "Spawns a templated entity into the current room. " +
             "Use 'dig' to wire newly spawned rooms into the live world.";

--- a/Core/Modules/Admin/Commands/TeleportCommand.cs
+++ b/Core/Modules/Admin/Commands/TeleportCommand.cs
@@ -26,6 +26,7 @@ namespace Hedron.Core.Modules.Admin.Commands
         public string Name => "teleport";
         public IReadOnlyList<string> Aliases { get; } = new[] { "tp" };
         public CommandCategory Category => CommandCategory.Admin;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Full;
         public string ShortDescription => "Teleport yourself to a room or player.";
         public string LongDescription => "Teleports you to the specified target. " +
             "Target can be a room blueprint id (e.g. room.crossroads) or a player's display name.";

--- a/Core/Modules/Chat/Commands/SayCommand.cs
+++ b/Core/Modules/Chat/Commands/SayCommand.cs
@@ -16,6 +16,7 @@ namespace Hedron.Core.Modules.Chat.Commands
         public string Name => "say";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Player;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
         public string ShortDescription => "Say something to everyone in the room.";
         public string LongDescription => "Broadcasts a message to all players in your current room.";
         public string Usage => "say <message>";

--- a/Core/Modules/Help/Commands/CommandsCommand.cs
+++ b/Core/Modules/Help/Commands/CommandsCommand.cs
@@ -20,6 +20,7 @@ namespace Hedron.Core.Modules.Help.Commands
         public string Name => "commands";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Player;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
         public string ShortDescription => "List available commands.";
         public string LongDescription => "Lists all commands available to you, grouped by category.";
         public string Usage => "commands";
@@ -38,7 +39,7 @@ namespace Hedron.Core.Modules.Help.Commands
             var entries = _allCommands.Value
                 .Where(c => IsVisible(c, context))
                 .OrderBy(c => (int)c.Category).ThenBy(c => c.Name)
-                .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category))
+                .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category, c.Aliases))
                 .ToList();
 
             await context.Output.WriteAsync(new HelpIndexMessage(entries)).ConfigureAwait(false);

--- a/Core/Modules/Help/Commands/HelpCommand.cs
+++ b/Core/Modules/Help/Commands/HelpCommand.cs
@@ -10,20 +10,26 @@ namespace Hedron.Core.Modules.Help.Commands
 {
     /// <summary>
     /// <c>help</c> — with no argument lists all visible commands; with a verb shows detailed
-    /// help for that command. Visibility is filtered by <see cref="IAuthorizationChecker"/>.
+    /// help for that command. Verb lookup uses the same two-phase resolution as
+    /// <see cref="CommandDispatcher"/> (exact first, prefix second) via <see cref="IVerbRegistry"/>
+    /// so that <c>help lo</c> displays help for <c>look</c> exactly as <c>lo</c> would dispatch.
+    /// Each command's declared aliases are shown so players can discover shorthand forms.
     /// </summary>
     public sealed class HelpCommand : ICommand
     {
         private readonly Lazy<IEnumerable<ICommand>> _allCommands;
+        private readonly Lazy<IVerbRegistry> _verbRegistry;
         private readonly IAuthorizationChecker _authorizationChecker;
 
         public string Name => "help";
         public IReadOnlyList<string> Aliases { get; } = new[] { "?" };
         public CommandCategory Category => CommandCategory.Player;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
         public string ShortDescription => "Show command help.";
         public string LongDescription =>
             "With no argument, lists all commands available to you grouped by category. " +
-            "With a verb argument, shows detailed help for that command.";
+            "With a verb argument, shows detailed help for that command. " +
+            "Partial verb names are accepted: 'help lo' displays help for 'look'.";
         public string Usage => "help [<verb>]";
         public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
             Array.Empty<IAuthorizationRequirement>();
@@ -33,9 +39,13 @@ namespace Hedron.Core.Modules.Help.Commands
                 Required: false, "Command verb to look up."),
         });
 
-        public HelpCommand(Lazy<IEnumerable<ICommand>> allCommands, IAuthorizationChecker authorizationChecker)
+        public HelpCommand(
+            Lazy<IEnumerable<ICommand>> allCommands,
+            Lazy<IVerbRegistry> verbRegistry,
+            IAuthorizationChecker authorizationChecker)
         {
             _allCommands = allCommands;
+            _verbRegistry = verbRegistry;
             _authorizationChecker = authorizationChecker;
         }
 
@@ -43,23 +53,7 @@ namespace Hedron.Core.Modules.Help.Commands
         {
             if (context.Args.TryGet<string>("verb", out var verb))
             {
-                var command = _allCommands.Value
-                    .Where(c => IsVisible(c, context))
-                    .FirstOrDefault(c =>
-                        string.Equals(c.Name, verb, StringComparison.OrdinalIgnoreCase)
-                        || c.Aliases.Any(a => string.Equals(a, verb, StringComparison.OrdinalIgnoreCase)));
-
-                if (command is null)
-                {
-                    await context.Output.WriteAsync(
-                        new PlainMessage($"No help found for '{verb}'.", OutputSeverity.System))
-                        .ConfigureAwait(false);
-                    return;
-                }
-
-                await context.Output.WriteAsync(
-                    new HelpEntryMessage(command.Name, command.LongDescription, command.Usage))
-                    .ConfigureAwait(false);
+                await ShowCommandHelp(context, verb!).ConfigureAwait(false);
             }
             else
             {
@@ -68,11 +62,72 @@ namespace Hedron.Core.Modules.Help.Commands
             }
         }
 
+        private async Task ShowCommandHelp(CommandContext context, string verb)
+        {
+            var registry = _verbRegistry.Value;
+
+            // Phase 1: exact match (primary name or alias).
+            if (!registry.TryGetExact(verb, out var command))
+            {
+                // Phase 2: prefix resolution — delegates to IVerbRegistry so the filter
+                // logic is not duplicated between HelpCommand and CommandDispatcher.
+                var candidates = registry.GetPrefixCandidates(verb);
+
+                switch (candidates.Count)
+                {
+                    case 0:
+                        await context.Output.WriteAsync(
+                            new PlainMessage($"No help found for '{verb}'.", OutputSeverity.System))
+                            .ConfigureAwait(false);
+                        return;
+
+                    case 1:
+                        command = candidates[0];
+                        break;
+
+                    default:
+                        // Filter to visible candidates before listing.
+                        var visible = candidates.Where(c => IsVisible(c, context)).ToList();
+                        if (visible.Count == 0)
+                        {
+                            await context.Output.WriteAsync(
+                                new PlainMessage($"No help found for '{verb}'.", OutputSeverity.System))
+                                .ConfigureAwait(false);
+                            return;
+                        }
+                        if (visible.Count == 1)
+                        {
+                            command = visible[0];
+                            break;
+                        }
+                        var names = string.Join(", ", visible.Select(c => c.Name));
+                        await context.Output.WriteAsync(
+                            new PlainMessage($"Ambiguous command '{verb}'. Did you mean: {names}?",
+                                OutputSeverity.System))
+                            .ConfigureAwait(false);
+                        return;
+                }
+            }
+
+            // Visibility gate — don't reveal admin commands to players.
+            if (!IsVisible(command!, context))
+            {
+                await context.Output.WriteAsync(
+                    new PlainMessage($"No help found for '{verb}'.", OutputSeverity.System))
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            await context.Output.WriteAsync(
+                new HelpEntryMessage(command!.Name, command.LongDescription, command.Usage, command.Aliases))
+                .ConfigureAwait(false);
+        }
+
         private IReadOnlyList<HelpIndexEntry> BuildIndex(CommandContext context)
             => _allCommands.Value
                 .Where(c => IsVisible(c, context))
                 .OrderBy(c => (int)c.Category).ThenBy(c => c.Name)
-                .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category))
+                .Select(c => new HelpIndexEntry(c.Name, c.ShortDescription, c.Category, c.Aliases))
                 .ToList();
 
         private bool IsVisible(ICommand command, CommandContext context)

--- a/Core/Modules/Help/HelpModule.cs
+++ b/Core/Modules/Help/HelpModule.cs
@@ -8,18 +8,26 @@ namespace Hedron.Core.Modules.Help
 {
     /// <summary>
     /// DI composition entry point for the Help module: the <c>help</c> and <c>commands</c>
-    /// commands. Depends on <c>IEnumerable&lt;ICommand&gt;</c> and
-    /// <c>IAuthorizationChecker</c> being registered before this is resolved.
+    /// commands. Depends on <c>IEnumerable&lt;ICommand&gt;</c>, <c>IAuthorizationChecker</c>,
+    /// and <c>IVerbRegistry</c> being registered before this is resolved.
+    /// <para>
+    /// Both <c>Lazy&lt;IEnumerable&lt;ICommand&gt;&gt;</c> and <c>Lazy&lt;IVerbRegistry&gt;</c>
+    /// break the circular dependency that would otherwise exist because <c>HelpCommand</c> is
+    /// itself an <c>ICommand</c> and <c>IVerbRegistry</c> is implemented by
+    /// <c>CommandDispatcher</c>, which depends on all <c>ICommand</c> registrations.
+    /// </para>
     /// </summary>
     public static class HelpModule
     {
         public static IServiceCollection AddHelpModule(this IServiceCollection services)
         {
-            // Lazy breaks the IEnumerable<ICommand> → HelpCommand → IEnumerable<ICommand> cycle:
-            // the factory is captured at construction but the collection is only resolved on first
-            // command execution, by which point the DI container is fully built.
+            // Lazy breaks the IEnumerable<ICommand> → HelpCommand → IEnumerable<ICommand> cycle.
             services.AddSingleton(sp =>
                 new Lazy<IEnumerable<ICommand>>(() => sp.GetServices<ICommand>()));
+
+            // Lazy breaks the HelpCommand → IVerbRegistry → CommandDispatcher → HelpCommand cycle.
+            services.AddSingleton(sp =>
+                new Lazy<IVerbRegistry>(() => sp.GetRequiredService<IVerbRegistry>()));
 
             services.AddSingleton<ICommand, HelpCommand>();
             services.AddSingleton<ICommand, CommandsCommand>();

--- a/Core/Modules/Movement/Commands/MoveCommand.cs
+++ b/Core/Modules/Movement/Commands/MoveCommand.cs
@@ -23,6 +23,7 @@ namespace Hedron.Core.Modules.Movement.Commands
         public string Name { get; }
         public IReadOnlyList<string> Aliases { get; }
         public CommandCategory Category => CommandCategory.Player;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
         public string ShortDescription { get; }
         public string LongDescription { get; }
         public string Usage { get; }

--- a/Core/Modules/World/Commands/LookCommand.cs
+++ b/Core/Modules/World/Commands/LookCommand.cs
@@ -18,6 +18,7 @@ namespace Hedron.Core.Modules.World.Commands
         public string Name => "look";
         public IReadOnlyList<string> Aliases { get; } = new[] { "l" };
         public CommandCategory Category => CommandCategory.Player;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
         public string ShortDescription => "Look at the current room.";
         public string LongDescription => "Displays a description of your current location, including visible exits and other players present.";
         public string Usage => "look";

--- a/Core/Output/HelpEntryMessage.cs
+++ b/Core/Output/HelpEntryMessage.cs
@@ -1,7 +1,13 @@
+using System.Collections.Generic;
+
 namespace Hedron.Core.Output
 {
     /// <summary>Detailed help for a single verb (the 'help &lt;verb&gt;' output).</summary>
-    public sealed record HelpEntryMessage(string Verb, string LongDescription, string Usage) : IOutputMessage
+    public sealed record HelpEntryMessage(
+        string Verb,
+        string LongDescription,
+        string Usage,
+        IReadOnlyList<string> Aliases) : IOutputMessage
     {
         public OutputCategory Category => OutputCategory.Help;
     }

--- a/Core/Output/HelpIndexEntry.cs
+++ b/Core/Output/HelpIndexEntry.cs
@@ -1,7 +1,12 @@
+using System.Collections.Generic;
 using Hedron.Core.Commands;
 
 namespace Hedron.Core.Output
 {
     /// <summary>One row in a help index listing.</summary>
-    public sealed record HelpIndexEntry(string Verb, string ShortDescription, CommandCategory Category);
+    public sealed record HelpIndexEntry(
+        string Verb,
+        string ShortDescription,
+        CommandCategory Category,
+        IReadOnlyList<string> Aliases);
 }

--- a/Core/Output/OutputWriter.cs
+++ b/Core/Output/OutputWriter.cs
@@ -32,7 +32,10 @@ namespace Hedron.Core.Output
         private static string RenderEntry(HelpEntryMessage m)
         {
             var sb = new StringBuilder();
-            sb.AppendLine($"[{m.Verb}]");
+            var header = m.Aliases.Count > 0
+                ? $"[{m.Verb}]  (aliases: {string.Join(", ", m.Aliases)})"
+                : $"[{m.Verb}]";
+            sb.AppendLine(header);
             sb.AppendLine(m.LongDescription);
             if (!string.IsNullOrEmpty(m.Usage))
             {
@@ -56,7 +59,12 @@ namespace Hedron.Core.Output
                 first = false;
                 sb.AppendLine($"=== {group.Key} ===");
                 foreach (var entry in group.OrderBy(e => e.Verb))
-                    sb.AppendLine($"  {entry.Verb,-14} {entry.ShortDescription}");
+                {
+                    var label = entry.Aliases.Count > 0
+                        ? $"{entry.Verb}  (aliases: {string.Join(", ", entry.Aliases)})"
+                        : entry.Verb;
+                    sb.AppendLine($"  {label,-20} {entry.ShortDescription}");
+                }
             }
             return sb.ToString().TrimEnd();
         }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -47,6 +47,9 @@ public static class Program
 
                 services.AddSingleton<IEventBus, EventBus>();
                 services.AddSingleton<ICommandDispatcher, CommandDispatcher>();
+                // CommandDispatcher implements IVerbRegistry; expose the same singleton under both interfaces.
+                services.AddSingleton<IVerbRegistry>(sp =>
+                    (IVerbRegistry)sp.GetRequiredService<ICommandDispatcher>());
                 services.AddSingleton<ISessionManager, SessionManager>();
 
                 // Command framework — argument parser and output writer factory

--- a/docs/architecture/06-commands.md
+++ b/docs/architecture/06-commands.md
@@ -29,9 +29,31 @@ public interface ICommand
     string Usage { get; }                          // formal grammar
     IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } // empty = public
     CommandArgumentSchema ArgumentSchema { get; }
+    CommandMatchingMode MatchingMode { get; }       // Partial (player default) | Full (admin default)
     Task ExecuteAsync(CommandContext context);
 }
 ```
+
+`CommandMatchingMode` controls how the dispatcher resolves the command name:
+
+- **`Partial`** — prefix resolution enabled; the shortest unambiguous prefix dispatches this command (`lo` → `look`). Use for player commands.
+- **`Full`** — exact match (or declared alias) required; prefix resolution is skipped. Use for admin commands where misfiring a prefix match is dangerous.
+
+**Resolution rules** (in priority order):
+1. **Exact match** — the typed verb matches a primary name or declared alias in the verb map. Always checked first; static aliases like `d` → `down` are resolved here, never in the prefix pool.
+2. **Prefix resolution** — only runs if step 1 misses. Collects all `Partial`-mode commands whose `Name` starts with the typed verb; sorts alphabetically; dispatches if exactly one match. Two or more → disambiguation error listing **all** matching names. Zero → unknown-command error.
+
+`IVerbRegistry` (implemented by `CommandDispatcher`) exposes the read-only command namespace:
+
+```csharp
+public interface IVerbRegistry
+{
+    IReadOnlyCollection<ICommand> AllCommands { get; }
+    bool TryGetExact(string verb, out ICommand? command);
+}
+```
+
+`HelpCommand` uses `IVerbRegistry` so that `help lo` resolves to `look` identically to how dispatch would resolve it — no duplicated matching logic.
 
 `CommandContext`:
 

--- a/docs/architecture/06-flows.md
+++ b/docs/architecture/06-flows.md
@@ -12,7 +12,7 @@
 |---|---|---|---|
 | 1 | [Server startup](#flow-1--server-startup) | `dotnet run --project Server` | Phase 2 (extended in slice 2) |
 | 2 | [Player connection](#flow-2--player-connection) | TCP client connects on the configured port | Phase 2 |
-| 3 | [Player command lifecycle](#flow-3--player-command-lifecycle) | Player sends a line of input | Phase 2 (replaced by slice 3 command framework; output leg re-traced again by slice 4) |
+| 3 | [Player command lifecycle](#flow-3--player-command-lifecycle) | Player sends a line of input | Phase 2 (replaced by slice 3 command framework; output leg re-traced in slice 4; prefix resolution added in slice 5) |
 | 4 | [Persistence flush cycle](#flow-4--persistence-flush-cycle) | `PersistenceFlushTimer` ticks, or shutdown | Phase 3 slice 1 |
 | 5 | [Content reload](#flow-5--content-reload-reload) | Privileged session sends `reload` | Phase 3 slice 2 (gate moved to dispatcher in slice 3) |
 | 6 | Output rendering | A command/system writes a typed `IOutputMessage` | Phase 3 slice 4 (added by that slice's PR) |
@@ -132,7 +132,7 @@ sequenceDiagram
 
 ## Flow 3 — Player command lifecycle
 
-**Summary.** Input bytes become a verb + raw tail; the dispatcher checks authorization via `IAuthorizationChecker`, parses arguments via `ICommandArgumentParser`, constructs a `CommandContext`, calls `ICommand.ExecuteAsync(context)`, and publishes `CommandExecutedEvent` for every outcome. Output goes through the minimal `IOutputWriter` (stringify-and-forward); slice 4 replaces the writer with a formatter-backed implementation.
+**Summary.** Input bytes become a verb + raw tail; the dispatcher performs a two-phase verb lookup (exact first, prefix second), checks authorization via `IAuthorizationChecker`, parses arguments via `ICommandArgumentParser`, constructs a `CommandContext`, calls `ICommand.ExecuteAsync(context)`, and publishes `CommandExecutedEvent` for every outcome. The `Verb` field in `CommandExecutedEvent` always carries the **resolved canonical name** (e.g. `look`), never the raw typed prefix (`lo`). Output goes through the minimal `IOutputWriter` (stringify-and-forward); slice 4 replaces the writer with a formatter-backed implementation.
 
 **Trigger.** A line of input arrives on a session's read stream.
 
@@ -149,28 +149,35 @@ sequenceDiagram
     Client->>Sess: input line
     Sess->>CD: DispatchAsync(session, input)
     CD->>CD: trim + split → verb, rawTail
-    alt verb unknown
-        CD->>Sess: WriteAsync(PlainMessage "Unknown command…")
-        CD->>Bus: Publish(CommandExecutedEvent ParseFailed)
-    else verb known
-        loop RequiredPrivileges
-            CD->>Auth: IsSatisfied(req, session)
+    alt verb exact-miss
+        CD->>CD: prefix scan (Partial-mode commands only, sorted A–Z)
+        alt zero prefix matches
+            CD->>Sess: WriteAsync(PlainMessage "Unknown command…")
+            CD->>Bus: Publish(CommandExecutedEvent ParseFailed)
+        else ambiguous prefix (2+)
+            CD->>Sess: WriteAsync(PlainMessage "Ambiguous command…all matches listed")
+            CD->>Bus: Publish(CommandExecutedEvent ParseFailed)
+        else unique prefix match → canonicalVerb = command.Name
         end
-        alt unauthorized
-            CD->>Sess: WriteAsync(PlainMessage "Not authorized")
-            CD->>Bus: Publish(CommandExecutedEvent Unauthorized)
-        else authorized
-            CD->>Parser: Parse(ArgumentSchema, rawTail)
-            alt parse failed
-                CD->>Sess: WriteAsync(PlainMessage reason + help hint)
-                CD->>Bus: Publish(CommandExecutedEvent ParseFailed)
-            else parsed
-                CD->>Cmd: ExecuteAsync(CommandContext)
-                Cmd->>Cmd: domain call / event publish
-                Cmd->>Sess: WriteAsync(IOutputMessage) via IOutputWriter
-                CD->>Bus: Publish(CommandExecutedEvent Success)
-                Bus->>Bus: priority-ordered handlers (20 → 80 → 90 → 95)
-            end
+    else verb exact hit (name or alias) → canonicalVerb = command.Name
+    end
+    loop RequiredPrivileges
+        CD->>Auth: IsSatisfied(req, session)
+    end
+    alt unauthorized
+        CD->>Sess: WriteAsync(PlainMessage "Not authorized")
+        CD->>Bus: Publish(CommandExecutedEvent Unauthorized, Verb=canonicalVerb)
+    else authorized
+        CD->>Parser: Parse(ArgumentSchema, rawTail, resolverContext)
+        alt parse failed
+            CD->>Sess: WriteAsync(PlainMessage reason + help hint)
+            CD->>Bus: Publish(CommandExecutedEvent ParseFailed, Verb=canonicalVerb)
+        else parsed
+            CD->>Cmd: ExecuteAsync(CommandContext)
+            Cmd->>Cmd: domain call / event publish
+            Cmd->>Sess: WriteAsync(IOutputMessage) via IOutputWriter
+            CD->>Bus: Publish(CommandExecutedEvent Success, Verb=canonicalVerb)
+            Bus->>Bus: priority-ordered handlers (20 → 80 → 90 → 95)
         end
     end
 ```
@@ -178,13 +185,15 @@ sequenceDiagram
 **Steps.**
 
 1. `TelnetSession` reads a line and calls `CommandDispatcher.DispatchAsync(session, input)`.
-2. The dispatcher trims input and splits on the first whitespace into verb + raw tail. Unknown verbs write `PlainMessage("Unknown command: <verb>. Type 'help' for a list.")` via `IOutputWriter`, publish `CommandExecutedEvent(ParseFailed)`, and return.
-3. **Privilege gate.** The dispatcher iterates `command.RequiredPrivileges` and calls `IAuthorizationChecker.IsSatisfied(req, session)` for each. The checker is the sole policy seam — `AdminRequirement` delegates to the existing `IAdminAuthorizer`. Any unsatisfied requirement writes a rejection `PlainMessage` via `IOutputWriter` and publishes `CommandExecutedEvent(Unauthorized)`.
-4. **Argument parse.** `ICommandArgumentParser.Parse(command.ArgumentSchema, rawTail)` does single-pass tokenization (whitespace + double-quoted groups), walks the declarative argument list, and coerces each token to its CLR type (`string`, `int`, `uint`, `Direction`). Enum-prefix matching works from day one (`n`/`no`/`nor` → `North`). On failure: the reason + `"Type 'help <verb>' for usage."` is written via `IOutputWriter`; `CommandExecutedEvent(ParseFailed)` is published.
+2. **Two-phase verb lookup.**
+   - **Phase 1 (exact):** `_byVerb.TryGetValue(verb)` — checks primary names and all declared aliases. If found, `canonicalVerb = command.Name` and skip to step 3. Static aliases like `d` → `down` resolve here; prefix resolution is never reached.
+   - **Phase 2 (prefix):** Collect all commands where `MatchingMode == Partial` and `command.Name.StartsWith(verb, OrdinalIgnoreCase)`. Sort alphabetically. Zero matches → write `PlainMessage("Unknown command: <verb>. Type 'help' for a list.")`, publish `CommandExecutedEvent(ParseFailed)`, return. Two or more matches → write `PlainMessage("Ambiguous command '<verb>'. Did you mean: <all names, comma-separated>?")`, publish `CommandExecutedEvent(ParseFailed)`, return. Exactly one match → `canonicalVerb = command.Name`.
+3. **Privilege gate.** The dispatcher iterates `command.RequiredPrivileges` and calls `IAuthorizationChecker.IsSatisfied(req, session)` for each. Any unsatisfied requirement writes a rejection `PlainMessage` via `IOutputWriter` and publishes `CommandExecutedEvent(Unauthorized, Verb=canonicalVerb)`.
+4. **Argument parse.** `ICommandArgumentParser.Parse(command.ArgumentSchema, rawTail, resolverContext)` does single-pass tokenization (whitespace + double-quoted groups), walks the declarative argument list, and coerces each token to its CLR type (`string`, `int`, `uint`, `Direction`). Enum-prefix matching works from day one (`n`/`no`/`nor` → `North`). String `Token` arguments that declare a non-null `IArgumentResolver` have prefix matching applied against the candidate list (no concrete resolver ships until slice 6). On failure: the reason + `"Type 'help <canonicalVerb>' for usage."` is written; `CommandExecutedEvent(ParseFailed, Verb=canonicalVerb)` is published.
 5. **Execute.** The dispatcher constructs `CommandContext(Session, InvokerEntityId, ParsedArguments, IOutputWriter, IServiceProvider)` and calls `command.ExecuteAsync(context)`. The body reads typed args via `context.Args.Get<T>(name)`, calls domain systems or publishes events via injected `IEventBus`, and writes all output via `context.Output.WriteAsync(IOutputMessage)`. No `session.SendLineAsync` in command bodies.
-6. **Minimal output seam.** `IOutputWriter.WriteAsync` stringifies the message (`PlainMessage` → its text; `HelpIndexMessage` / `HelpEntryMessage` → plain-text rendering) and calls `session.SendLineAsync`. Slice 4 replaces this implementation with a formatter-backed one.
+6. **Minimal output seam.** `IOutputWriter.WriteAsync` stringifies the message (`PlainMessage` → its text; `HelpIndexMessage` / `HelpEntryMessage` → plain-text rendering, including aliases) and calls `session.SendLineAsync`. Slice 4 replaces this implementation with a formatter-backed one.
 7. **Exception trap.** Any uncaught exception is caught, logged at `Error` with a full stack trace, a `PlainMessage("Something went wrong. The error has been logged.")` is written, and `CommandExecutedEvent(Threw)` is published. No stack trace reaches the session.
-8. **`CommandExecutedEvent`.** Published on every dispatch path — success, parse-fail, unauthorized, threw. `CommandLoggingHandler` (priority 80) writes one structured-log line per command via `ILogger`. `AdminAuditHandler` keeps subscribing to the four richer slice-2 admin events and does **not** subscribe to `CommandExecutedEvent`.
+8. **`CommandExecutedEvent`.** Published on every dispatch path — success, parse-fail, unauthorized, threw. The `Verb` field carries the **resolved canonical command name** (e.g. `look` when the player typed `lo`), not the raw typed prefix. This makes log lines stable regardless of what the player typed. `CommandLoggingHandler` (priority 80) writes one structured-log line per command via `ILogger`. `AdminAuditHandler` keeps subscribing to the four richer slice-2 admin events and does **not** subscribe to `CommandExecutedEvent`.
 
 **Cross-references.**
 - [`Core/Commands/CommandDispatcher.cs`](../../Core/Commands/CommandDispatcher.cs), [`Core/Commands/ICommand.cs`](../../Core/Commands/ICommand.cs)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -4,6 +4,8 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 
 **Grouping:** by `CommandCategory`. Within each category, alphabetical by primary verb.
 
+**`MatchingMode`** — every command declares `CommandMatchingMode.Partial` (prefix resolution enabled; player commands) or `CommandMatchingMode.Full` (exact match required; admin commands). See `06-commands.md` for the two-phase lookup rules and `IVerbRegistry` for the read-only interface that exposes the command namespace to `HelpCommand` and future tab-completion.
+
 ---
 
 ## Player commands
@@ -11,6 +13,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `commands`
 
 **Aliases:** none  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Help/Commands/CommandsCommand.cs`  
 **Description:** Prints a category-grouped one-line index of all commands visible to the caller. Same visibility filtering as `help` (admin commands hidden when their `RequiredPrivileges` are unsatisfied).  
 **Usage:** `commands`  
@@ -22,6 +25,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `down` / `d`
 
 **Aliases:** `d`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
 **Description:** Move down if an exit exists.  
 **Usage:** `down`  
@@ -33,6 +37,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `east` / `e`
 
 **Aliases:** `e`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
 **Description:** Move east if an exit exists.  
 **Usage:** `east`  
@@ -44,6 +49,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `help` / `?`
 
 **Aliases:** `?`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Help/Commands/HelpCommand.cs`  
 **Description:** With no argument, lists all commands visible to the caller grouped by category. With a verb argument, shows `LongDescription` and `Usage` for that command.  
 **Usage:** `help [<verb>]`  
@@ -55,6 +61,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `look` / `l`
 
 **Aliases:** `l`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/World/Commands/LookCommand.cs`  
 **Description:** Displays the current room description, visible exits, and other players present. Delegates to `IBroadcastSystem.SendRoomDescriptionAsync`; output is not yet routed through the `IOutputWriter` formatter (deferred to slice 4).  
 **Usage:** `look`  
@@ -66,6 +73,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `north` / `n`
 
 **Aliases:** `n`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
 **Description:** Move north if an exit exists.  
 **Usage:** `north`  
@@ -77,6 +85,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `say`
 
 **Aliases:** none  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Chat/Commands/SayCommand.cs`  
 **Description:** Broadcasts a message to all players in the current room.  
 **Usage:** `say <message>`  
@@ -88,6 +97,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `south` / `s`
 
 **Aliases:** `s`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
 **Description:** Move south if an exit exists.  
 **Usage:** `south`  
@@ -99,6 +109,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `up` / `u`
 
 **Aliases:** `u`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
 **Description:** Move up if an exit exists.  
 **Usage:** `up`  
@@ -110,6 +121,7 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ### `west` / `w`
 
 **Aliases:** `w`  
+**MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Movement/Commands/MoveCommand.cs`  
 **Description:** Move west if an exit exists.  
 **Usage:** `west`  
@@ -127,6 +139,7 @@ All admin commands require `AdminRequirement`. The dispatcher enforces this via 
 ### `dig`
 
 **Aliases:** none  
+**MatchingMode:** `Full`  
 **Location:** `Core/Modules/Admin/Commands/DigCommand.cs`  
 **Description:** Adds an exit from the current room to the target room and wires the reverse link by default. Updates the in-memory `RoomTemplate` so a same-session `reload` won't undo the change. The source YAML file is not rewritten; durability comes from `PersistenceSystem`.  
 **Usage:** `dig <direction> <targetRoomBlueprintId>`  
@@ -138,6 +151,7 @@ All admin commands require `AdminRequirement`. The dispatcher enforces this via 
 ### `reload`
 
 **Aliases:** none  
+**MatchingMode:** `Full`  
 **Location:** `Core/Modules/Admin/Commands/ReloadCommand.cs`  
 **Description:** Re-scans the content directory and refreshes the template registry. Newly authored templates with no live counterpart are seeded. **Existing live entities are not modified** — descriptions, exits, and components on rooms that already exist will not change. To pick up edits to a live room, restart, or use `dig` for exit changes.  
 **Usage:** `reload`  
@@ -149,6 +163,7 @@ All admin commands require `AdminRequirement`. The dispatcher enforces this via 
 ### `spawn`
 
 **Aliases:** none  
+**MatchingMode:** `Full`  
 **Location:** `Core/Modules/Admin/Commands/SpawnCommand.cs`  
 **Description:** Spawns a templated entity into the world. In slice 3 this creates an orphan entity (rooms/areas); use `dig` to wire a new room in. Item and mob placement land with their slices.  
 **Usage:** `spawn <blueprintId>`  
@@ -160,6 +175,7 @@ All admin commands require `AdminRequirement`. The dispatcher enforces this via 
 ### `teleport` / `tp`
 
 **Aliases:** `tp`  
+**MatchingMode:** `Full`  
 **Location:** `Core/Modules/Admin/Commands/TeleportCommand.cs`  
 **Description:** Teleports the invoker to a target room (by blueprint id) or to a player's current room (by display name).  
 **Usage:** `teleport <roomBlueprintId|playerName>`  

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -34,6 +34,7 @@ Every use-case file contains:
 | `implemented` | [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) | Phase 3 slice 2 |
 | `planned` | [`command-framework.md`](command-framework.md) | Phase 3 slice 3 |
 | `planned` | [`output-framework.md`](output-framework.md) | Phase 3 slice 4 |
+| `implemented` | [`command-prefix-matching.md`](command-prefix-matching.md) | Phase 3 (after slice 4) |
 | `deferred` | [`admin-privilege-elevation.md`](admin-privilege-elevation.md) | Future (TBD) — placeholder |
 
 > The slice-numbering question was resolved ("slice 3 and shift"): the previously-combined `command-and-output-framework.md` is split into slice 3 (command framework) and slice 4 (output framework). "Account / character creation" is now **slice 5**, and all downstream slices shift **+2**. See [`../roadmap/plan.md`](../roadmap/plan.md) for the renumbered slice queue.

--- a/docs/use-cases/command-prefix-matching.md
+++ b/docs/use-cases/command-prefix-matching.md
@@ -1,0 +1,242 @@
+# Use Case: Command Prefix Matching
+
+**Status:** implemented
+**Actors:** Player, Administrator, System
+**Module:** `Core/Commands/` (infrastructure enhancement to the command-framework slice)
+
+---
+
+## Description
+
+Extends the slice-3 command framework with dynamic prefix resolution for verb lookup. A player typing `lo` resolves to `look`; typing `dr` resolves to `drop`. Each command declares a `MatchingMode` (`Partial` or `Full`): player commands default to `Partial` (prefix resolution enabled); admin commands default to `Full` (exact match required, because the cost of misfiring `dig` or `reload` is high). Static aliases registered on `ICommand.Aliases` remain in the verb map at the exact-match tier and are consulted before prefix resolution begins — the existing `d` alias on `MoveCommand` therefore continues to route to `down`, not to the `dig`/`drop`/`down` ambiguity pool. The `IArgumentResolver` seam already present on `CommandArgument` (null in slice 3) is given its concrete interface definition and parser wiring in this slice; concrete resolver implementations (entity-name lookup, inventory lookup, etc.) are deferred to slice 6. `HelpCommand` is extended to display each command's declared aliases so players can discover shorthand forms.
+
+---
+
+## Preconditions
+
+- Phase 3 slices 1–3 have merged: the slice-3 `ICommand` shape (`Name`, `Aliases`, `MatchingMode` is **added by this slice**), `ICommandDispatcher`, `CommandDispatcher`, `ICommandArgumentParser`, `CommandArgumentSchema`, `IArgumentResolver` (null stub), and the 14 commands (12 original slice-2 commands + `help` + `commands`, both added by slice 3) (`look`, `say`, six `MoveCommand` instances, `spawn`, `teleport`/`tp`, `dig`, `reload`, `help`, `commands`) all exist.
+- `CommandDispatcher._byVerb` is built at construction time from exact name + alias entries (a `Dictionary<string, ICommand>` with case-insensitive comparer).
+- `CommandArgumentParser.Coerce` already does enum-prefix matching; the `Resolver` field of `CommandArgument` is null.
+- No existing player command verb is ambiguous under its own prefix (e.g. `look` is the only verb starting with `lo`). Static aliases may cover short prefixes (e.g. `d` = `down`) — these continue to work unchanged because exact-match lookup runs before prefix resolution.
+
+---
+
+## Postconditions
+
+- `ICommand` gains a `MatchingMode` property (`CommandMatchingMode.Partial | Full`). Player commands default to `Partial`; admin commands default to `Full`. The property is a required interface member with no default; compile-enforced choice.
+- `CommandDispatcher` performs a two-phase verb lookup: (1) exact match (name + aliases in `_byVerb`) — if found, dispatch as today; (2) if no exact match found AND the session input is not an exact alias, run prefix resolution across all registered commands whose `MatchingMode == Partial`. Prefix resolution returns the unique command whose `Name` starts with the typed verb; alphabetically first if multiple match; `Ambiguous` if multiple remain after mode filtering. Ambiguous prefixes write a disambiguation error listing **all** matching command names — the list is never truncated and they do not silently pick one.
+- `CommandArgumentParser` gains the wiring to invoke `IArgumentResolver` for `string`-typed `Token` arguments whose command declares a resolver, and applies prefix matching against the candidate list when the resolver returns non-null. Concrete resolver implementations (entity-name, inventory, room-exit lookup) are **deferred to slice 6**; this slice ships the interface and the parser call-site only. Enum arguments are unchanged (they already do prefix matching).
+- An `IVerbRegistry` interface is introduced. `CommandDispatcher` implements it. It exposes a read-only view of registered command names for use by prefix resolution and `help`/`commands` display. This replaces the private `_byVerb` dictionary as the surface other components (tests, future tab-completion) can inspect without coupling to the full dispatcher.
+- `help <prefix>` behaviour: if the exact verb is not found, prefix resolution is attempted on the help argument — the command that would have been dispatched is what help displays. If ambiguous, help lists all matching commands.
+- `HelpCommand` displays each command's declared `Aliases` alongside its name and description. A command with no aliases renders nothing in that field. This is the only place aliases are currently surfaced to players; the `commands` list command is updated identically.
+- The slice-3 `CommandLoggingHandler` records the *resolved* verb (the canonical `ICommand.Name`), not the raw typed prefix, so log lines are stable regardless of what the player typed.
+- All 14 existing commands compile against the new interface with the appropriate default mode. No gameplay semantics change.
+
+---
+
+## Main Flow
+
+1. **Input arrives.** `CommandDispatcher.DispatchAsync(session, input)` splits verb + raw tail as today.
+
+2. **Phase 1: Exact lookup.** `_byVerb.TryGetValue(verb, out command)` — includes all exact names and static aliases. If found, proceed to the privilege gate (unchanged from slice 3). Static alias `d` → `down` resolves here; prefix resolution is never reached.
+
+3. **Phase 2: Prefix resolution.** Collect all commands where `command.MatchingMode == Partial` AND `command.Name.StartsWith(verb, OrdinalIgnoreCase)`. Sort candidates by `Name` (ordinal, case-insensitive) — alphabetically first wins. Zero candidates: write `"Unknown command: <verb>. Type 'help' for a list."` and publish `CommandExecutedEvent(ParseFailed)`. Exactly one candidate: proceed as if exact match, using the candidate. Two or more candidates: write `"Ambiguous command '<verb>'. Did you mean: <all matching names, comma-separated>?"` and publish `CommandExecutedEvent(ParseFailed)`. The disambiguation list is **all** matches; nothing is omitted or truncated.
+
+4. **Privilege gate and argument parse.** Unchanged from slice 3. `CommandContext` is constructed with the *resolved* `ICommand.Name` as the canonical verb (not the raw typed input), so logging and audit are always stable.
+
+5. **Argument resolver wiring (if configured).** `CommandArgumentParser` contains the call-site: for each `Token`-kind string argument that has a non-null `IArgumentResolver`, it calls `resolver.GetCandidates(context)` and applies prefix matching. Unique match → substitute canonical form. Ambiguous → `ParseResult.Failure`. No match → fall through to raw literal. **No concrete resolver implementations ship in this slice** — the wiring is present and correct, but no command registers a non-null resolver until slice 6.
+
+6. **Execute.** `command.ExecuteAsync(context)` runs as today.
+
+7. **Logging.** `CommandLoggingHandler` receives `CommandExecutedEvent`; `Verb` field contains the resolved canonical name (e.g. `look`), not the raw prefix (`lo`). `ArgsSummary` contains the post-resolution argument values.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Change |
+|---|---|---|
+| `CommandExecutedEvent` (existing) | `CommandDispatcher` | `Verb` field now carries the resolved canonical verb, not the raw typed input. Payload shape is otherwise unchanged. |
+
+No new events. Prefix resolution is a synchronous, in-dispatcher decision; it produces no state change that warrants a past-tense event.
+
+---
+
+## Systems / Handlers Involved
+
+### ICommand (existing — extended)
+
+New required property:
+
+```
+CommandMatchingMode MatchingMode { get; }
+```
+
+`CommandMatchingMode` is a new enum in `Core/Commands/`:
+
+```
+public enum CommandMatchingMode { Partial, Full }
+```
+
+Default convention (enforced by documentation and the `add-command` skill, not by the interface itself since C# requires explicit implementation): player commands return `Partial`; admin commands return `Full`.
+
+### IVerbRegistry (new — `Core/Commands/IVerbRegistry.cs`)
+
+Read-only view of the registered verb space, consumed by prefix resolution, `HelpCommand`, and future tab-completion:
+
+```
+public interface IVerbRegistry
+{
+    IReadOnlyCollection<ICommand> AllCommands { get; }
+    bool TryGetExact(string verb, out ICommand? command);
+}
+```
+
+`CommandDispatcher` implements `IVerbRegistry` (it already holds the verb map). Registered as `IVerbRegistry` in DI alongside `ICommandDispatcher`.
+
+### CommandDispatcher (existing — modified)
+
+- Constructor and `_byVerb` unchanged.
+- `DispatchAsync` gains the two-phase lookup described in the main flow.
+- Implements `IVerbRegistry`.
+- No new constructor dependencies — prefix resolution is a pure in-memory set operation over the already-held command list.
+
+### ICommandArgumentParser / CommandArgumentParser (existing — modified)
+
+`CommandArgumentParser.Coerce` gains the call-site wiring: for `string`-typed `Token` arguments with a non-null `IArgumentResolver`, the resolver is invoked to get candidates, then prefix matching is applied. The resolver returns `IReadOnlyList<string>?` — null means "not applicable; pass through." The concrete interface definition replaces the null stub:
+
+```
+public interface IArgumentResolver
+{
+    /// Returns the candidate strings for prefix matching, or null if
+    /// prefix matching does not apply for this invocation.
+    IReadOnlyList<string>? GetCandidates(CommandArgumentResolverContext context);
+}
+
+public readonly record struct CommandArgumentResolverContext(
+    ISession Session,
+    uint InvokerEntityId,
+    IServiceProvider Services);
+```
+
+`Core/Commands/IArgumentResolver.cs` — replaces the current empty stub.
+`Core/Commands/CommandArgumentResolverContext.cs` — new value type.
+
+**No concrete `IArgumentResolver` implementations are delivered in this slice.** No live command sets a non-null resolver. The entity-name and inventory resolver implementations land in slice 6 (items + inventory). The parser wiring is present and exercised by unit-testable stub scenarios.
+
+### HelpCommand (existing — modified)
+
+`help <verb>` falls through to prefix resolution using `IVerbRegistry` when exact lookup misses. Writes a disambiguation list (complete, no truncation) if the prefix is ambiguous. No change to `HelpCommand`'s DI dependencies — it already holds `IEnumerable<ICommand>`; it gains `IVerbRegistry` to delegate the two-phase lookup rather than duplicating it.
+
+In addition, the help output for a command is extended to include the command's `ICommand.Aliases` list. When a player runs `help look` (for example), the rendered block now shows:
+
+```
+look  (aliases: l)
+  Describes your current surroundings.
+```
+
+A command with no aliases omits the aliases line entirely. The `commands` verb-listing command receives the same treatment: each line shows the canonical name followed by any aliases in parentheses. This is the first time aliases are surfaced to the player; no new DI dependencies are required since `HelpCommand` already iterates `ICommand` instances.
+
+---
+
+## Content Tooling Impact
+
+Pure infrastructure. No new authored data files, no new `TemplateRegistry` entries, no new admin commands.
+
+The 14 existing commands each gain a `MatchingMode` declaration. By convention: the four admin commands (`spawn`, `teleport`/`tp`, `dig`, `reload`) declare `Full`; the remaining player commands declare `Partial`. The `add-command` skill (`../skills/add-command/SKILL.md`) must be updated to include `MatchingMode` as a required step, with the correct default shown for each `CommandCategory`.
+
+No config keys are added. Matching mode is static (per-command declaration), not a runtime setting.
+
+---
+
+## Cross-cutting surfaces stressed
+
+- **Commands** — **Adequate.** The slice-3 command framework is the surface being extended. Verb-prefix lookup is a pure modification to `CommandDispatcher._byVerb` lookup logic; the `ICommand` interface gains one required property. No hand-rolled patterns: the resolution logic is in one place (`CommandDispatcher`) and the test surface is `IVerbRegistry`.
+
+- **Output** — **Adequate.** Disambiguation error and ambiguous-argument messages are `PlainMessage(OutputSeverity.Error)` values written via the existing `IOutputWriter`. No new output shape is needed.
+
+- **Event bus** — **Adequate.** `CommandExecutedEvent` is reused unchanged (the `Verb` field meaning is clarified, not the schema changed). No new bus machinery.
+
+- **Persistence** — **Adequate.** No `[Persistent]` components are added or changed. Matching mode is a static code declaration, not saved state.
+
+- **Configuration** — **Adequate.** Matching mode is a static compile-time declaration on each command; no runtime config override is needed and the static approach is demonstrably sufficient. No config keys are added or consulted.
+
+- **ECS queries** — **Adequate.** No entity queries in this slice.
+
+- **Sessions** — **Adequate.** `CommandArgumentResolverContext` wraps `ISession` the same way `CommandContext` does. No change to `ISession`.
+
+- **Content templates** — **Adequate.** No template schema changes.
+
+- **`add-command` skill** — **Gap exposed — must update.** The `add-command` skill currently shows the post-slice-3 `ICommand` shape. Adding `MatchingMode` as a required property without updating the skill would cause every future command author to produce a non-compiling stub on the first attempt. **Resolution:** the skill update is in scope for this slice's PR. In addition, `docs/architecture/06-commands.md` contains the authoritative `ICommand` interface shape verbatim and must also be updated in the same PR to include the `MatchingMode` property. This is a documentation surface, not a framework surface, but the CLAUDE.md ground rule ("if the slice adds a new required interface member, the skill must reflect it") makes it a merge requirement.
+
+- **`IArgumentResolver` seam** — **Gap discharged (interface + wiring only).** The seam was null in slice 3. This slice gives it a concrete interface, `CommandArgumentResolverContext`, and the parser call-site. The entity-name resolution scenario (finding the nearest orc by typing "orc" into a `get` command) is deferred — concrete resolver implementations land in slice 6. No command in this slice registers a non-null resolver, so the path is wired but not exercised against live data until slice 6.
+
+---
+
+## Flows introduced or modified
+
+### Flow 3 — Player command lifecycle (extended)
+
+The existing Flow 3 traces: input → verb lookup (exact only) → authorization → argument parse → execute → output → `CommandExecutedEvent`.
+
+This slice modifies **step 2** (verb lookup) by adding the prefix-resolution phase after an exact-miss. The mermaid diagram must be updated to add the prefix-resolution branch. Specifically:
+
+- The `alt verb unknown` branch becomes `alt verb exact-miss` with two sub-branches: prefix resolves uniquely (proceed), or zero/ambiguous (write error).
+- The `Verb` field in the `CommandExecutedEvent` publish calls must note that the resolved canonical name is used.
+
+In addition, the **step 8 prose** (the description of `CommandLoggingHandler` receiving `CommandExecutedEvent`) must be corrected in the same PR. Prior to this slice the prose states that `Verb` equals the raw typed input; after this slice `Verb` is the resolved canonical command name (e.g. `look` when the player typed `lo`). The step 8 prose must reflect this change.
+
+No other flows are affected. The architecture-reviewer PR gate requires `06-flows.md` to be updated with the redrawn Flow 3 diagram and corrected step 8 prose before merge.
+
+### No new canonical flow introduced.
+
+Prefix resolution is an inline extension of the existing dispatch flow, not a new chain.
+
+---
+
+## Design Notes
+
+- **Aliases win before prefix resolution.** Static aliases (e.g. `d` = `down`, `n` = `north`) are in `_byVerb` as exact entries and are never visible to prefix resolution. This is by construction — if `d` resolves via alias before the prefix loop runs, `d` → `down` is guaranteed even when `dig` and `drop` exist. No special-casing needed.
+
+- **Alphabetically first, not "most popular".** The disambiguation rule is deterministic and stable as new commands are added. "Most recently used" or "most popular" would require state and would change behaviour across sessions — unacceptable for an MUD where players learn muscle memory. Alphabetical is predictable.
+
+- **Ambiguous prefixes are errors, not silent guesses.** Silently picking a command from an ambiguous prefix would produce surprising action (a player typing `d` in a world without the `down` alias could suddenly `dig` or `drop`). A clear disambiguation message teaches the player the minimum required prefix. This matches classic MUD conventions (DikuMUD, ROM, SMAUG all produce "AMBIGUOUS COMMAND" lists).
+
+- **`Full` mode for admin commands is a safety default, not a hard constraint.** A future admin command that the author explicitly wants prefix-accessible (e.g. a short `stat` inspection verb) can declare `Partial`. The point is that the failure mode for mistaken `Full` (typing more characters) is much lower-risk than mistaken `Partial` (firing a destructive admin command from an accidental prefix).
+
+- **`IVerbRegistry` as a seam for tab-completion.** Tab-completion is not in scope for this slice, but it requires the same read-only view of the command namespace. By extracting `IVerbRegistry` now, the tab-completion slice (deferred) can consume it without touching `CommandDispatcher`'s internals.
+
+- **`CommandArgumentResolverContext` is intentionally minimal.** It carries `ISession`, `InvokerEntityId`, and `IServiceProvider`. Future resolver implementations that need room contents or inventory lists obtain them via `IServiceProvider`. No dependency on `CommandContext` — the resolver runs inside the parser, which runs before the `CommandContext` is constructed.
+
+- **`help <prefix>` reuses dispatcher resolution logic via `IVerbRegistry`.** `HelpCommand` gains `IVerbRegistry` as a dependency to perform the same two-phase lookup. This ensures help and dispatch agree on what verb a prefix resolves to, with no duplicated matching code.
+
+- **No change to `CommandExecutedEvent` schema.** The `Verb` field already carries a `string`. Its *meaning* shifts from "raw typed verb" to "resolved canonical verb name", which is strictly an improvement for log consumers. This is a breaking semantic change for any log query that expected the raw typed prefix; since no such queries exist yet, it is an acceptable evolution. The `ArgsSummary` field carries post-resolution argument values; this was always the intent.
+
+- **Aliases in help output.** `ICommand.Aliases` existed in slice 3 but was never shown to the player. This slice adds aliases to `HelpCommand` output and the `commands` listing. Players learn shorthands (e.g. `l` for `look`) through the help system rather than word of mouth. The formatting is minimal: `name  (aliases: a, b)` on the header line; commands with no aliases omit the parenthetical. No new data structure is required — `ICommand.Aliases` is already `IReadOnlyList<string>`.
+
+- **Disambiguation list is complete.** When a prefix is ambiguous the full set of matching command names is written. Truncation (e.g. "did you mean: drop, dig, and 3 more?") is explicitly rejected — the complete list is what teaches the player the minimum distinguishing prefix.
+
+- **Out of scope for this slice.** Tab-completion (needs session-level interrupt handling and partial-line buffering). Fuzzy/edit-distance matching (not MUD-conventional; deferred indefinitely). Concrete `IArgumentResolver` implementations (slice 6). Per-session matching-mode override (e.g. "always require full match for this player"). Locale-sensitive sort order (English-only MUD; not a priority).
+
+---
+
+## Open Questions
+
+None. The following were resolved in planning:
+
+- **What wins when a static alias collides with a prefix match?** Alias (exact match runs first). Established by the `d`/`down` example in the idea itself.
+- **Ambiguous prefix → pick first or error?** Error with disambiguation list. Matches MUD convention; prevents silent misfire.
+- **Admin commands default to `Full` or `Partial`?** `Full`. The idea specifies this explicitly.
+- **Does `help <prefix>` participate in prefix resolution?** Yes, via `IVerbRegistry`, so help and dispatch agree.
+- **Disambiguation list: truncated or complete?** Complete — all matching command names are shown, no truncation.
+- **Argument resolver concrete implementations: this slice or later?** Interface + parser wiring land here; concrete resolver implementations (entity-name, inventory) are deferred to slice 6.
+- **Are aliases surfaced to players?** Yes, in this slice — `HelpCommand` and `commands` display each command's declared aliases.
+
+---
+
+## Related
+
+- [`command-framework.md`](command-framework.md) — slice 3; introduced `ICommand`, `CommandDispatcher`, `ICommandArgumentParser`, `IArgumentResolver` (null stub), and deferred verb-prefix matching explicitly ("Verb-prefix matching (`d` → `dig`) ... explicitly deferred"). This slice discharges that deferral.
+- [`output-framework.md`](output-framework.md) — slice 4; disambiguation messages use the `PlainMessage`/`IOutputWriter` output path this slice reuses.
+- [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) — slice 2; established the four admin commands that this slice assigns `Full` matching mode.
+- [`admin-privilege-elevation.md`](admin-privilege-elevation.md) — deferred; future `grant`/`revoke` admin commands would also declare `Full` matching mode as admin commands.


### PR DESCRIPTION
## Summary

- Adds dynamic prefix resolution to `CommandDispatcher`: `lo` → `look`, `dr` → `drop`. Each command declares `CommandMatchingMode` (`Partial` for player commands, `Full` for admin commands). Static aliases always win before prefix resolution, preserving `d` → `down`. Ambiguous prefixes produce a complete, non-truncated disambiguation list.
- Introduces `IVerbRegistry` as a read-only seam over the command namespace — consumed by `HelpCommand` and available for future tab-completion without coupling to the full dispatcher. `GetPrefixCandidates` is the single location for the prefix-filter logic; both `CommandDispatcher` and `HelpCommand` call it.
- Promotes `IArgumentResolver` from an empty stub to a real interface with `GetCandidates(CommandArgumentResolverContext)` and wires the call-site in `CommandArgumentParser`. No concrete resolver ships until slice 6.
- `HelpCommand` now uses `IVerbRegistry` for two-phase lookup so `help lo` resolves identically to dispatching `lo`. Both `help <verb>` and `commands` display each command's declared aliases so players can discover shorthand forms.
- All 14 existing commands gain `MatchingMode`: 10 player commands → `Partial`, 4 admin commands → `Full`.
- Closes the spec/code review loop in `implement-use-case` and `use-case-planner` skills so future slices enforce both gates automatically.

## Architecture gates

Both mandatory Phase 3 reviewer gates passed before this commit:
- **Spec-mode** — `architecture-reviewer` run against `docs/use-cases/command-prefix-matching.md`; two rounds to resolve 4 blocking findings (missing `06-commands.md` update obligation, incomplete Flow 3 prose commitment, Configuration surface misclassification, untraceable command count).
- **Code-mode** — `architecture-reviewer` run against the full diff; verdict `APPROVE WITH NITS`; three nits resolved (README status mismatch, `docs/reference/commands.md` catalog not updated, duplicate prefix-filter LINQ consolidated into `IVerbRegistry.GetPrefixCandidates`).

## Docs updated

- `docs/use-cases/command-prefix-matching.md` — new, status `implemented`
- `docs/architecture/06-commands.md` — `ICommand` shape updated (`MatchingMode`), `IVerbRegistry` and two-phase resolution rules documented
- `docs/architecture/06-flows.md` — Flow 3 mermaid redrawn with prefix-resolution branch; step 2 and step 8 prose corrected (`Verb` = resolved canonical name, not raw typed input)
- `docs/reference/commands.md` — `MatchingMode` field added to all 14 entries; `IVerbRegistry` noted in preamble
- `.claude/skills/add-command/SKILL.md` — `MatchingMode` added as step 4 (required member); admin command example updated
- `.claude/agents/use-case-planner.md` — mandatory spec-mode reviewer gate added to output section
- `.claude/skills/implement-use-case/SKILL.md` — mandatory code-mode reviewer gate added as step 9

## Test plan

- [x] `lo` dispatches `look`; `l` dispatches `look` (alias wins before prefix pool)
- [x] `d` dispatches `down` (static alias, never reaches prefix resolution)
- [x] `di` returns unknown command — admin `dig` requires full match (`Full` mode)
- [ ] Two player commands sharing a prefix produce a disambiguation list showing all matches
- [x] `help lo` displays help for `look` with aliases shown; `help ?` resolves via alias
- [x] `commands` output shows `look  (aliases: l)` and `help  (aliases: ?)`
- [x] Build is green: `dotnet build Hedron.sln`

🤖 Generated with [Claude Code](https://claude.com/claude-code)