### PR TITLE
Slice 5a spec: bare-bones content spawning + architecture hardening

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -28,6 +28,7 @@ The point of this mode is to catch architecture violations **before code exists*
    - SR-4 a referenced flow / catalog entry doesn't exist or won't be updated
    - SR-5 a load-bearing open question is being deferred
 5. Cross-check the doc's **Cross-cutting surfaces stressed** and **Flows introduced or modified** sections: are they honest and complete given what the spec actually describes? A surface the spec clearly exercises but doesn't list is itself a finding.
+6. **Agent/skill audit (INV-20).** Glob `.claude/skills/*.md` and `.claude/agents/*.md`. For each file, check whether the spec introduces, extends, or contradicts a pattern that skill/agent advises. Flag any file that would give incorrect guidance if the spec ships without updating it. This is a blocking finding — stale tooling produces violations on the next slice.
 
 A spec-mode review blocks `implement-use-case` until blocking findings are resolved in the doc.
 
@@ -44,6 +45,7 @@ A spec-mode review blocks `implement-use-case` until blocking findings are resol
 6. **Pattern-repetition sweep (INV-19).** Any hand-rolled pattern in ≥3 new/modified files (arg parsing, privilege checks, output formatting, `[Persistent]` loops) → framework-promotion finding.
 7. **Flows-doc audit (INV-17).** For each flow in the doc's "Flows introduced or modified," open `06-flows.md` and verify body **and** mermaid match the as-built code.
 8. **Catalog audit (INV-16).** New/changed component, system, handler, event → matching `docs/reference/*.md` updated; use-case status/deviations updated.
+9. **Agent/skill audit (INV-20).** Glob `.claude/skills/*.md` and `.claude/agents/*.md`. For each changed architectural pattern in the diff, check whether any skill or agent file advises that pattern and would become stale or misleading. Flag as a blocking finding with a suggested resolution.
 
 ## Output format
 
@@ -54,10 +56,14 @@ A spec-mode review blocks `implement-use-case` until blocking findings are resol
 <APPROVE | APPROVE WITH NITS | NEEDS CHANGES>
 
 ### Blocking
-- <INV-n | SR-n> — <doc§ or file:line> — one-line reason + the fix
+- <INV-n | SR-n> — <doc§ or file:line> — one-line reason
+  Suggested resolution: <what to change — do not apply; confirm with user first>
 
 ### Non-blocking
-- <id> — <where> — concern
+- <id> — <where> — concern + suggested resolution if any
+
+### Agent/skill updates required
+- <.claude/path> — what needs updating and why (INV-20)
 
 ### Doc/flow drift
 - <doc path> — what's stale
@@ -68,8 +74,11 @@ A spec-mode review blocks `implement-use-case` until blocking findings are resol
 
 Lead with one of the three verdict words verbatim so the caller can branch on it. No violations: say so in one sentence. Do not pad. Do not re-explain a rule unless asked *why*.
 
+**All findings are advisory.** The reviewer reports and suggests; it does not apply changes. Every suggested resolution must be confirmed by the user before the calling session makes any edit. If the user approves a suggestion, the calling session applies it — the reviewer does not.
+
 ## What you are NOT
 
+- Not an editor — never modify files, never apply fixes. Suggest only.
 - Not a style/naming reviewer (beyond INV-6 event naming).
 - Not a correctness/test-logic reviewer.
 - Not a performance reviewer (unless a hot path bypasses or abuses the bus).

--- a/.claude/agents/use-case-planner.md
+++ b/.claude/agents/use-case-planner.md
@@ -28,6 +28,11 @@ You do not write the C# code — that's for the user or the implement-use-case s
    - **Acknowledged debt** — gap with rationale; tracked in `backlog.md`.
 
    This audit is what would have caught the slice-2 command-framework miss. The bar for honesty is: if you wrote *any* code that hand-rolls something the architecture hasn't specified, the surface is **gap exposed**.
+
+   **Persistence opt-in audit (mandatory sub-check).** For every component this slice introduces *or touches*, explicitly confirm its `[Persistent]` status:
+   - Does it hold world or character state that must survive a server restart? → must be `[Persistent]`.
+   - Is it transient (session reference, cached value, frame-only flag)? → must omit `[Persistent]`, with a one-sentence rationale.
+   - Existing components that were previously untagged are not exempt — if this slice reads or writes a component that lacks `[Persistent]` and that omission would cause data loss, surface it as a **Gap exposed** finding, not a silent assumption. Close it in this slice or create an explicit backlog entry.
 8. **Flows audit (required).** List every canonical flow in `06-flows.md` this slice introduces, replaces, or extends. The implementation slice's PR must update `06-flows.md` to match — the architecture-reviewer agent will block on drift. If the slice introduces a recurring flow that doesn't yet have a canonical entry, add a `06-flows.md` flow specification to the slice scope.
 9. **Produce the implementation plan** as a checklist grouped by layer:
    - **New components** (with shape) — mark reused ones

--- a/.claude/skills/add-component/SKILL.md
+++ b/.claude/skills/add-component/SKILL.md
@@ -37,10 +37,15 @@ Do **not**:
 ## Steps
 
 1. Create the file at the chosen location.
-2. Decide the archetype set that requires this component. Update `Core/ECS/ArchetypeRegistry.cs` so the right archetypes include it as required or optional.
-3. If it's a shared component, add a one-line row to [docs/reference/components.md](../../../docs/reference/components.md) with its shape and owner.
-4. If any existing system will now read/write it, note the dependency in [docs/reference/systems.md](../../../docs/reference/systems.md).
-5. Archetype composition docs: update [docs/reference/archetypes.md](../../../docs/reference/archetypes.md) if a standard archetype changes.
+2. **Decide persistence opt-in.** Explicitly answer: does this component's data need to survive a server restart?
+   - **Yes → add `[Persistent]`** on the class. `PersistenceSystem` will save and restore it automatically.
+   - **No → omit `[Persistent]`** and document why (e.g. transient session reference, frame-only state, derived/recomputed on load).
+   - **Unsure?** Default to `[Persistent]` for any component that holds world or character state a player or designer authored. Default to omitting it for components that hold runtime-only references (`Session`, timers, cached lookups). If the decision is non-obvious, call it out explicitly in the use-case doc's Cross-cutting surfaces section.
+   - **Existing components touched by this work** must have their `[Persistent]` status confirmed as part of this step, not assumed.
+3. Decide the archetype set that requires this component. Update `Core/ECS/ArchetypeRegistry.cs` so the right archetypes include it as required or optional.
+4. If it's a shared component, add a one-line row to [docs/reference/components.md](../../../docs/reference/components.md) with its shape and owner. Include the persistence decision (`[Persistent]` or "transient — reason").
+5. If any existing system will now read/write it, note the dependency in [docs/reference/systems.md](../../../docs/reference/systems.md).
+6. Archetype composition docs: update [docs/reference/archetypes.md](../../../docs/reference/archetypes.md) if a standard archetype changes.
 
 ## Anti-patterns
 

--- a/.claude/skills/add-event/SKILL.md
+++ b/.claude/skills/add-event/SKILL.md
@@ -5,7 +5,7 @@ description: Use when adding a new event type to the event bus. Covers naming (p
 
 # Add an Event
 
-Events are past-tense facts published to the event bus. Handlers subscribe by priority and react. Services *never* publish events — only handlers do.
+Events are past-tense facts published to the event bus. Handlers subscribe by priority and react. Systems *never* publish events — only Initiators (commands, scheduled ticks) and Handlers do.
 
 Authoritative rules: [docs/architecture/03-events.md](../../../docs/architecture/03-events.md) · pitfalls: [docs/architecture/04-pitfalls.md](../../../docs/architecture/04-pitfalls.md).
 
@@ -33,14 +33,14 @@ Rule: "enrich" means capture **state at publish time that subscribers can't reco
 1. Pick the module that owns the event: `Core/Modules/<Feature>/Events/<X>Event.cs`.
 2. Name past-tense, specific.
 3. Thin payload by default; enrich only for state that changes before handlers run.
-4. The **publishing handler** (not a service) calls `eventBus.Publish(new XEvent(...))`.
+4. The **publishing Initiator or Handler** (not a service/system) calls `eventBus.Publish(new XEvent(...))`. Initiators (commands, scheduled ticks) publish when the event is a direct consequence of their action; Handlers publish when the event is a downstream reaction to a prior event.
 5. Register subscribers with priorities in each subscribing feature's `AddXModule(IServiceCollection)` extension (e.g. `Core/Modules/<Feature>/<Feature>Module.cs`).
 6. Add the event to [docs/architecture/03-events.md](../../../docs/architecture/03-events.md) under its category (combat, movement, inventory, etc.).
 7. If a use case now produces this event, update its "Events fired" section in `docs/use-cases/<relevant>.md`.
 
 ## Common mistakes
 
-- **Service publishing an event.** Services return results; the handler that called the service publishes.
+- **Service/system publishing an event.** Systems return results; the Initiator (command or scheduled tick) or Handler that called the system publishes.
 - **Logic in an event handler that belongs in a system.** Handlers call systems; systems compute. Keep handlers thin.
 - **Over-enriched payloads.** If three handlers each read `player.Name` from the event payload, that's fine. If the payload carries the entire player snapshot, redesign.
 - **Missing order intent.** If handler B needs B's effect to happen after handler A's, set priorities — don't rely on registration order.

--- a/docs/architecture/01-layers.md
+++ b/docs/architecture/01-layers.md
@@ -46,7 +46,7 @@ The four numbered layers below (Handlers → Domain Systems → Core Systems →
 
 **Characteristics:**
 - Thin. A command is **≤ 30 lines**; if it grows, the logic belongs in a domain system.
-- No gameplay logic, no multi-step branching. "Publish A, then call system X, then conditionally publish B" is a *handler*, not an initiator — move it.
+- No game-rule logic, no conditional branching on game state. "Publish A, then call system X, then **conditionally** publish B based on a game rule" is a *handler*, not an initiator — move it. Publishing multiple events is fine when every event is an unconditional, direct consequence of the command's action (e.g. `dig` always creates the room *and* always moves the player — both events belong in the command). The test: would extracting this into a handler reveal any game logic, or just re-publish mechanically? If the latter, keep it in the command.
 - Parses/gathers input, resolves targets via domain-system lookups (`InventorySystem.FindByName`, `LocationSystem.FindInRoom`), calls the relevant domain system, publishes the resulting event(s).
 - May publish events. This is the tier's defining permission, shared only with Handlers.
 
@@ -59,7 +59,8 @@ The four numbered layers below (Handlers → Domain Systems → Core Systems →
 
 **Anti-patterns:**
 - Game rules inside a command (`if armor > threshold…`) — belongs in a domain system.
-- Multi-step orchestration inside a command — that's a handler.
+- Conditional event routing inside a command (`if condition → publish A, else → publish B`) — that's a handler.
+- Unconditional sequential publishing is not the same thing: a command that always publishes A then B as direct consequences of its action is fine.
 - A domain/core system reaching for the event bus to "save a hop" — forbidden; return a result and let the initiator or a handler publish.
 
 ### Heartbeat / scheduled-tick — forward design constraints

--- a/docs/architecture/checklist.md
+++ b/docs/architecture/checklist.md
@@ -32,7 +32,7 @@
 
 ## C. Initiators (commands & heartbeat)
 
-**INV-8 — Initiators are thin and rule-free.** Parse/gather → resolve target via a domain-system lookup → call the domain system → publish the resulting event(s). A command is ≤ 30 lines. No gameplay rules, no multi-step branching (that's a handler). Explanation: [01-layers.md](01-layers.md#initiators--entry-points).
+**INV-8 — Initiators are thin and rule-free.** Parse/gather → resolve target via a domain-system lookup → call the domain system → publish the resulting event(s). A command is ≤ 30 lines. No game-rule logic; no conditional branching on game state to decide which events to fire (that's a handler). Publishing multiple events is acceptable when every event is an unconditional, direct consequence of the command's action — the test is: "would a handler here contain any game logic, or just mechanically re-publish?" If the latter, keep it in the command. Explanation: [01-layers.md](01-layers.md#initiators--entry-points).
 
 **INV-9 — Initiators never call Handlers directly.** An initiator publishes an event; the bus routes it. Explanation: [01-layers.md](01-layers.md).
 
@@ -73,6 +73,10 @@ When reviewing a use-case doc *before* implementation, beyond the per-INV spec c
 - **SR-3 — The spec contradicts an established skill or convention.** e.g. it specifies a command shape that the `add-command` skill forbids. One of them is wrong; resolve before implementation.
 - **SR-4 — A referenced flow or catalog entry doesn't exist or won't be updated.** The "Flows introduced or modified" / "Cross-cutting surfaces stressed" sections name flows/surfaces; verify each is real and that the spec commits to updating it.
 - **SR-5 — An open question is load-bearing.** If a deferred decision determines whether an INV is satisfiable, it is not deferrable — it blocks implementation.
+
+**INV-20 — Agent tooling stays current with architecture.** Any slice that introduces, clarifies, or changes an architectural rule or layer pattern updates the relevant `.claude/skills/*.md` and `.claude/agents/*.md` files in the same PR. Skills and agents are developer tooling — stale guidance produces the next slice's violations.
+- *Spec:* does the use-case introduce or depend on a pattern any existing skill advises? If the spec changes that pattern, commit to updating the relevant skill file.
+- *Code:* do changed files establish a pattern not yet reflected in any skill? Does any change contradict guidance in an existing skill or agent?
 
 ---
 

--- a/docs/reference/handlers.md
+++ b/docs/reference/handlers.md
@@ -27,7 +27,7 @@ Ask:
 **Responsibilities:** apply death penalties; respawn; rest-state transitions; rest recovery; unconscious state.
 **Uses:** `IDeathSystem`, `IVisibilitySystem`, `INotificationSystem`, `ILocationSystem`, `IAttributeSystem`
 
-### PlayerMovementHandler
+### PlayerMovedHandler
 **Events:** `PlayerMovedEvent`, `PlayerTeleportedByAdminEvent` (Phase 3 slice 2), `PlayerEnterRoomEvent`, `PlayerExitRoomEvent`
 **Responsibilities:** translate a successful move (player-initiated or admin-teleport) into the visible effects: departure broadcast on source room, arrival broadcast on destination, `look` to the moved player; fire movement triggers (traps, ambushes). Both move and teleport events funnel through the same private helper to avoid drift; teleport uses direction-agnostic flavour text.
 **Uses:** `IMovementSystem`, `ILocationSystem`, `IVisibilitySystem`, `IBroadcastSystem`

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -46,6 +46,16 @@ Acknowledged debt from Phase 3 slice 4 ([`../use-cases/output-framework.md`](../
 
 `CommandDispatcher` carries five injected dependencies and owns authorization, parsing, output, event publication, and exception trapping (spec-mode review smell S1). A middleware/pipeline chain would isolate these concerns. Deferred from slice 3 to avoid ballooning the 12-command refactor. Revisit when a sixth concern would be added to the dispatcher, or if testing the dispatcher becomes painful.
 
+### 🔵 Locale enhancements
+
+Deferred from slice 5a (bare-bones content spawning). Three related capabilities held together because they share a data-model decision:
+
+- **Room-to-area membership** — a `RoomComponent.AreaId` field or a dedicated component linking each room to an `AreaComponent` entity. `RoomCreatedByAdminEvent` and `mkroom` logic would eventually set area membership at creation time.
+- **Coordinate system** — a `CoordinateComponent` (`int X, int Y, int Z`) on room entities, enabling map generation and cardinal distance queries.
+- **Area-level properties** — PvP flag, respawn rate, ambient lighting — currently on `AreaComponent` but not yet instantiated or enforced by any slice.
+
+These are deferred together because adding coordinates without area membership is premature, and area properties without coordinates have limited value. Revisit when the mob-wandering slice (slice 8) or a mapping command surfaces a concrete need.
+
 ### 🔵 Archetype catalogue refresh
 
 The archetype list in [`../reference/archetypes.md`](../reference/archetypes.md) was written against the old component shapes. Re-audit once a few Phase 3 slices have landed real components.

--- a/docs/use-cases/bare-bones-content-spawning.md
+++ b/docs/use-cases/bare-bones-content-spawning.md
@@ -1,0 +1,337 @@
+# Use Case: Bare-Bones Content Spawning
+
+**Status:** planned
+**Actors:** Administrator
+**Module:** `Core/Modules/Admin/` (commands, events, handler extensions); new domain system `Core/Modules/Admin/Systems/RoomBuilderSystem.cs`
+
+---
+
+## Description
+
+Provides in-game admin commands (`dig`, `set`) to create and edit room content at runtime without pre-authored YAML files. `dig <direction> [name]` creates a new room entity in the named direction from the administrator's current position, wires bidirectional exits, and auto-moves the administrator into the new room. `set <property> <value>` mutates the name or description of the room the administrator is currently standing in. Both commands delegate domain logic to a new `IRoomBuilderSystem` so the same operations can be reused by a future in-game editor without a live session. This slice unblocks functional testing of slices 6+ (items, mobs) by letting administrators build testable room networks at runtime rather than pre-authoring YAML.
+
+The `dig` command introduced in slice 2 (`dig <direction> <targetRoomBlueprintId>`) is **replaced** by the new behaviour described here. The old "connect to an existing room" path is dropped in this slice.
+
+---
+
+## Preconditions
+
+- Slices 1–5 are complete. The following exist and are not re-introduced by this slice:
+  - `IAdminAuthorizer`, `AdminRequirement` privilege gate (slice 2).
+  - `spawn`, `teleport`/`tp`, `dig`, `reload` commands (slice 2); `dig` is replaced in this slice.
+  - `EntitySpawnedByAdminEvent`, `PlayerTeleportedByAdminEvent`, `RoomExitAuthoredByAdminEvent`, `ContentReloadedEvent` (slice 2). `RoomExitAuthoredByAdminEvent` remains defined but `dig` no longer publishes it (see Design Notes).
+  - `AdminAuditHandler` (slice 2) — subscribes to admin events; extended here.
+  - `PersistenceHandler` — marks entities dirty on admin events; extended here.
+  - `PlayerMovedHandler` — handles `PlayerMovedEvent` with broadcast + look; unchanged.
+  - `ITemplateRegistry`, `RoomTemplate`, `EntityService`, `IEventBus`.
+  - `RoomComponent` (`Name`, `Description`, `Exits: Dictionary<Direction, uint>`).
+  - `LocationComponent` (`RoomEntityId: uint`, `[Persistent]`).
+  - `BlueprintComponent` (`BlueprintId: string`, `[Persistent]`).
+  - Full command framework (slice 3): `ICommand`, `CommandContext`, `CommandArgument`, `CommandArgumentKind`, `CommandMatchingMode`, `AdminRequirement`.
+  - Output framework (slice 4): `IOutputWriter`, `PlainMessage`, `OutputSeverity`.
+  - Account/character system (slice 5): `AccountComponent`, `CharacterComponent`, `PlayerComponent`.
+- The administrator is connected with a fully bound session (`PlayerEntityId != 0`) and has admin rights (`IAdminAuthorizer.IsPrivileged` returns `true`).
+- The administrator is standing in a room entity that has a `RoomComponent` and a `LocationComponent`.
+- Entity IDs are `uint` (runtime). Blueprint IDs are `string` (designer-facing, e.g. `room.adhoc.<shortid>`).
+
+---
+
+## Postconditions
+
+### After `dig <direction> [name]`
+
+- A new room entity exists in `EntityService` with `RoomComponent` (Name, Description), and `BlueprintComponent` (auto-generated id `room.adhoc.<shortid>`).
+- The new room is registered in `ITemplateRegistry` via a minimal `RoomTemplate`.
+- The source room's `RoomComponent.Exits[direction]` points to the new room entity id.
+- The new room's `RoomComponent.Exits[Opposite(direction)]` points to the source room entity id.
+- Both source and new room are marked dirty in `IPersistenceSystem`.
+- A `RoomCreatedByAdminEvent` is published.
+- The administrator has been moved into the new room; the existing `PlayerMovedHandler` has fired broadcast + look.
+- If an exit already existed in the named direction, the command fails with a clear error message; no room is created.
+
+### After `set <property> <value>`
+
+- `RoomComponent.Name` or `RoomComponent.Description` on the administrator's current room is updated to `value`.
+- The room entity is marked dirty in `IPersistenceSystem`.
+- A `RoomPropertySetByAdminEvent` is published.
+- The administrator receives a one-line confirmation.
+
+---
+
+## Main Flow
+
+### Flow A — `dig <direction> [name]`
+
+1. **Privilege gate.** `CommandDispatcher` evaluates `AdminRequirement` via `IAuthorizationChecker`. Non-privileged sessions receive a rejection `PlainMessage` and the command body does not execute.
+2. **Conflict check.** `DigCommand` reads the invoker's `LocationComponent.RoomEntityId`, retrieves the `RoomComponent` for that entity, and checks whether `Exits` already contains the requested `Direction`. If yes, writes a `PlainMessage` error ("An exit already exists in that direction.") and returns.
+3. **Room creation.** The command calls `IRoomBuilderSystem.CreateRoom(name)` (default name `"New Room"` if omitted). `RoomBuilderSystem` generates a unique blueprint id (see Design Notes), calls `EntityService.CreateEntity()`, attaches `RoomComponent` and `BlueprintComponent`, registers a minimal `RoomTemplate` with `ITemplateRegistry`, and returns `RoomCreationResult(RoomEntityId, BlueprintId)`.
+4. **Exit wiring.** The command calls `IRoomBuilderSystem.LinkExits(sourceRoomId, direction, newRoomId, bidirectional: true)`. `RoomBuilderSystem` mutates `RoomComponent.Exits` on both rooms and updates both in-memory `RoomTemplate` exit maps.
+5. **Event publication.** The command publishes `RoomCreatedByAdminEvent(AdminEntityId, NewRoomEntityId, BlueprintId, SourceRoomEntityId, Direction, BidirectionalLinkCreated: true)` then publishes `PlayerMovedEvent(AdminEntityId, SourceRoomEntityId, NewRoomEntityId)`. Both are unconditional, direct consequences of `dig` — no game-rule branch separates them. The command then writes a confirmation `PlainMessage` (e.g. `"Room 'New Room' (room.adhoc.a1b2c3) created to the north."`).
+6. **`AdminAuditHandler` fires (priority 80).** Writes a structured log entry for `RoomCreatedByAdminEvent`.
+7. **`PersistenceHandler` fires (priority 90).** Marks both the new room and the source room dirty.
+8. **`PlayerMovedHandler` fires** on `PlayerMovedEvent`. Handles departure broadcast on the source room, arrival broadcast on the new room, `look` sent to the administrator.
+
+### Flow B — `set <property> <value>`
+
+1. **Privilege gate.** Same as Flow A step 1.
+2. **Argument parsing.** `CommandDispatcher` parses `property` as a `Token` arg (`name` or `description`) and `value` as a `RestOfLine` arg. If `property` is unrecognized, the parser writes a usage hint and publishes `CommandExecutedEvent(ParseFailed)`.
+3. **Mutation.** The command calls `IRoomBuilderSystem.SetRoomName(roomId, value)` or `IRoomBuilderSystem.SetRoomDescription(roomId, value)` against the invoker's current `LocationComponent.RoomEntityId`.
+4. **Event publication.** The command publishes `RoomPropertySetByAdminEvent(AdminEntityId, RoomEntityId, PropertyName, NewValue)`.
+5. **Handlers fire.** `AdminAuditHandler` (priority 80) writes a structured log entry. `PersistenceHandler` (priority 90) marks the room dirty.
+6. **Confirmation.** The command writes a `PlainMessage` (e.g. `"Room name set to 'Market Square'."`) via `context.Output`.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Payload | Purpose |
+|---|---|---|---|
+| `RoomCreatedByAdminEvent` | `DigCommand` | `uint AdminEntityId, uint NewRoomEntityId, string BlueprintId, uint SourceRoomEntityId, Direction Direction, bool BidirectionalLinkCreated` | Triggers persistence dirty-mark on both rooms; audit log; future map/editor hooks. |
+| `RoomPropertySetByAdminEvent` | `SetCommand` | `uint AdminEntityId, uint RoomEntityId, string PropertyName, string NewValue` | Triggers persistence dirty-mark on the room; audit log. |
+| `PlayerMovedEvent` | `DigCommand` (auto-move leg) | existing payload — `uint EntityId, uint FromRoomEntityId, uint ToRoomEntityId` | Consumed by existing `PlayerMovedHandler`; published directly by the command because auto-move is an unconditional consequence of `dig`. |
+
+**Note on `RoomExitAuthoredByAdminEvent`:** This event was published by the slice-2 `dig` command. The new `dig` publishes `RoomCreatedByAdminEvent` instead. `RoomExitAuthoredByAdminEvent` remains defined (future commands may use it for connecting existing rooms) but is no longer fired by `dig`. Any handler that subscribed only because of `dig` must be reviewed — `PersistenceHandler` and `AdminAuditHandler` will stop subscribing to it for `dig`-sourced mutations and subscribe to `RoomCreatedByAdminEvent` instead.
+
+---
+
+## Systems / Handlers Involved
+
+### IRoomBuilderSystem (new — domain system)
+
+**Location:** `Core/Modules/Admin/Systems/RoomBuilderSystem.cs`
+
+```
+IRoomBuilderSystem
+  RoomCreationResult CreateRoom(string name, string description = "")
+  void LinkExits(uint sourceRoomId, Direction direction, uint targetRoomId, bool bidirectional)
+  void SetRoomName(uint roomId, string name)
+  void SetRoomDescription(uint roomId, string description)
+```
+
+`RoomCreationResult` is a readonly record struct: `(uint RoomEntityId, string BlueprintId)`.
+
+**`CreateRoom`** must: call `EntityService.CreateEntity()`; attach `RoomComponent(Name, Description = "")` and `BlueprintComponent(BlueprintId = "room.adhoc.<shortid>")`; register a minimal `RoomTemplate` with `ITemplateRegistry`; return `RoomCreationResult`. Does not publish events.
+
+**`LinkExits`** must: set `sourceRoom.Exits[direction] = targetRoomId`; if `bidirectional`, set `targetRoom.Exits[Opposite(direction)] = sourceRoomId`; update the in-memory `RoomTemplate` exits on both rooms (same pattern as the old `DigCommand`). Does not publish events.
+
+**`SetRoomName` / `SetRoomDescription`** must: mutate `RoomComponent.Name` or `.Description` directly. Do not publish events — that is the command's responsibility.
+
+**Rationale for extraction.** Room creation logic must be reusable without a live player session (a future in-game editor will call the same operations). Commands are thin orchestrators; systems hold domain logic. One builder system per content type is the pattern; a `IWorldBuilderFacade` coordinator may be introduced when multi-type operations need shared context (deferred to when evidence of need exists).
+
+**Dependencies:** `EntityService`, `ITemplateRegistry`, `ILogger<RoomBuilderSystem>`.
+
+### DigCommand (replaces slice 2 implementation)
+
+**Location:** `Core/Modules/Admin/Commands/DigCommand.cs`
+**Verb:** `dig`
+**Aliases:** none
+**Matching mode:** `CommandMatchingMode.Full`
+**Required privilege:** `AdminRequirement`
+**Argument schema:**
+  - `direction` — `Token`, required, `Direction` enum (prefix matching applies: `n`/`no`/`nor` → `North`)
+  - `name` — `RestOfLine`, optional (default `"New Room"` when absent or blank)
+
+**Body:** conflict check → `IRoomBuilderSystem.CreateRoom` → `IRoomBuilderSystem.LinkExits` → publish `RoomCreatedByAdminEvent` → publish `PlayerMovedEvent` → write confirmation `PlainMessage`. Both events are unconditional direct consequences of `dig`; no game-rule branch separates them (see INV-8).
+
+### SetCommand (new)
+
+**Location:** `Core/Modules/Admin/Commands/SetCommand.cs`
+**Verb:** `set`
+**Aliases:** none
+**Matching mode:** `CommandMatchingMode.Full`
+**Required privilege:** `AdminRequirement`
+**Argument schema:**
+  - `property` — `Token`, required, accepted values: `name`, `description`
+  - `value` — `RestOfLine`, required
+
+**Body:** resolve invoker's current room → `IRoomBuilderSystem.SetRoomName` or `SetRoomDescription` → publish `RoomPropertySetByAdminEvent` → write confirmation `PlainMessage`.
+
+### AdminAuditHandler (extended)
+
+New subscriptions: `RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent`. Priority 80 (unchanged). Writes one structured-log entry per event with stable event name `AdminCommandExecuted`.
+
+### PersistenceHandler (extended)
+
+New subscriptions:
+- `RoomCreatedByAdminEvent` — marks `NewRoomEntityId` and `SourceRoomEntityId` dirty.
+- `RoomPropertySetByAdminEvent` — marks `RoomEntityId` dirty.
+
+Priority 90 (unchanged).
+
+### PlayerMovedHandler (no change)
+
+The auto-move in `dig` publishes the existing `PlayerMovedEvent`. The handler handles it normally — no extension required.
+
+---
+
+## Content Tooling Impact
+
+This slice **is** content tooling. Every room created via `dig` is immediately live and addressable.
+
+**Blueprint ID scheme.** Auto-generated blueprint ids use the format `room.adhoc.<shortid>` where `<shortid>` is a short (6–8 char) alphanumeric unique string generated at creation time (not a sequential integer, to remain stable if entities are deleted and recreated). The generated id is shown in the confirmation message so the administrator can reference the room by blueprint id for debugging.
+
+**Admin commands introduced or replaced:**
+
+| Verb | Purpose | Status |
+|---|---|---|
+| `dig <direction> [name]` | Create a new room in the named direction; auto-move invoker into it | Replaces slice-2 `dig` |
+| `set <property> <value>` | Set `name` or `description` on the current room | New |
+
+**`TemplateRegistry` entries.** `IRoomBuilderSystem.CreateRoom` registers a `RoomTemplate` entry for every new room it creates. The template carries only `Name` and `Description` in this slice; exits are added by `LinkExits`. This ensures a same-session `reload` does not orphan the new entity.
+
+**Inspectability.** An administrator can inspect a newly created room by simply moving into it (via `dig`) or teleporting to it (via `tp <blueprintId>`) and reading the room description. `look` (existing command) renders `RoomComponent.Name`, `Description`, and `Exits`. No additional inspection command is required in this slice.
+
+**No YAML authoring required.** Rooms created via `dig` exist only in memory and in the persistence layer (`data/entities/entity-{id}.json`). They are not written to `data/content/`. A future "save room to YAML" command is tracked in the backlog as an extension to the existing `dig` write-back debt.
+
+---
+
+## Cross-Cutting Surfaces Stressed
+
+### Commands — **Adequate**
+
+The full command framework (slice 3) covers `DigCommand` and `SetCommand` without modification. `RestOfLine` args, `Token` args, `AdminRequirement`, and `CommandMatchingMode.Full` all exist. `Direction` enum prefix matching was validated in slice 3a.
+
+### Output — **Adequate**
+
+`PlainMessage` via `IOutputWriter` covers all output in this slice (confirmation lines, error rejections). No new `IOutputMessage` shapes are needed.
+
+### Persistence — **Adequate**
+
+`IPersistenceSystem.MarkDirty` is the correct dirty-tracking seam. The extension to `PersistenceHandler` follows the established pattern (subscribe to new admin events, call `MarkDirty`). `RoomComponent` is currently **not** tagged `[Persistent]`; only `BlueprintComponent` and `LocationComponent` are. This is pre-existing — any room mutations survive via `BlueprintComponent` identity and the fact that `RoomComponent` data is seeded from `RoomTemplate` on reload. However, `SetRoomName` / `SetRoomDescription` mutate `RoomComponent` directly and those mutations are **not** `[Persistent]`. This is acknowledged debt (see Design Notes).
+
+### Event bus — **Adequate**
+
+Two new past-tense events (`RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent`) follow the existing thin-payload pattern. The event bus interface is unchanged.
+
+### ECS queries — **Adequate**
+
+`EntityService.HasComponent<RoomComponent>`, `EntityService.GetComponent<LocationComponent>`, and `EntityService.GetComponent<RoomComponent>` are the query patterns used. All exist.
+
+### Broadcast — **Adequate**
+
+The auto-move in `dig` uses `PlayerMovedEvent` → `PlayerMovedHandler` → `IBroadcastSystem`. No direct `IBroadcastSystem` calls are made from new code; the existing handler owns that.
+
+### Time — **Not exercised.** No time-based logic in this slice.
+
+### Content templates — **Adequate**
+
+`ITemplateRegistry.Register` and the minimal `RoomTemplate.Apply` pattern are established in slice 2. `RoomBuilderSystem` calls `Register` with a programmatically constructed `RoomTemplate`. No YAML deserialization path is exercised.
+
+### Configuration — **Adequate**
+
+No new configuration keys. The admin command framework reads `Admin:PrivilegedNames` (existing).
+
+### Sessions — **Adequate**
+
+`CommandContext.Session` provides `PlayerEntityId` for all invoker resolution. No new session state.
+
+### Modules — **Adequate**
+
+`AdminModule.AddAdminModule(IServiceCollection)` is extended to register `IRoomBuilderSystem` (singleton) and the two updated/new commands (`DigCommand` replacing the old, `SetCommand` new). No new module entry-point.
+
+### `RoomComponent` persistence — **Resolved in this slice**
+
+`RoomComponent` is tagged `[Persistent]` by this slice (pre-existing gap from slice 2, closed here). `PersistenceSystem` will now save and restore `Name`, `Description`, and `Exits` on every room entity. Ad-hoc rooms created by `dig` survive server restart: `PersistenceBootstrap` hydrates `RoomComponent` alongside `BlueprintComponent`; `WorldContentLoader`'s skip-on-conflict pass leaves the hydrated entity intact. `set` changes to `Name` / `Description` are flushed on the next `PersistenceFlushTimer` tick and restored correctly on restart.
+
+---
+
+## Flows Introduced or Modified
+
+### Flow 5 — Content reload (no change)
+
+`reload` is not modified by this slice. Ad-hoc rooms created by `dig` are registered in `ITemplateRegistry`; a subsequent `reload` will not seed them again (they already have live entities) and will not destroy them.
+
+### Flow 3 — Player command lifecycle (extended, not structurally changed)
+
+Two new commands plug into Flow 3 via the existing dispatcher. No change to the dispatcher's sequence diagram. The mermaid diagram in `06-flows.md` does not need updating — the command additions are registered commands, not dispatcher changes.
+
+### New flow — Admin room creation (`dig` command)
+
+A new canonical flow entry must be added to `06-flows.md` for this slice covering the `dig` command path. This is a recurring flow (every content-building session exercises it) that does not yet have a canonical entry.
+
+**Flow title:** Admin room creation (`dig`)
+**Trigger:** Privileged session sends `dig <direction> [name]`
+**Participants:** `TelnetSession`, `CommandDispatcher`, `IAuthorizationChecker`, `DigCommand`, `IRoomBuilderSystem`, `IEventBus`, `AdminAuditHandler`, `PersistenceHandler`, `PlayerMovedHandler`
+
+```mermaid
+sequenceDiagram
+    participant Sess as TelnetSession
+    participant CD as CommandDispatcher
+    participant Auth as IAuthorizationChecker
+    participant Cmd as DigCommand
+    participant RBS as IRoomBuilderSystem
+    participant Bus as IEventBus
+    participant Audit as AdminAuditHandler
+    participant PH as PersistenceHandler
+    participant PMH as PlayerMovedHandler
+
+    Sess->>CD: "dig north Garden"
+    CD->>Auth: IsSatisfied(AdminRequirement, session)
+    alt unauthorized
+        CD->>Sess: rejection PlainMessage
+    else authorized
+        CD->>Cmd: ExecuteAsync(CommandContext)
+        Cmd->>Cmd: check Exits[North] on current room
+        alt exit exists
+            Cmd->>Sess: error PlainMessage
+        else no exit
+            Cmd->>RBS: CreateRoom("Garden")
+            RBS-->>Cmd: RoomCreationResult(newRoomId, "room.adhoc.a1b2c3")
+            Cmd->>RBS: LinkExits(sourceId, North, newRoomId, true)
+            Cmd->>Bus: Publish(RoomCreatedByAdminEvent)
+            Bus->>Audit: HandleAsync (priority 80) → structured log
+            Bus->>PH: HandleAsync (priority 90) → MarkDirty(newRoomId, sourceId)
+            Cmd->>Bus: Publish(PlayerMovedEvent)
+            Bus->>PMH: HandleAsync → departure broadcast + arrival broadcast + look
+            Cmd->>Sess: confirmation PlainMessage
+        end
+    end
+```
+
+**PR must add this flow to `06-flows.md`** (new entry: Flow 8 — Admin room creation).
+
+---
+
+## Design Notes
+
+- **`RoomComponent` is tagged `[Persistent]` in this slice.** This resolves a gap carried from slice 2: previously `Name`, `Description`, and `Exits` were not saved to disk, meaning ad-hoc rooms lost their `RoomComponent` on restart and `set` changes were discarded. Tagging `[Persistent]` means `PersistenceSystem` saves all three fields; the blueprint-seeds-world skip-on-conflict pass correctly leaves fully-hydrated room entities alone. `RoomBuilderSystem.SetRoomName` and `SetRoomDescription` mutate the live `RoomComponent` only — no template mirroring is required for durability. `LinkExits` still mirrors to the in-memory `RoomTemplate` for same-session `reload` consistency.
+
+- **`RoomExitAuthoredByAdminEvent` is retained but no longer fired by `dig`.** The event remains in the codebase for potential future use (e.g. a command that connects two existing rooms). `AdminAuditHandler` and `PersistenceHandler` do not need to subscribe to it on behalf of `dig`-sourced mutations — `RoomCreatedByAdminEvent` covers that path. Any handler previously subscribing only to handle `dig`-sourced state changes should migrate to `RoomCreatedByAdminEvent`.
+
+- **`set` scope is intentionally narrow.** Only `RoomComponent.Name` and `RoomComponent.Description` are settable in this slice. Expanding `set` to target items, mobs, and other entity types is deferred to slices 6+ when those types exist. The command argument schema (`property` as a `Token`) makes expansion additive — new accepted values are added without changing the schema shape.
+
+- **Locale enhancements deferred.** Room-to-area membership (`RoomComponent.AreaId` or a dedicated component), coordinate system (`CoordinateComponent` with `int X, Y, Z`), and area-level properties (PvP, respawn, lighting) are deferred together. See `backlog.md` entry: `🔵 Locale enhancements`.
+
+- **Short-id generation and uniqueness.** `RoomBuilderSystem.CreateRoom` generates the `<shortid>` suffix for blueprint ids using 8 characters from Base36 of a `Guid`-derived value. Before calling `ITemplateRegistry.Register`, it calls `ITemplateRegistry.TryGet` to confirm the generated id is not already taken; on collision (statistically negligible but possible) it regenerates. This places uniqueness responsibility on the caller, not on `Register` — `TemplateRegistry.Register` performs a bare upsert and does not collision-guard, matching its existing contract. The generated id is shown in the confirmation message so the admin can use it with `teleport`.
+
+- **`mkitem` and `mkmob` are not in this slice.** In-game item and mob creation commands follow the same pattern as `IRoomBuilderSystem` (logic extracted into a domain system, command as thin orchestrator) and are deferred to the slices that introduce those entity types: `mkitem` lands with slice 6 (items + inventory) and `mkmob` lands with slice 8 (mobs + wandering). This slice intentionally limits scope to room authoring.
+
+- **`dig` drops the "connect to an existing room" path.** The slice-2 `dig <direction> <targetRoomBlueprintId>` syntax is replaced entirely. If an administrator needs to connect two existing rooms, a future `link <direction> <targetBlueprintId>` command (not in this slice) would publish `RoomExitAuthoredByAdminEvent` for that case.
+
+- **No `mkroom` standalone command.** A standalone orphan-room creation command was considered and dropped; `dig` covers the creation use case while immediately placing the administrator in context. An orphaned room with no exits is not useful without a follow-up dig anyway.
+
+---
+
+## Reference Catalog Updates (required in same PR)
+
+Per INV-16, every new or changed system, component, handler, or command must update the reference catalogs in the same PR. Checklist:
+
+| File | Change |
+|---|---|
+| `docs/reference/systems.md` | Add `IRoomBuilderSystem` entry (domain system, `Core/Modules/Admin/`, dependencies: `EntityService`, `ITemplateRegistry`) |
+| `docs/reference/components.md` | Update `RoomComponent` row: `Persisted?` → `yes` (tagged `[Persistent]` in this slice) |
+| `docs/reference/commands.md` | Replace `dig` entry (new schema: `dig <direction> [name]`, fires `RoomCreatedByAdminEvent`); add `set` entry |
+| `docs/reference/handlers.md` | Update `AdminAuditHandler` subscription list (add `RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent`); update `PersistenceHandler` subscription list (same two events) |
+| `docs/use-cases/README.md` | Add index row: `planned` \| `bare-bones-content-spawning.md` \| Phase 3 slice 5a |
+| `docs/architecture/06-flows.md` | Add Flow 8 (Admin room creation) with full mermaid diagram and index row |
+
+---
+
+## Related
+
+- [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) — slice 2; introduced `dig`, `spawn`, `teleport`, `reload`, `RoomExitAuthoredByAdminEvent`, `AdminAuditHandler`, `PersistenceHandler` extensions. This slice replaces `dig`'s behaviour and adds `set`.
+- [`persistence-substrate.md`](persistence-substrate.md) — slice 1; `PersistenceSystem` and `MarkDirty` pattern used by new `PersistenceHandler` subscriptions.
+- [`command-framework.md`](command-framework.md) — slice 3; `ICommand`, `CommandContext`, `CommandArgumentKind`, `AdminRequirement` used by both new commands.
+- [`output-framework.md`](output-framework.md) — slice 4; `PlainMessage` and `IOutputWriter` used for all command output.
+- [`account-character-creation.md`](account-character-creation.md) — slice 5; provides `PlayerComponent`, `CharacterComponent`, and the `PlayerEntityId`-bound session this slice's commands run under.
+- [`admin-privilege-elevation.md`](admin-privilege-elevation.md) — deferred; future persisted `AdminPrivilegeComponent` layer on top of the config allowlist used by `AdminRequirement`.


### PR DESCRIPTION
## Summary

- **New use-case doc** (`docs/use-cases/bare-bones-content-spawning.md`) for Phase 3 slice 5a — the pre-implementation spec that gates `implement-use-case`. Passed spec-mode architecture review (APPROVE WITH NITS, all nits resolved).
- **INV-8 clarified** in `checklist.md` and `01-layers.md`: the prohibition on initiators is game-rule logic and conditional branching, not unconditional sequential event publication. Adds a practical test for the distinction.
- **INV-20 added**: agent tooling (`.claude/skills/`, `.claude/agents/`) must stay current with architecture changes in the same PR as those changes.
- **Architecture reviewer hardened**: findings are now explicitly advisory; added agent/skill audit step to both review modes; "Not an editor" constraint added.
- **Use-case planner hardened**: persistence opt-in sub-check added to cross-cutting surface audit.
- **`add-component` skill**: explicit persistence opt-in decision step added.
- **`add-event` skill**: "only handlers publish" corrected to "Initiators or Handlers publish" throughout (INV-5 alignment).
- **`docs/reference/handlers.md`**: `PlayerMovementHandler` corrected to `PlayerMovedHandler` (matches live class).
- **Backlog**: `🔵 Locale enhancements` entry added (room-to-area membership, `CoordinateComponent`, area-level properties — deferred from slice 5a).

## What the slice 5a spec covers

- `dig <direction> [name]` — creates a new room, wires bidirectional exits, auto-moves admin in. Replaces slice-2 `dig <direction> <targetBlueprintId>`.
- `set <property> <value>` — sets `name` or `description` on the current room.
- `IRoomBuilderSystem` — new domain system holding creation logic outside command classes (reusable by a future editor without a live session).
- `RoomComponent` tagged `[Persistent]` — closes a slice-2 gap where room name/description/exits were lost on restart.
- `mkitem`/`mkmob` explicitly deferred to slices 6 and 8.
- Full reference catalog update checklist, Flow 8 mermaid, and locale enhancements backlog stub included in the spec.

## Test plan

- [x] Spec-mode architecture review: **APPROVE WITH NITS** — all nits resolved before this PR
- [x] `docs/use-cases/bare-bones-content-spawning.md` contains all required sections per `docs/use-cases/README.md` template
- [x] INV-8 test: confirm `DigCommand` body in the spec publishes two unconditional events with no game-rule branch between them
- [x] INV-20 test: confirm all `.claude/` files touched are consistent with the architecture changes in this PR
- [x] `PlayerMovedHandler` name matches `Core/Modules/Movement/Handlers/PlayerMovedHandler.cs`
- [x] No C# code changed — this is a spec + tooling PR only

🤖 Generated with [Claude Code](https://claude.com/claude-code)