### PR TITLE
feat: room YAML write path and orphan blueprint warnings

### DIFF
--- a/Core/Modules/Admin/Commands/DigCommand.cs
+++ b/Core/Modules/Admin/Commands/DigCommand.cs
@@ -9,6 +9,8 @@ using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
 using Hedron.Core.Modules.Admin.Systems;
 using Hedron.Core.Modules.Movement.Events;
+using Hedron.Core.Modules.World.Systems;
+using Hedron.Core.Modules.World.Templates;
 using Hedron.Core.Output;
 using Hedron.Core.Systems;
 
@@ -22,6 +24,8 @@ namespace Hedron.Core.Modules.Admin.Commands
     public sealed class DigCommand : ICommand
     {
         private readonly IRoomBuilderSystem _roomBuilder;
+        private readonly IRoomContentWriter _contentWriter;
+        private readonly ITemplateRegistry _templateRegistry;
         private readonly EntityService _entityService;
         private readonly IEventBus _eventBus;
         private readonly IPersistenceSystem _persistence;
@@ -47,11 +51,15 @@ namespace Hedron.Core.Modules.Admin.Commands
 
         public DigCommand(
             IRoomBuilderSystem roomBuilder,
+            IRoomContentWriter contentWriter,
+            ITemplateRegistry templateRegistry,
             EntityService entityService,
             IEventBus eventBus,
             IPersistenceSystem persistence)
         {
             _roomBuilder = roomBuilder;
+            _contentWriter = contentWriter;
+            _templateRegistry = templateRegistry;
             _entityService = entityService;
             _eventBus = eventBus;
             _persistence = persistence;
@@ -97,6 +105,17 @@ namespace Hedron.Core.Modules.Admin.Commands
                 sourceRoomId,
                 direction,
                 BidirectionalLinkCreated: true)).ConfigureAwait(false);
+
+            // Write YAML for the new room. Also re-write the source room's YAML because
+            // LinkExits added a new exit to its template's Exits map.
+            if (_templateRegistry.TryGet(result.BlueprintId, out var newTpl) &&
+                newTpl is RoomTemplate newRoomTpl)
+                await _contentWriter.WriteAsync(newRoomTpl).ConfigureAwait(false);
+
+            if (_entityService.TryGet<BlueprintComponent>(sourceRoomId, out var srcBp) &&
+                _templateRegistry.TryGet(srcBp.BlueprintId, out var srcTpl) &&
+                srcTpl is RoomTemplate srcRoomTpl)
+                await _contentWriter.WriteAsync(srcRoomTpl).ConfigureAwait(false);
 
             // Save both rooms immediately — admin content must be durable without waiting
             // for a flush cycle.

--- a/Core/Modules/Admin/Commands/SetCommand.cs
+++ b/Core/Modules/Admin/Commands/SetCommand.cs
@@ -8,6 +8,8 @@ using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
 using Hedron.Core.Modules.Admin.Systems;
+using Hedron.Core.Modules.World.Systems;
+using Hedron.Core.Modules.World.Templates;
 using Hedron.Core.Output;
 using Hedron.Core.Systems;
 
@@ -20,6 +22,8 @@ namespace Hedron.Core.Modules.Admin.Commands
     public sealed class SetCommand : ICommand
     {
         private readonly IRoomBuilderSystem _roomBuilder;
+        private readonly IRoomContentWriter _contentWriter;
+        private readonly ITemplateRegistry _templateRegistry;
         private readonly EntityService _entityService;
         private readonly IEventBus _eventBus;
         private readonly IPersistenceSystem _persistence;
@@ -43,11 +47,15 @@ namespace Hedron.Core.Modules.Admin.Commands
 
         public SetCommand(
             IRoomBuilderSystem roomBuilder,
+            IRoomContentWriter contentWriter,
+            ITemplateRegistry templateRegistry,
             EntityService entityService,
             IEventBus eventBus,
             IPersistenceSystem persistence)
         {
             _roomBuilder = roomBuilder;
+            _contentWriter = contentWriter;
+            _templateRegistry = templateRegistry;
             _entityService = entityService;
             _eventBus = eventBus;
             _persistence = persistence;
@@ -93,6 +101,14 @@ namespace Hedron.Core.Modules.Admin.Commands
                 roomId,
                 normalizedProperty,
                 value)).ConfigureAwait(false);
+
+            // RoomBuilderSystem.SetRoomName/Description already mirrors the change to the
+            // in-memory template. Write the updated template to YAML so it round-trips on
+            // the next server start.
+            if (_entityService.TryGet<BlueprintComponent>(roomId, out var bp) &&
+                _templateRegistry.TryGet(bp.BlueprintId, out var tpl) &&
+                tpl is RoomTemplate roomTpl)
+                await _contentWriter.WriteAsync(roomTpl).ConfigureAwait(false);
 
             await _persistence.SaveEntityAsync(roomId).ConfigureAwait(false);
 

--- a/Core/Modules/Admin/Systems/RoomBuilderSystem.cs
+++ b/Core/Modules/Admin/Systems/RoomBuilderSystem.cs
@@ -66,12 +66,16 @@ namespace Hedron.Core.Modules.Admin.Systems
         {
             if (_entityService.TryGet<RoomComponent>(roomId, out var room))
                 room.Name = name;
+            var tpl = TryGetTemplate(roomId);
+            if (tpl is not null) tpl.Name = name;
         }
 
         public void SetRoomDescription(uint roomId, string description)
         {
             if (_entityService.TryGet<RoomComponent>(roomId, out var room))
                 room.Description = description;
+            var tpl = TryGetTemplate(roomId);
+            if (tpl is not null) tpl.Description = description;
         }
 
         private string GenerateUniqueBlueprintId()
@@ -109,6 +113,15 @@ namespace Hedron.Core.Modules.Admin.Systems
             if (!_templateRegistry.TryGet(sourceBp.BlueprintId, out var template)) return;
             if (template is RoomTemplate roomTemplate)
                 roomTemplate.Exits[direction] = targetBp.BlueprintId;
+        }
+
+        private RoomTemplate? TryGetTemplate(uint roomId)
+        {
+            if (_entityService.TryGet<BlueprintComponent>(roomId, out var bp) &&
+                _templateRegistry.TryGet(bp.BlueprintId, out var template) &&
+                template is RoomTemplate roomTemplate)
+                return roomTemplate;
+            return null;
         }
 
         private static Direction? Opposite(Direction d) => d switch

--- a/Core/Modules/World/Systems/IRoomContentWriter.cs
+++ b/Core/Modules/World/Systems/IRoomContentWriter.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Hedron.Core.Modules.World.Templates;
+
+namespace Hedron.Core.Modules.World.Systems
+{
+    /// <summary>
+    /// Writes <see cref="RoomTemplate"/> definitions to the content store (YAML under
+    /// <c>data/content/rooms/</c>). Symmetric write path for <see cref="RoomTemplateDeserializer"/>.
+    /// Called by admin commands that create or mutate room blueprint definitions, and by
+    /// <see cref="WorldContentLoader"/> when seeding the void room for the first time.
+    /// </summary>
+    public interface IRoomContentWriter
+    {
+        Task WriteAsync(RoomTemplate template, CancellationToken ct = default);
+    }
+}

--- a/Core/Modules/World/Systems/RoomContentWriter.cs
+++ b/Core/Modules/World/Systems/RoomContentWriter.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hedron.Core.Modules.World.Templates;
+using Microsoft.Extensions.Configuration;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Hedron.Core.Modules.World.Systems
+{
+    /// <summary>
+    /// YAML-based <see cref="IRoomContentWriter"/>. Serializes a <see cref="RoomTemplate"/>
+    /// to <c>{contentDirectory}/rooms/{blueprintId}.yaml</c> using an atomic write (tmp → rename).
+    /// Mirrors the DTO shape used by <see cref="RoomTemplateDeserializer"/> so round-trips are
+    /// lossless.
+    /// </summary>
+    public sealed class RoomContentWriter : IRoomContentWriter
+    {
+        private readonly string _roomsDirectory;
+        private readonly ISerializer _yaml;
+
+        public RoomContentWriter(IConfiguration configuration)
+        {
+            var contentDirectory = configuration["World:ContentDirectory"] ?? "data/content/";
+            _roomsDirectory = System.IO.Path.Combine(contentDirectory, "rooms");
+            _yaml = new SerializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+        }
+
+        public async Task WriteAsync(RoomTemplate template, CancellationToken ct = default)
+        {
+            Directory.CreateDirectory(_roomsDirectory);
+
+            // Convert Direction enum keys → string keys to match the deserializer's DTO shape.
+            var exitDtos = new Dictionary<string, string>();
+            foreach (var (direction, targetBlueprintId) in template.Exits)
+                exitDtos[direction.ToString()] = targetBlueprintId;
+
+            var dto = new RoomDto
+            {
+                Id          = template.BlueprintId,
+                Name        = template.Name,
+                Description = template.Description,
+                AreaId      = string.IsNullOrEmpty(template.AreaId) ? null : template.AreaId,
+                Exits       = exitDtos.Count > 0 ? exitDtos : null,
+            };
+
+            var body     = _yaml.Serialize(dto);
+            var filePath = Path.Combine(_roomsDirectory, $"{template.BlueprintId}.yaml");
+            var tmpPath  = filePath + ".tmp";
+
+            await File.WriteAllTextAsync(tmpPath, body, ct).ConfigureAwait(false);
+            File.Move(tmpPath, filePath, overwrite: true);
+        }
+
+        // DTO shape must stay in sync with RoomTemplateDeserializer.RoomDto.
+        private sealed class RoomDto
+        {
+            public string Id { get; set; } = string.Empty;
+            public string Name { get; set; } = string.Empty;
+            public string Description { get; set; } = string.Empty;
+            public string? AreaId { get; set; }
+            public Dictionary<string, string>? Exits { get; set; }
+        }
+    }
+}

--- a/Core/Modules/World/Systems/WorldContentLoader.cs
+++ b/Core/Modules/World/Systems/WorldContentLoader.cs
@@ -37,6 +37,7 @@ namespace Hedron.Core.Modules.World.Systems
         private readonly ITemplateRegistry _templateRegistry;
         private readonly IContentSerializer _serializer;
         private readonly IPersistenceSystem _persistence;
+        private readonly IRoomContentWriter _roomContentWriter;
         private readonly Hedron.Core.WorldConfiguration _worldConfig;
         private readonly ILogger<WorldContentLoader> _logger;
         private readonly string _contentDirectory;
@@ -47,6 +48,7 @@ namespace Hedron.Core.Modules.World.Systems
             ITemplateRegistry templateRegistry,
             IContentSerializer serializer,
             IPersistenceSystem persistence,
+            IRoomContentWriter roomContentWriter,
             Hedron.Core.WorldConfiguration worldConfig,
             IConfiguration configuration,
             ILogger<WorldContentLoader> logger)
@@ -55,6 +57,7 @@ namespace Hedron.Core.Modules.World.Systems
             _templateRegistry = templateRegistry;
             _serializer = serializer;
             _persistence = persistence;
+            _roomContentWriter = roomContentWriter;
             _worldConfig = worldConfig;
             _logger = logger;
             _contentDirectory = configuration["World:ContentDirectory"] ?? "data/content/";
@@ -78,9 +81,18 @@ namespace Hedron.Core.Modules.World.Systems
                     _logger.LogWarning(
                         "WorldContentLoader: content directory '{Dir}' is missing or empty — seeding void room.",
                         _contentDirectory);
-                    var voidId = SeedVoidRoom();
+                    var voidId = await SeedVoidRoomAsync(ct).ConfigureAwait(false);
                     // Save immediately so the entity ID is stable across restarts.
                     await _persistence.SaveEntityAsync(voidId, ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    // Entity snapshot exists from a previous run but there is no YAML file
+                    // (e.g. content directory was wiped, or this is the first run after the
+                    // room-YAML feature was introduced). Reconstruct the template from the
+                    // live entity and write the YAML so future startups load cleanly.
+                    await RecoverVoidRoomTemplateAsync(liveBlueprints[VoidRoomBlueprintId], ct)
+                        .ConfigureAwait(false);
                 }
             }
             else
@@ -99,6 +111,15 @@ namespace Hedron.Core.Modules.World.Systems
             }
 
             ResolveStartingRoom();
+
+            // Warn about any blueprint-tagged entity whose YAML template is not in the
+            // registry. This catches JSON snapshots whose content files have been deleted
+            // or were never written (e.g. rooms created before this feature existed).
+            //
+            // Note: character and account entities do not carry BlueprintComponent, so they
+            // are naturally excluded here. Accounts are aspirationally intended to have YAML
+            // counterparts in a future slice.
+            WarnOrphanedBlueprintEntities();
         }
 
         public async Task<ContentReloadResult> ReloadAsync(CancellationToken ct = default)
@@ -121,6 +142,8 @@ namespace Hedron.Core.Modules.World.Systems
                 await _persistence.SaveEntityAsync(id, ct).ConfigureAwait(false);
             LinkRoomExits(liveBlueprints);
             PlaceItemsInRooms(liveBlueprints, newlySpawned);
+
+            WarnOrphanedBlueprintEntities();
 
             return new ContentReloadResult(loaded, unchanged, removed);
         }
@@ -166,17 +189,71 @@ namespace Hedron.Core.Modules.World.Systems
             }
         }
 
-        private uint SeedVoidRoom()
+        private async Task<uint> SeedVoidRoomAsync(CancellationToken ct)
         {
             var voidTemplate = new RoomTemplate(VoidRoomBlueprintId)
             {
                 Name = "The Void",
-                Description = "A featureless grey expanse. No content has been authored yet — use @dig to start building.",
+                Description = "A featureless grey expanse. No content has been authored yet — use dig to start building.",
             };
             _templateRegistry.Register(VoidRoomBlueprintId, voidTemplate);
             var spawned = _templateRegistry.Spawn(VoidRoomBlueprintId);
             _entityService.AddComponent(spawned.Id, new PersistentEntity());
+
+            // Write YAML immediately so the void room has a content file on first startup.
+            await _roomContentWriter.WriteAsync(voidTemplate, ct).ConfigureAwait(false);
+
             return spawned.Id;
+        }
+
+        /// <summary>
+        /// Called when the void room entity already exists in the snapshot store but its YAML
+        /// file is absent (e.g. the content directory was wiped, or this server was upgraded
+        /// from a version that did not write room YAML). Reconstructs the template from the
+        /// live entity's <see cref="RoomComponent"/> and writes the YAML so subsequent starts
+        /// load cleanly without an orphan warning.
+        /// </summary>
+        private async Task RecoverVoidRoomTemplateAsync(uint voidEntityId, CancellationToken ct)
+        {
+            _entityService.TryGet<RoomComponent>(voidEntityId, out var roomComp);
+
+            var voidTemplate = new RoomTemplate(VoidRoomBlueprintId)
+            {
+                Name        = roomComp?.Name ?? "The Void",
+                Description = roomComp?.Description
+                              ?? "A featureless grey expanse. No content has been authored yet — use dig to start building.",
+            };
+            _templateRegistry.Register(VoidRoomBlueprintId, voidTemplate);
+
+            _logger.LogInformation(
+                "WorldContentLoader: void room entity exists but has no YAML — writing recovery file.");
+            await _roomContentWriter.WriteAsync(voidTemplate, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Scans all entities that carry a <see cref="BlueprintComponent"/> and logs a warning
+        /// for any whose blueprint id is absent from the template registry. Such entities have
+        /// a JSON snapshot but no YAML counterpart, which means their template definition is
+        /// missing and they will be re-spawned as duplicates on the next start (or silently
+        /// lose blueprint identity on reload).
+        /// </summary>
+        private void WarnOrphanedBlueprintEntities()
+        {
+            foreach (var (entityId, blueprint) in _entityService.GetAllComponents<BlueprintComponent>())
+            {
+                if (string.IsNullOrEmpty(blueprint.BlueprintId))
+                    continue;
+
+                if (_templateRegistry.TryGet(blueprint.BlueprintId, out _))
+                    continue;
+
+                _logger.LogWarning(
+                    "WorldContentLoader: entity {EntityId} has blueprint '{BlueprintId}' but no " +
+                    "matching YAML template was loaded. The content file may be missing. " +
+                    "If this is a room or item created before YAML write support was added, " +
+                    "re-create it via dig/mkitem to generate the YAML file.",
+                    entityId, blueprint.BlueprintId);
+            }
         }
 
         /// <summary>

--- a/Core/Modules/World/WorldModule.cs
+++ b/Core/Modules/World/WorldModule.cs
@@ -23,6 +23,7 @@ namespace Hedron.Core.Modules.World
             services.AddSingleton<ITemplateRegistry, TemplateRegistry>();
             services.AddSingleton<IContentSerializer, YamlContentSerializer>();
             services.AddSingleton<IWorldContentLoader, WorldContentLoader>();
+            services.AddSingleton<IRoomContentWriter, RoomContentWriter>();
 
             // Per-kind deserializers — the World module owns the room/area kinds. Future
             // modules (mobs, items) register their own kinds the same way without touching


### PR DESCRIPTION
## Summary

- **Room YAML write path** — `dig` and `set` now write `data/content/rooms/{blueprintId}.yaml` files symmetrically to how `mkitem`/`setitem` write item YAML. Adds `IRoomContentWriter` / `RoomContentWriter` (atomic tmp→rename, DTO matches `RoomTemplateDeserializer` for lossless round-trips).
- **Void room YAML on boot** — `SeedVoidRoomAsync` writes the void room YAML on first startup; `RecoverVoidRoomTemplateAsync` handles upgrading existing servers that have the entity JSON but no YAML file.
- **Orphan blueprint warnings** — `WarnOrphanedBlueprintEntities` logs a `Warning` at the end of load and reload for any entity carrying a `BlueprintComponent` whose blueprint ID has no loaded template. Character and account entities naturally lack `BlueprintComponent` so they are excluded without special-casing.
- **`RoomBuilderSystem` template mirror fix** — `SetRoomName` and `SetRoomDescription` were not mirroring changes to the in-memory `RoomTemplate` (gap vs `ItemBuilderSystem`). Fixed while wiring the YAML write path.

## Test plan

- [x] Fresh server start: `data/content/rooms/room.void.yaml` is created on first boot, no orphan warning logged
- [x] Restart: void room YAML present, no warning
- [x] Delete `data/content/rooms/room.void.yaml`, restart: recovery branch runs, YAML recreated, no warning on next restart
- [x] `dig north`: `data/content/rooms/room.adhoc.{id}.yaml` appears for new room; source room YAML is also rewritten with the new exit
- [x] `set name Throne Room`: source room YAML is rewritten with updated name
- [x] Manually delete a room YAML while keeping entity JSON, restart: orphan warning appears in console for that blueprint ID

🤖 Generated with [Claude Sonnet 4.6](https://claude.com/claude-code)