### PR TITLE
docs: slice 8 (mobs) and slice 8a (attributes) use-case specs

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -72,6 +72,15 @@ Deferred from slice 7 design notes. Two related capabilities:
 
 Both are meaningful improvements to UX but would bloat slices 6–7. Revisit when the number of "are you sure?" flows justifies the infrastructure cost.
 
+### 🔵 Mob death / respawn and `BlueprintComponent` clearing (INV-21)
+
+When mob combat death lands (slice 9+), the death/respawn slice must decide:
+
+- **Reset in place:** HP restored on the same entity; `BlueprintComponent` is never cleared. Simple, but the entity ID is reused, which means save-file references to the dead entity slot survive.
+- **Destroy and re-seed:** The dead entity is destroyed (or archived); a new entity is spawned from the `MobTemplate`; `BlueprintComponent` is cleared from the corpse before the corpse entity is left or destroyed. Required by INV-21 ("when a player interaction makes an instance independent, clear `BlueprintComponent`").
+
+The chosen approach must be called out explicitly in the death/respawn use-case doc's Design Notes. If destroy-and-re-seed is chosen, `BlueprintComponent` must be cleared on the corpse entity before the new entity is spawned so the blueprint slot is free for the next spawn cycle (INV-21).
+
 ### 🔵 Archetype catalogue refresh
 
 The archetype list in [`../reference/archetypes.md`](../reference/archetypes.md) was written against the old component shapes. Re-audit once a few Phase 3 slices have landed real components.

--- a/docs/roadmap/plan.md
+++ b/docs/roadmap/plan.md
@@ -27,14 +27,14 @@ The target is defined by:
 |---|---|---|
 | **1 — Strip** | ✅ complete | [`completed/phase-1-strip.md`](completed/phase-1-strip.md) |
 | **2 — Foundation / MVP** | ✅ complete | [`completed/phase-2-mvp.md`](completed/phase-2-mvp.md) |
-| **3 — Vertical slices** | 🟡 in progress (slices 1–7 done; **next: slice 8 — mobs + wandering**) | per-slice docs in [`../use-cases/`](../use-cases/); see [Slice queue](#slice-queue) |
+| **3 — Vertical slices** | 🟡 in progress (slices 1–7 done; **next: slice 8 — mobs**) | per-slice docs in [`../use-cases/`](../use-cases/); see [Slice queue](#slice-queue) |
 | **4 — Hardening** | 🔵 not started | testing, CI, perf, thread-safety review — see [`backlog.md`](backlog.md) |
 
 For the per-slice ledger of completed work, read [`done.md`](done.md).
 
 ## Current focus
 
-**Phase 3 slice 8 — Mobs + wandering.** Slice 7 is complete. Slice 8 delivers: mob entity model, `MobDataComponent`, wandering behavior via the first `TimeSystem` use, mob spawn from YAML, and mob room presence in `look`. Spec: to be authored. Prerequisite: slice 7 (complete).
+**Phase 3 slice 8 — Mobs (basic entity model and spawn).** Slice 7 is complete. Slice 8 delivers: mob entity model (`MobDataComponent`), admin authoring (`mkmob`/`setmob`), YAML spawn (`kind: mob`), and mob room presence in `look`. Wandering is explicitly deferred — it requires a `TimeSystem` and AI infrastructure that belong in a later slice. Spec: [`../use-cases/mobs.md`](../use-cases/mobs.md). Prerequisite: slice 7 (complete).
 
 The per-slice spec is the single source of truth for "what is being built right now" — this file deliberately does not duplicate it.
 
@@ -69,8 +69,9 @@ Order is **revised** from the original Phase 3 list to pull content tooling forw
 | 5b | **Persistence two-level model** | `PersistentEntity` marker component; area-scoped periodic flush; save-on-change for admin/lifecycle transitions; `PersistenceHandler` deleted; dirty-set model removed | ✅ done |
 | 6 | Items + inventory + `get`/`drop`/`look <item>` | Object interaction and inspection; `ItemDataComponent`, `InventoryComponent`; admin `mkitem`/`setitem`; concrete `IArgumentResolver` impls | ✅ done |
 | 7 | Equipment + `wear`/`remove` | Gear; `EquipmentComponent`, `WornSlot` enum, `wear`/`remove`/`equipment` commands | ✅ done |
-| 8 | Mobs + wandering | Populated world; first `TimeSystem` use | 🟢 next |
-| 9 | Combat | Core gameplay loop | 🟡 blocked on 8 |
+| 8 | Mobs (basic entity model and spawn) | Populated world; no wandering | 🟢 next |
+| 8a | Attributes and vitals (`AttributesComponent`, `PoolsComponent`, `score`) | HP + base stats required for combat | 🟡 blocked on 8 |
+| 9 | Combat | Core gameplay loop | 🟡 blocked on 8a |
 | 10 | Death and respawn | Combat is terminal until this exists | 🟡 blocked on 9 |
 | 11 | Skills | Character progression | 🟢 ready after 9 |
 | 12 | Shopping | Economy | 🟢 ready after 6 |

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -46,6 +46,8 @@ At slice close-out, `sync-roadmap` **trims** it to its durable behavior spec —
 | `implemented` | [`persistence-two-level-model.md`](persistence-two-level-model.md) | Phase 3 slice 5b |
 | `planned` | [`items-and-inventory.md`](items-and-inventory.md) | Phase 3 slice 6 |
 | `planned` | [`equipment.md`](equipment.md) | Phase 3 slice 7 |
+| `planned` | [`mobs.md`](mobs.md) | Phase 3 slice 8 |
+| `planned` | [`attributes.md`](attributes.md) | Phase 3 slice 8a |
 | `deferred` | [`admin-privilege-elevation.md`](admin-privilege-elevation.md) | Future (TBD) — placeholder |
 
 > See [`../roadmap/plan.md`](../roadmap/plan.md#slice-queue) for the full slice queue and current focus.

--- a/docs/use-cases/attributes.md
+++ b/docs/use-cases/attributes.md
@@ -1,0 +1,201 @@
+# Use Case: Attributes and Vitals
+
+**Status:** planned
+**Actors:** Player, Administrator, System
+**Module:** `Core/Modules/Attributes/` (new); `Core/ECS/Components/` (cross-cutting components); `Core/Modules/Mobs/` (`MobTemplate` and builder extended); `Core/Modules/Account/` (`CreateCharacterAsync` and `CharacterHydrationHandler` extended)
+
+---
+
+## Description
+
+Introduces the data layer for entity health and base combat statistics. Every living entity — player or mob — gains an `AttributesComponent` (Level, Strength, Dexterity, Constitution) and a `PoolsComponent` (MaxHp, CurrentHp). These two components are the minimum foundation the combat slice requires: without HP, damage has nowhere to land; without base stats, attack and defense calculations have no ground truth. This slice deliberately stops at the data layer — it seeds and exposes values, but performs no damage application or death detection. Those belong to the combat slice.
+
+The `score` command gives players visibility into their own stats. Admin tooling extends `setmob` with attribute properties and introduces a `setplayer` admin command for direct stat manipulation during testing.
+
+**Prerequisite:** Slice 8 (mobs) complete. `MobDataComponent`, `MobTemplate`, and `IMobBuilderSystem` must exist.
+
+---
+
+## Preconditions
+
+- Slices 1–8 complete. Reused: `EntityService`, `IEventBus`, `IPersistenceSystem`, `IOutputWriter`, `ICommandDispatcher`, `IAdminAuthorizer`, `AdminRequirement`, `ISessionManager`, `MobDataComponent`, `MobTemplate`, `IMobBuilderSystem`, `IMobContentWriter`, `CharacterComponent`, `AccountSystem.CreateCharacterAsync`, `CharacterHydrationHandler`, `WorldContentLoader`.
+- Mobs have `MobDataComponent`, `LocationComponent`, `BlueprintComponent`, and `PersistentEntity` from slice 8.
+- Players have `CharacterComponent` and `LocationComponent` from slice 5.
+
+---
+
+## Postconditions
+
+- `AttributesComponent` (`Level: int`, `Strength: int`, `Dexterity: int`, `Constitution: int`) exists under `Core/ECS/Components/` and is `[Persistent]`.
+- `PoolsComponent` (`MaxHp: int`, `CurrentHp: int`) exists under `Core/ECS/Components/` and is `[Persistent]`.
+- `AccountSystem.CreateCharacterAsync` attaches default `AttributesComponent { Level=1, Strength=10, Dexterity=10, Constitution=10 }` and `PoolsComponent { MaxHp=100, CurrentHp=100 }` to every new character, saved as part of the existing `LoginFlow` save call.
+- `CharacterHydrationHandler` attaches empty-default `AttributesComponent` and `PoolsComponent` to existing characters that lack them, without immediately saving (migration guard — same pattern as `InventoryComponent`).
+- `MobTemplate` gains optional `Level: int`, `MaxHp: int`, `Strength: int`, `Dexterity: int`, `Constitution: int` fields. `MobTemplate.Apply` attaches `AttributesComponent` and `PoolsComponent` from template values; if `Level` is absent or 0, defaults (Level 1, Str/Dex/Con 10, MaxHp/CurrentHp 100) are used.
+- `setmob <blueprintId> level <n>`, `setmob <blueprintId> hp <n>`, `setmob <blueprintId> str <n>`, `setmob <blueprintId> dex <n>`, `setmob <blueprintId> con <n>` mutate `AttributesComponent` / `PoolsComponent` on the live mob entity and update the template YAML via `IMobContentWriter`.
+- Admin `setplayer <characterName> level <n>` / `setplayer <characterName> hp <n>` sets attributes/pools on a currently-connected player's entity by character name.
+- `score` displays the invoking player's Level, HP (`CurrentHp/MaxHp`), Strength, Dexterity, and Constitution in a formatted `ScoreDisplayMessage`. No events fired.
+- `IAttributeSystem` (domain system, `Core/Modules/Attributes/Systems/`) exposes `GetLevel(entityId)`, `GetMaxHp(entityId)`, `GetStrength(entityId)`, `GetDexterity(entityId)`, `GetConstitution(entityId)` as the read seams the combat slice will call; mutation methods (`SetLevel`, `SetMaxHp`, `SetAttribute`) serve the admin path.
+
+---
+
+## Main Flow
+
+### Flow A-1 — New character creation (attribute initialization)
+
+1. `AccountSystem.CreateCharacterAsync` (existing): allocates entity, attaches `CharacterComponent`, `LocationComponent`, `PersistentEntity`.
+2. **Extended here:** also attaches `AttributesComponent { Level=1, Strength=10, Dexterity=10, Constitution=10 }` and `PoolsComponent { MaxHp=100, CurrentHp=100 }`.
+3. Saved via the existing `LoginFlow` `SaveEntityAsync(characterEntityId)` call — no additional save needed.
+
+### Flow A-2 — Existing character hydration (migration guard)
+
+1. `CharacterHydrationHandler.HandleAsync(WorldContentReadyEvent)` (existing): iterates all hydrated character entities.
+2. **Extended here:** for each character entity, if `AttributesComponent` is absent, attaches default. If `PoolsComponent` is absent, attaches default. Does not call `SaveEntityAsync` immediately — the components are attached to the live entity and persisted on the character's next save-on-change event.
+
+### Flow A-3 — Mob entity spawn with attributes
+
+1. `WorldContentLoader` calls `MobTemplate.Apply(entity, entityService)` for each newly-spawned mob.
+2. **Extended here:** `MobTemplate.Apply` attaches `AttributesComponent` from template values (defaults if `Level == 0`) and `PoolsComponent { MaxHp, CurrentHp = MaxHp }`.
+3. Saved immediately as part of the existing `SpawnMissingEntities` save pass.
+
+### Flow B-1 — `score`
+
+1. Player sends `score`. `ScoreCommand.ExecuteAsync` has no privilege requirement.
+2. Reads `CharacterComponent`, `AttributesComponent`, `PoolsComponent` from invoker entity. If either component is absent (pre-hydration edge case), uses default values rather than writing an error.
+3. Builds `ScoreDisplayMessage(CharacterName, Level, CurrentHp, MaxHp, Strength, Dexterity, Constitution)`. Writes to invoker. No events fired.
+
+### Flow C-1 — Admin `setmob <blueprintId> level/hp/str/dex/con <value>`
+
+1. **Privilege gate.** `AdminRequirement` checked.
+2. **Resolve mob.** Looks up blueprint in `ITemplateRegistry` and live entity in `EntityService` via `BlueprintComponent.BlueprintId`. Not found → error.
+3. **Mutation.** Calls `IMobBuilderSystem.SetAttribute(mobEntityId, template, property, value)` (new method added to the builder). For `hp`: sets `PoolsComponent.MaxHp`; if `CurrentHp > new MaxHp`, clamps `CurrentHp = MaxHp`. For `level`, `str`, `dex`, `con`: sets the corresponding `AttributesComponent` field. Updates the corresponding field on `MobTemplate`.
+4. **YAML write.** Calls `IMobContentWriter.WriteAsync(template)`.
+5. **Event + save.** Publishes `MobPropertySetByAdminEvent` (reused from slice 8; `PropertyName` carries the attribute key). Calls `IPersistenceSystem.SaveEntityAsync(mobEntityId)`. Writes a confirmation `PlainMessage`.
+6. `AdminAuditHandler` logs the event.
+
+### Flow C-2 — Admin `setplayer <characterName> level/hp <value>`
+
+1. **Privilege gate.** `AdminRequirement` checked.
+2. **Resolve player.** `SetPlayerCommand` iterates `ISessionManager.GetAll()` and finds the session whose `CharacterComponent.CharacterName` matches (case-insensitive). Not found → "No connected player named '<name>'."
+3. **Mutation.** Calls `IAttributeSystem.SetLevel(entityId, value)` or `IAttributeSystem.SetMaxHp(entityId, value)`; clamps `CurrentHp` to new `MaxHp` if needed.
+4. **Event + save.** Publishes `PlayerAttributeSetByAdminEvent(AdminEntityId, PlayerEntityId, PropertyName, NewValue)`. Calls `IPersistenceSystem.SaveEntityAsync(playerEntityId)`. Writes a confirmation `PlainMessage`.
+5. `AdminAuditHandler` logs the event.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Payload | Purpose |
+|---|---|---|---|
+| `MobPropertySetByAdminEvent` | `SetMobCommand` (extended from slice 8) | `uint AdminEntityId, uint MobEntityId, string PropertyName, string NewValue` | Reused from slice 8; attribute changes on mobs share the existing audit event |
+| `PlayerAttributeSetByAdminEvent` | `SetPlayerCommand` | `uint AdminEntityId, uint PlayerEntityId, string PropertyName, string NewValue` | Audit log; future stat-recalculation hooks |
+
+---
+
+## Systems / Handlers Involved
+
+| Artifact | Kind | Responsibility |
+|---|---|---|
+| `IAttributeSystem` / `AttributeSystem` | Domain system | Read-only getters for `AttributesComponent` / `PoolsComponent`; mutation methods for admin and initialization paths (event publication is callers' responsibility) |
+| `IMobBuilderSystem` (extended) | Domain system | Gains `SetAttribute(mobEntityId, template, property, value)` for `level`, `hp`, `str`, `dex`, `con` |
+| `AccountSystem` (extended) | Domain system | `CreateCharacterAsync` attaches default `AttributesComponent` + `PoolsComponent` |
+| `CharacterHydrationHandler` (extended) | Handler | Attaches default `AttributesComponent` + `PoolsComponent` to existing characters that lack them |
+| `MobTemplate` (extended) | Infrastructure | Gains `Level`, `MaxHp`, `Strength`, `Dexterity`, `Constitution` fields; `Apply` attaches both components |
+| `SetMobCommand` (extended) | Command | Handles five new properties: `level`, `hp`, `str`, `dex`, `con` |
+| `SetPlayerCommand` | Command (new) | Admin command to set `level` or `hp` on a currently-connected player by character name |
+| `ScoreCommand` | Command (new) | Player command; reads and displays `AttributesComponent` + `PoolsComponent` |
+| `AdminAuditHandler` (extended) | Handler | Subscribes to `PlayerAttributeSetByAdminEvent` |
+
+---
+
+## Content Tooling Impact
+
+**`MobTemplate` YAML extension.** `kind: mob` files gain optional attribute fields:
+
+```yaml
+kind: mob
+blueprintId: mob.forest.wolf
+name: A grey wolf
+description: A lean wolf with silver-tipped fur.
+keywords:
+  - wolf
+type: Creature
+spawnRoomBlueprintId: room.forest.clearing
+level: 3
+maxHp: 45
+strength: 12
+dexterity: 14
+constitution: 11
+```
+
+Omitting any attribute field causes `MobTemplate.Apply` to use defaults (Level 1, Str/Dex/Con 10, MaxHp 100, CurrentHp 100). This is a purely additive YAML extension — existing `kind: mob` files without attribute fields remain valid.
+
+**Admin commands.** Five new `setmob` sub-properties: `level`, `hp`, `str`, `dex`, `con`. One new admin command: `setplayer <characterName> level <n>` / `setplayer <characterName> hp <n>`.
+
+**Player command.** `score` — no args, no privilege requirement.
+
+**Inspect / verify.** Players use `score` to confirm their own stats. Admins use `setmob <blueprintId> level <n>` and read the confirmation echo to verify mob attributes.
+
+---
+
+## Cross-cutting Surfaces Stressed
+
+| Surface | Assessment |
+|---|---|
+| **Commands** | Adequate — `ICommand`, `AdminRequirement`, argument parsing, `IOutputWriter`, and `CommandExecutedEvent` are all established. `score` is a zero-arg player command; `setplayer` is an admin command with two positional tokens. No new command infrastructure needed. |
+| **Output** | Gap exposed (minor, resolvable in this slice) — `ScoreDisplayMessage` does not exist. A new message shape and a corresponding formatter case are added. No output infrastructure changes required — purely additive. |
+| **ECS** | Adequate — component attach/query patterns are established. Two new `[Persistent]` cross-cutting components follow existing conventions. |
+| **Persistence** | Adequate — two-level model is in place. Both components are `[Persistent]`; entities that carry them already have `PersistentEntity`. No persistence infrastructure changes. |
+| **Event bus** | Adequate — one new event type (`PlayerAttributeSetByAdminEvent`) follows the established thin-payload pattern. `AdminAuditHandler` subscribes. |
+| **Content templates** | Gap exposed (minor, resolvable in this slice) — `MobTemplate` and `MobTemplateDeserializer` gain new optional fields. No template infrastructure changes; additive-only to the YAML schema. |
+| **Broadcast** | Not stressed. `score` is a single-player write; `setplayer` confirmation goes to the admin only. |
+| **Time / heartbeat** | Not stressed. No timed or periodic behavior introduced. |
+| **Configuration** | Not stressed. No new config keys. |
+
+---
+
+## Flows Introduced or Modified
+
+Flow numbering dependency: the mobs slice (slice 8, prerequisite) must have added Flow 15 (`mkmob — admin mob creation`) to `flows/README.md` before this slice closes. If that is not yet done at implementation time, the flows doc must be reconciled — Flow 16 (`score`) is stable only once Flow 15 is written.
+
+| # | Flow | Change |
+|---|---|---|
+| 1 | Server startup | Extended: `MobTemplate.Apply` now attaches `AttributesComponent` + `PoolsComponent` for newly-spawned mobs. Mermaid: add a `Note over MobTemplate,ES: also attaches AttributesComponent + PoolsComponent` annotation inside the `SpawnMissingEntities` loop, after the `Spawn(blueprintId)` call. |
+| 7 | Login / character flow | Extended: `AccountSystem.CreateCharacterAsync` attaches `AttributesComponent` + `PoolsComponent` to new characters. Mermaid: update the `Note over AccSys` in step 6 to read `creates entity, attaches CharacterComponent + LocationComponent + AttributesComponent + PoolsComponent + PersistentEntity`. |
+| 16 | `score` (new) | New flow in `flows/README.md`: player sends `score`; `CommandDispatcher` routes to `ScoreCommand`; `ScoreCommand` calls `EntityService.TryGet<AttributesComponent>` and `TryGet<PoolsComponent>`; writes `ScoreDisplayMessage` via `IOutputWriter`. No events. |
+
+---
+
+## Reference Catalog Updates
+
+- `docs/reference/components.md` — add `AttributesComponent` and `PoolsComponent` rows to the cross-cutting table.
+- `docs/reference/components-planned.md` — promote `AttributesComponent` and `PoolsComponent` to `components.md` (with the adopted `Strength`/`Dexterity`/`Constitution` naming); remove or update the planned-catalog entries (`Might`/`Finesse`/`Will`) so they no longer imply the superseded design is in force.
+- `docs/reference/systems.md` — add `IAttributeSystem` / `AttributeSystem` row. **Pre-condition:** the mobs slice (slice 8) must have added the `IMobBuilderSystem` row first; update that row to add `SetAttribute` once it exists.
+- `docs/reference/commands.md` — add rows for `score` and `setplayer`. **Pre-condition:** the mobs slice (slice 8) must have added `mkmob` and `setmob` rows first; update the `setmob` row to record the five new sub-properties (`level`, `hp`, `str`, `dex`, `con`) once it exists.
+
+---
+
+## Design Notes
+
+- **`AttributesComponent` and `PoolsComponent` are cross-cutting.** Both live under `Core/ECS/Components/` so `Core/Modules/Combat/` can read them without depending on a domain module. This mirrors `EquipmentComponent` (cross-cutting since slice 7).
+- **Direct-set, no formula.** `MaxHp` is set directly by the template or admin command — no derived formula in this slice. The combat slice will introduce a formula once stat relationships are validated through play. Starting with direct-set avoids locking in numbers that need to change. When a formula is introduced, `CreateCharacterAsync` and `MobTemplate.Apply` will need updating — acknowledged debt.
+- **`setplayer` is test tooling.** In production, character stats would be driven by level-up events. For the current phase (no progression system), `setplayer` provides a manual override path for test scenarios and admin intervention. Protected by `AdminRequirement`.
+- **`hp` sets `MaxHp`, clamps `CurrentHp`.** When an admin sets `hp <n>` on a mob, `MaxHp` is updated and `CurrentHp` is clamped to `min(CurrentHp, n)`. Setting `hp` does not heal the mob to full — healing belongs to the respawn or heal-command slice.
+- **Migration guard does not save.** `CharacterHydrationHandler` attaches missing components without calling `SaveEntityAsync`. This matches the established pattern from `InventoryComponent` (slice 6) and avoids persistence I/O during the startup sequence.
+- **`score` shows own stats only.** There is no `look <player>` or `inspect <mob>` stat display in this slice. A dedicated `inspect` admin command is acknowledged debt.
+- **`IAttributeSystem` mutation methods publish no events (INV-5).** Event publication is the caller's (command's) responsibility. `SetLevel` and `SetMaxHp` mutate components only; the calling command publishes the appropriate audit event.
+- **`IMobBuilderSystem.SetAttribute` follows the same INV-5 discipline (INV-5).** `SetAttribute` mutates the live entity's `AttributesComponent` / `PoolsComponent` fields and updates the corresponding field on the in-memory `MobTemplate` record. It does not call `IEventBus`, `IPersistenceSystem`, or `IMobContentWriter`. YAML writing, entity saving, and event publishing are all the calling command's responsibility.
+- **`CurrentHp` clamping lives in the domain system (INV-8).** The rule "if `CurrentHp > new MaxHp`, clamp `CurrentHp = MaxHp`" is enforced inside `IMobBuilderSystem.SetAttribute` (and `IAttributeSystem.SetMaxHp`), not in the command body. Commands are thin; game rules belong in domain systems.
+- **Stat naming deviates from `components-planned.md`.** The planned catalog (`docs/reference/components-planned.md`) listed `Might`, `Finesse`, `Will` as the stat names. This slice uses `Strength`, `Dexterity`, `Constitution` — the conventional MUD stat set — because they are directly meaningful to players and align with the combat model the design targets. The planned catalog was written before the combat model was designed; the deviation is intentional and supersedes the planned names.
+- **Default values.** Level 1, Str/Dex/Con 10, MaxHp 100, CurrentHp 100. These are placeholders for the combat slice to calibrate against.
+
+---
+
+## Related
+
+- [`mobs.md`](mobs.md) — slice 8; provides `MobDataComponent`, `MobTemplate`, `IMobBuilderSystem`, and `IMobContentWriter` extended here.
+- [`equipment.md`](equipment.md) — slice 7; `EquipmentComponent` established the cross-cutting component precedent.
+- [`account-character-creation.md`](account-character-creation.md) — slice 5; `CreateCharacterAsync` and `CharacterHydrationHandler` extended here.
+- [`persistence-two-level-model.md`](persistence-two-level-model.md) — slice 5b; both new components follow the two-level persistence model.
+- [`output-framework.md`](output-framework.md) — slice 4; `ScoreDisplayMessage` plugs into the same formatter pipeline.
+
+For the slice queue, see [`../roadmap/plan.md`](../roadmap/plan.md).

--- a/docs/use-cases/mobs.md
+++ b/docs/use-cases/mobs.md
@@ -1,0 +1,189 @@
+# Use Case: Mobs — Basic Entity Model and Spawn
+
+**Status:** planned
+**Spec review:** passed (2026-05-25)
+**Actors:** Player, Administrator, System
+**Module:** `Core/Modules/Mobs/` (new); `Core/Modules/World/` (`WorldContentLoader` extended); `Core/ECS/Components/` (`MobDataComponent`)
+
+---
+
+## Description
+
+Introduces mobs as first-class NPC entities in the world. A mob is a non-player character that occupies a room and is visible to players using `look`. This slice delivers the mob entity model, an admin authoring path (`mkmob` / `setmob`), spawn from YAML (`kind: mob`), and mob room presence in `look` output. Wandering (AI movement) is intentionally deferred — that requires a `TimeSystem` and AI behavior infrastructure that belongs in a dedicated slice. The goal here is the mob lifecycle: authored in YAML → spawned into a room → visible to players.
+
+This slice is **deliberately narrow**: no combat, no loot, no dialogue, no wandering, no factions. Those land in later slices. The mob entity model established here (component shape, template, spawn path) is the foundation they build on. The implementation pattern mirrors the items slice (6) as closely as possible.
+
+**Prerequisite:** Slices 1–7 complete.
+
+---
+
+## Preconditions
+
+- Slices 1–7 complete. Reused: `EntityService`, `IEventBus`, `ITemplateRegistry`, `IPersistenceSystem`, `IBroadcastSystem`, `IOutputWriter`, `ICommandDispatcher`, `LocationComponent`, `RoomComponent`, `PersistentEntity`, `BlueprintComponent`, `IAdminAuthorizer`, `AdminRequirement`, `WorldContentLoader` (extended here). `IItemBuilderSystem` and `IItemContentWriter` are the direct precedents for the builder and content-writer interfaces introduced in this slice.
+- Every connected player has a valid `LocationComponent`.
+
+---
+
+## Postconditions
+
+- `MobDataComponent` (`Name: string`, `Description: string`, `Keywords: List<string>`, `MobType: MobType`) exists under `Core/ECS/Components/` (cross-cutting) and is `[Persistent]`.
+- `MobType` enum exists (`None`, `Vendor`, `Guard`, `Creature`) alongside `MobDataComponent`. It is data-only in this slice — no routing or behavior logic consumes it.
+- A `MobTemplate` YAML shape (`kind: mob`) exists under `Core/Modules/Mobs/Templates/`. `MobTemplateDeserializer` deserializes YAML into `MobTemplate`. `WorldContentLoader` loads `kind: mob` files from a `mobs/` subdirectory on startup and reload.
+- Admin `mkmob [name]` creates an ad-hoc mob entity in the invoker's current room. A confirmation shows the blueprint id. Blueprint id format: `mob.adhoc.<8-char-base36>`.
+- Admin `setmob <blueprintId> <property> <value>` mutates name, description, keywords, or type on the target mob. Blueprint and live entity are kept in sync; `IMobContentWriter.WriteAsync(template)` writes the YAML file to disk after every mutation.
+- Mob entities spawned from templates carry: `MobDataComponent`, `LocationComponent { RoomEntityId }`, `BlueprintComponent`, `PersistentEntity`.
+- `RoomDescriptionMessage` gains a `Mobs: IReadOnlyList<string>` field. `IBroadcastSystem.SendRoomDescriptionAsync` populates `Mobs` with `MobDataComponent.Name` for every entity in the room that carries `MobDataComponent`. `look` (no arg) displays mob names below items: one line per mob rendered as `"<Name> is here."`.
+- `WorldContentLoader.LoadAndSpawnAsync` calls `PlaceMobsInRooms` (new private method, mirrors `PlaceItemsInRooms`) for newly-spawned mob entities only; restored-from-persistence entities are skipped.
+
+---
+
+## Main Flow
+
+### Flow A-1 — Admin `mkmob [name]`
+
+1. **Privilege gate.** `CommandDispatcher` evaluates `AdminRequirement`; non-privileged sessions are rejected before `MkMobCommand.ExecuteAsync` runs.
+2. **Creation.** `MkMobCommand` calls `IMobBuilderSystem.CreateMob(name, roomEntityId)`. The system generates blueprint id `mob.adhoc.<8-char-base36>`, allocates an entity via `EntityService`, attaches `MobDataComponent { Name, Description="", Keywords=[], MobType=None }` + `BlueprintComponent { BlueprintId }` + `PersistentEntity` + `LocationComponent { RoomEntityId = invoker's current room }`, and registers a minimal `MobTemplate` in `ITemplateRegistry`. Returns `MobCreationResult(mobEntityId, blueprintId, template)`.
+3. **YAML write.** Command calls `IMobContentWriter.WriteAsync(template)`. This step runs **before** the event publish and entity save — YAML write first ensures the template file exists on disk before any crash-window opens, matching the crash-safety ordering precedent in `LoginFlow` (character save before account save). Order: YAML write → `SaveEntityAsync` → publish `MobCreatedByAdminEvent`.
+4. **Event + save.** Calls `IPersistenceSystem.SaveEntityAsync(mobEntityId)`. Publishes `MobCreatedByAdminEvent(AdminEntityId, MobEntityId, BlueprintId, RoomEntityId)`. Writes a confirmation `PlainMessage` including the blueprint id.
+5. `AdminAuditHandler` (priority 80) logs the event.
+
+### Flow A-2 — Admin `setmob <blueprintId> <property> <value>`
+
+1. **Privilege gate.** As A-1.
+2. **Resolve mob.** Command looks up `blueprintId` in `ITemplateRegistry`. Not found → "Unknown blueprint id." Then queries `EntityService` for the live entity with matching `BlueprintComponent.BlueprintId`. Not found → "No live mob entity for that blueprint."
+3. **Mutation.** For the named property, calls the corresponding `IMobBuilderSystem.Set*` method. `keywords` splits `value` on whitespace. `type` parses as `MobType` enum; invalid value → "Unknown mob type."
+4. **YAML write + save.** Command calls `IMobContentWriter.WriteAsync(template)` first, then `IPersistenceSystem.SaveEntityAsync(mobEntityId)`. Order matches A-1: YAML write → entity save → event publish.
+5. **Event + confirmation.** Publishes `MobPropertySetByAdminEvent(AdminEntityId, MobEntityId, PropertyName, NewValue)`. Writes a confirmation `PlainMessage`.
+6. `AdminAuditHandler` (priority 80) logs the event.
+
+### Flow A-3 — World-content mob spawn (startup / reload)
+
+1. `WorldContentLoader.LoadTemplatesAsync` reads files from `<ContentDirectory>/mobs/` with the configured format extension. For each, calls `IContentSerializer.Deserialize("mob", body)` → `MobTemplateDeserializer.Deserialize` → `MobTemplate`. Registers in `ITemplateRegistry`.
+2. `SpawnMissingEntities` (existing): for mob templates with no live entity in the blueprint map, calls `ITemplateRegistry.Spawn(blueprintId)`. `MobTemplate.Apply` attaches `MobDataComponent` from template values. `SpawnMissingEntities` also attaches `PersistentEntity` and adds to `liveBlueprints`. Returns the `newlySpawned` set.
+3. **Immediate save.** `WorldContentLoader` calls `IPersistenceSystem.SaveEntityAsync` for every newly-spawned entity (mob and otherwise) to make IDs durable.
+4. **`PlaceMobsInRooms(liveBlueprints, newlySpawned)`.** For each `MobTemplate` whose entity is in `newlySpawned` and whose `SpawnRoomBlueprintId` is non-empty: resolves the room blueprint id → room entity id via `liveBlueprints`, attaches `LocationComponent { RoomEntityId }`. Restored-from-persistence entities are skipped. If the spawn room is unknown, logs a warning and the mob is created without a location.
+
+### Flow B-1 — `look` (no arg) with mobs present
+
+1. Player sends `look`. `LookCommand` calls `IBroadcastSystem.SendRoomDescriptionAsync(playerEntityId, roomEntityId)`.
+2. `BroadcastSystem.SendRoomDescriptionAsync` (extended here): queries all entities that have `MobDataComponent` + `LocationComponent.RoomEntityId == roomEntityId`. Builds `Mobs` list from `MobDataComponent.Name` for each.
+3. Produces `RoomDescriptionMessage` with `Mobs` populated. `TelnetOutputFormatter` renders mob names below the items section, one line per mob: `"<Name> is here."`.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Payload | Purpose |
+|---|---|---|---|
+| `MobCreatedByAdminEvent` | `MkMobCommand` | `uint AdminEntityId, uint MobEntityId, string BlueprintId, uint RoomEntityId` | Audit log; future editor hooks |
+| `MobPropertySetByAdminEvent` | `SetMobCommand` | `uint AdminEntityId, uint MobEntityId, string PropertyName, string NewValue` | Audit log |
+
+---
+
+## Systems / Handlers Involved
+
+| Artifact | Kind | Responsibility |
+|---|---|---|
+| `IMobBuilderSystem` / `MobBuilderSystem` | Domain system | Entity allocation, component attachment, template registration for ad-hoc mobs (`mkmob`) and property mutation (`setmob`) |
+| `IMobContentWriter` / `MobContentWriter` | Domain system (I/O) | Serializes `MobTemplate` to YAML; mirrors `IItemContentWriter` |
+| `MobTemplateDeserializer` | Infrastructure | Deserializes `kind: mob` YAML into `MobTemplate`; registered via `IContentSerializer` |
+| `WorldContentLoader` | Core system (extended) | Loads mob templates, spawns missing mob entities, places newly-spawned mobs in rooms |
+| `AdminAuditHandler` | Handler (existing, extended) | Subscribes to `MobCreatedByAdminEvent` and `MobPropertySetByAdminEvent`; logs structured entries |
+| `BroadcastSystem` | Core system (extended) | `SendRoomDescriptionAsync` populates `RoomDescriptionMessage.Mobs` |
+| `TelnetOutputFormatter` | Infrastructure (extended) | Renders `RoomDescriptionMessage.Mobs` lines |
+
+---
+
+## Content Tooling Impact
+
+**Data-file shape (`kind: mob`)**
+
+```yaml
+kind: mob
+blueprintId: mob.forest.wolf
+name: A grey wolf
+description: A lean wolf with silver-tipped fur.
+keywords:
+  - wolf
+  - grey
+type: Creature
+spawnRoomBlueprintId: room.forest.clearing
+```
+
+Fields:
+- `blueprintId` — unique mob blueprint id (e.g. `mob.<area>.<name>`)
+- `name` — display name shown in `look`
+- `description` — long description; resolved by a future `look <mob>` command (not wired in this slice)
+- `keywords` — prefix-matchable tokens for future `kill <mob>` / `look <mob>` commands
+- `type` — `MobType` enum value (data only; no behavior in this slice)
+- `spawnRoomBlueprintId` — blueprint id of the room this mob spawns in on first startup
+
+**Content directory.** YAML files are placed under `<World:ContentDirectory>/mobs/` (e.g. `data/content/mobs/wolf.yaml`).
+
+**Admin commands.** `mkmob [name]` and `setmob <blueprintId> <property> <value>` (properties: `name`, `description`, `keywords`, `type`).
+
+**`TemplateRegistry` entries.** Every `kind: mob` YAML file registers one `MobTemplate`.
+
+**Inspect / verify.** A designer confirms a mob is present by connecting a player to the spawn room and running `look`. The mob name should appear in the room description.
+
+---
+
+## Cross-cutting Surfaces Stressed
+
+| Surface | Assessment |
+|---|---|
+| **Commands** | Adequate — `AdminRequirement`, `ICommandDispatcher`, `ICommand` shape, argument parsing, and `PlainMessage` confirmation are all established. `mkmob` and `setmob` follow the exact shape of `mkitem` and `setitem`. No new command infrastructure needed. |
+| **Output** | Gap exposed (minor, resolvable in this slice) — `RoomDescriptionMessage` has no `Mobs` field today. The field and its formatter rendering path must be added. This is a surgical extension of an existing message shape; no new output infrastructure is required. |
+| **ECS** | Adequate — `EntityService`, `HasComponent<T>`, `GetAllComponents<T>`, and component attachment are all in place. |
+| **Persistence** | Adequate — two-level model (`PersistentEntity` + `[Persistent]`), `SaveEntityAsync`, and `FlushAllPersistentAsync` are established. `MobDataComponent` follows the same model as `ItemDataComponent`. |
+| **Event bus** | Adequate — `IEventBus`, handler subscription, priority model, and `AdminAuditHandler` subscribing to new event types all work without changes. |
+| **Content templates** | Gap exposed (minor, resolvable in this slice) — `WorldContentLoader` does not yet handle `kind: mob`. Adding `LoadKindAsync("mob", "mobs", ct)`, `PlaceMobsInRooms`, and `MobTemplateDeserializer` extends the existing pattern without touching the loading interface. |
+| **Broadcast** | Gap exposed (minor, resolvable in this slice) — `SendRoomDescriptionAsync` does not currently populate a `Mobs` field. `BroadcastSystem` must query `MobDataComponent`-bearing entities in the room. A `GetAllComponents<MobDataComponent>()` call filtered by room id covers this. |
+| **Time / heartbeat** | Not stressed. Wandering (the only mob behavior that requires a tick) is deferred. |
+| **Configuration** | Adequate — `World:ContentDirectory` drives the content root; adding a `mobs/` subdirectory requires no config change. |
+
+---
+
+## Flows Introduced or Modified
+
+| # | Flow | Change |
+|---|---|---|
+| 1 | Server startup | Extended: `LoadTemplatesAsync` adds a `kind: mob` loading pass; `SpawnMissingEntities` spawns mob entities; `PlaceMobsInRooms` places newly-spawned mobs. Mermaid diagram updated to show mob loading and placement steps. |
+| 5 | Content reload | Extended: `ReloadAsync` now includes mob templates in the additive re-scan, `SpawnMissingEntities`, and `PlaceMobsInRooms` pass. The existing Flow 5 mermaid is missing `PlaceItemsInRooms` (pre-existing gap) and will also need `PlaceMobsInRooms`; both are added to the diagram in this PR. |
+| 6 | Output rendering | Extended: `RoomDescriptionMessage` gains a `Mobs` field; `TelnetOutputFormatter` case-match adds mob rendering below items. |
+| — | Admin mob creation (`mkmob`) | New flow (Flow 15 in `flows/README.md`): mirrors Flow 12 (`mkitem`). |
+
+---
+
+## Reference Catalog Updates
+
+- `docs/reference/components.md` — add `MobDataComponent` row to the cross-cutting table.
+- `docs/reference/archetypes.md` — note that the `Mob` archetype now has a partial real implementation: required `MobDataComponent` + `LocationComponent`; `BlueprintComponent` and `PersistentEntity` present on all template-spawned instances. The archetype registry is not yet built (still target-state); this is a catalog tracking note.
+- `docs/reference/systems.md` — add rows for `IMobBuilderSystem` / `MobBuilderSystem`, `IMobContentWriter` / `MobContentWriter`, and note the `WorldContentLoader` and `BroadcastSystem` extensions.
+- `docs/reference/handlers.md` — update the `AdminAuditHandler` entry's "Events:" line to add `MobCreatedByAdminEvent` and `MobPropertySetByAdminEvent`.
+
+---
+
+## Design Notes
+
+- **`MobDataComponent` is cross-cutting.** Placed under `Core/ECS/Components/` so future modules (combat, AI, dialogue) can query mob names without taking a dependency on `Core/Modules/Mobs/`. This mirrors `ItemDataComponent`.
+- **Mob persistence.** Mobs carry `PersistentEntity` so they survive restarts without a respawn system. When the death/respawn slice lands, the respawn system may choose to destroy and re-seed mob instances rather than persist them — at that point `PersistentEntity` may be removed from mob entities. This is acknowledged debt.
+- **`BlueprintComponent` and respawn.** Unlike items (which clear `BlueprintComponent` on pickup to free the blueprint slot — INV-21), mobs have no "pickup" transition. When a mob is killed in a future slice, the respawn system will decide whether to reuse the entity (HP reset) or destroy it and spawn a fresh one (clearing `BlueprintComponent` from the corpse first). This decision belongs to the death/respawn slice; `BlueprintComponent` is retained on live mob entities for now so `setmob` lookups work. The INV-21 obligation (clear `BlueprintComponent` on the dead entity before re-spawning a new one, or reset in place) is tracked in `docs/roadmap/backlog.md` under the mob death/respawn item.
+- **`PlaceMobsInRooms` mirrors `PlaceItemsInRooms`.** Only entities in the `newlySpawned` set are placed. Restored-from-persistence mobs already carry a saved `LocationComponent`; overriding it would clobber their live position (and, once wandering exists, wherever they wandered to).
+- **`MobType` is data only.** No matching or routing logic uses `MobType` in this slice. It is a classification field for future use (vendor dialogue, guard aggression flags, AI routing).
+- **Mob display in `look`.** One line per mob: `"<Name> is here."`. Identical-name mobs are not stacked ("A grey wolf is here.\nA grey wolf is here." not "Two grey wolves are here."). Stacking is acknowledged debt.
+- **`look <mob>` is out of scope.** Inspecting a specific mob by keyword belongs to the same slice that introduces `kill <mob>` argument resolution. `LookCommand`'s item-fallback path is not extended to mob entities here.
+- **No loot or equipment.** `InventoryComponent` and `EquipmentComponent` are not attached to mob entities in this slice. They are added when the combat/death slice requires them.
+
+---
+
+## Related
+
+- [`items-and-inventory.md`](items-and-inventory.md) — slice 6; `IItemBuilderSystem`, `PlaceItemsInRooms`, `ItemTemplateDeserializer`, `IItemContentWriter` are the direct precedents for this slice's new interfaces.
+- [`equipment.md`](equipment.md) — slice 7; `EquipmentComponent` is cross-cutting for players and mobs; not attached in this slice.
+- [`world-content-loading-and-admin-substrate.md`](world-content-loading-and-admin-substrate.md) — slice 2; `ITemplateDeserializer` pattern and `WorldContentLoader` extension points.
+- [`persistence-two-level-model.md`](persistence-two-level-model.md) — slice 5b; `[Persistent]` + `PersistentEntity` model that mobs follow.
+- [`output-framework.md`](output-framework.md) — slice 4; `RoomDescriptionMessage` extended here with a `Mobs` field.
+- [`attributes.md`](attributes.md) — slice 8a (follows this slice); extends `MobTemplate` with `Level`, `MaxHp`, and base stats.
+
+For the slice queue, see [`../roadmap/plan.md`](../roadmap/plan.md).


### PR DESCRIPTION
## Summary

- Adds [`docs/use-cases/mobs.md`](docs/use-cases/mobs.md) — slice 8 spec for basic mob entity model and spawn (no wandering). Covers `MobDataComponent`, `MobTemplate` (`kind: mob` YAML), `mkmob`/`setmob` admin commands, `WorldContentLoader` extension, and mob room presence in `look`. Spec review gate passed (2026-05-25).
- Adds [`docs/use-cases/attributes.md`](docs/use-cases/attributes.md) — slice 8a spec for attributes and vitals (`AttributesComponent`, `PoolsComponent`, `score` command, `setplayer` admin command). Prerequisite for combat (slice 9).
- Updates `docs/use-cases/README.md` index, `docs/roadmap/plan.md` slice queue and current focus, and `docs/roadmap/backlog.md` with the mob death/respawn INV-21 obligation.

## Spec review status

- **mobs.md** — APPROVE WITH NITS (architecture-reviewer spec-mode, 2026-05-25). No blocking findings. Remaining nits are implementation-time commitments enforced at the code-review gate.
- **attributes.md** — APPROVE WITH NITS (three re-review passes; final verdict clean). All blocking findings resolved. Advisory notes recorded in the doc.

## Test plan

- [x] Both use-case docs render cleanly in GitHub markdown (no broken links, well-formed tables)
- [x] `docs/use-cases/README.md` index links to both new files
- [x] `docs/roadmap/plan.md` slice queue shows slice 8 (mobs), slice 8a (attributes), slice 9 (combat) in correct order
- [x] mobs.md carries `**Spec review:** passed (2026-05-25)` so the implement-use-case agent skips the spec gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)