### PR TITLE
docs: use-case specs for slices 9-a/9-b/9-c/9 (combat prerequisite planning)

### DIFF
--- a/.claude/skills/add-domain-system/SKILL.md
+++ b/.claude/skills/add-domain-system/SKILL.md
@@ -31,10 +31,12 @@ public class CombatSystem : ICombatSystem
 ## Dependency rules
 
 - **Domain systems can depend on core systems** (DiceSystem, SkillSystem, AttributeCalculator, EffectTracker, TimeSystem, RandomGeneratorSystem).
-- **Domain systems should NOT depend on other domain systems directly.** Coordinate cross-domain effects through handlers that publish events.
-- **No `IEventBus` inside a domain system.** Services don't publish — handlers do.
+- **Domain systems may depend on other domain systems** when the dependency is lower-level in the feature graph and does not form a cycle. The architecture checklist (`01-layers.md`) explicitly permits `Domain → Domain (same or lower level)`. Example: `ICombatSystem` calling `IStatSystem` to compute effective stats is valid — `IStatSystem` is a pure-read computation layer that `ICombatSystem` consumes.
+- **Prefer event-driven coordination for lateral/peer domain systems** when the callee may itself need to publish downstream events, or when tight coupling would prevent independent testing of each system. This is a design preference, not an invariant.
+- **The hard prohibition is Core → Domain** (INV-2). Core systems are generic and must not know about game-specific domain concepts.
+- **No `IEventBus` inside any system, domain or core.** Systems compute and return results; Initiators and Handlers publish events (INV-5).
 
-Why: this keeps systems composable, unit-testable, and free of side effects.
+Why: domain systems may compose each other to implement game rules (e.g. combat calls stat system calls attribute system). The constraint is that the dependency graph must remain acyclic and flow downward within the domain layer.
 
 ## Pure where possible
 

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -26,9 +26,9 @@ Evaluate after `TimeSystem` exists and concurrency shape is known. May not be ne
 
 ## Phase 3+ ideas (not yet a slice)
 
-### 🔵 Heartbeat / TimeSystem
+### ~~🔵 Heartbeat / TimeSystem~~ — promoted to slice 9-b
 
-Needed for combat pulses, mob AI ticks, effect expiries. Lands as part of the first Phase 3 slice that needs scheduled work — currently expected to be the mob-wandering slice (slice 8 in [`plan.md`](plan.md)).
+Promoted to an active slice. `IHeartbeatService` + `HeartbeatTickEvent` land as Phase 3 slice 9-b. See [`plan.md`](plan.md) slice queue.
 
 ### 🔵 Web / SignalR dual client
 

--- a/docs/roadmap/plan.md
+++ b/docs/roadmap/plan.md
@@ -34,7 +34,14 @@ For the per-slice ledger of completed work, read [`done.md`](done.md).
 
 ## Current focus
 
-**Phase 3 slice 9 — Combat.** Slice 8a is complete; `AttributesComponent` and `PoolsComponent` are live for both players and mobs, providing the HP and stat ground truth combat needs. Slice 9 delivers the core combat loop: `kill <mob>`, attack/defense resolution using `AttributesComponent`, damage application to `PoolsComponent.CurrentHp`, and `CombatEndedEvent`. Spec: [`../use-cases/combat.md`](../use-cases/combat.md). Prerequisites: slices 8 and 8a (both complete).
+**Phase 3 slices 9-a / 9-b / 9-c — Combat prerequisites (parallel).** Slice 8a is complete. Before the core combat loop can land, three independent infrastructure slices must ship: entity state management (9-a), the heartbeat time system (9-b), and the stat computation system (9-c). All three can be designed and implemented in parallel; slice 9 (combat proper) is blocked on all three.
+
+| Sub-slice | Spec | Status |
+|---|---|---|
+| **9-a — Entity state management** | [`../use-cases/entity-state-management.md`](../use-cases/entity-state-management.md) | 🟢 planning |
+| **9-b — Time system (heartbeat)** | [`../use-cases/time-system.md`](../use-cases/time-system.md) | 🟢 planning |
+| **9-c — Stat computation system** | [`../use-cases/stat-system.md`](../use-cases/stat-system.md) | 🟢 planning |
+| **9 — Combat** | [`../use-cases/combat.md`](../use-cases/combat.md) | 🟡 blocked on 9-a, 9-b, 9-c |
 
 The per-slice spec is the single source of truth for "what is being built right now" — this file deliberately does not duplicate it.
 
@@ -71,7 +78,10 @@ Order is **revised** from the original Phase 3 list to pull content tooling forw
 | 7 | Equipment + `wear`/`remove` | Gear; `EquipmentComponent`, `WornSlot` enum, `wear`/`remove`/`equipment` commands | ✅ done |
 | 8 | Mobs (basic entity model and spawn) | Populated world; no wandering | ✅ done |
 | 8a | Attributes and vitals (`AttributesComponent`, `PoolsComponent`, `score`) | HP + base stats required for combat | ✅ done |
-| 9 | Combat | Core gameplay loop | 🟢 next |
+| 9-a | Entity state management | Centralized entity state flags; command gating; prereq for combat and future states (resting, incapacitation, …) | 🟢 next |
+| 9-b | Time system (heartbeat) | `IHeartbeatService`, `HeartbeatTickEvent`; prereq for combat, mob AI, effect expiry | 🟢 next |
+| 9-c | Stat computation system | `IStatSystem` effective-stat pipeline; base + equipment bonus seam for future effects/buffs | 🟢 next |
+| 9 | Combat | Core gameplay loop | 🟡 blocked on 9-a, 9-b, 9-c |
 | 10 | Death and respawn | Combat is terminal until this exists | 🟡 blocked on 9 |
 | 11 | Skills | Character progression | 🟢 ready after 9 |
 | 12 | Shopping | Economy | 🟢 ready after 6 |

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -48,6 +48,10 @@ At slice close-out, `sync-roadmap` **trims** it to its durable behavior spec —
 | `planned` | [`equipment.md`](equipment.md) | Phase 3 slice 7 |
 | `planned` | [`mobs.md`](mobs.md) | Phase 3 slice 8 |
 | `planned` | [`attributes.md`](attributes.md) | Phase 3 slice 8a |
+| `planned` | [`entity-state-management.md`](entity-state-management.md) | Phase 3 slice 9-a |
+| `planned` | [`time-system.md`](time-system.md) | Phase 3 slice 9-b |
+| `planned` | [`stat-system.md`](stat-system.md) | Phase 3 slice 9-c |
+| `planned` | [`combat.md`](combat.md) | Phase 3 slice 9 |
 | `deferred` | [`admin-privilege-elevation.md`](admin-privilege-elevation.md) | Future (TBD) — placeholder |
 
 > See [`../roadmap/plan.md`](../roadmap/plan.md#slice-queue) for the full slice queue and current focus.

--- a/docs/use-cases/combat.md
+++ b/docs/use-cases/combat.md
@@ -1,0 +1,312 @@
+# Use Case: Combat
+
+**Status:** planned
+**Actors:** Player, Mob, System
+**Module:** `Core/Modules/Combat/` (new); `Core/Modules/Mobs/` (mob death path); `Core/Modules/EntityState/` (state management — slice 9-a); `Core/Modules/Time/` (heartbeat — slice 9-b); `Core/Modules/Stats/` (stat computation — slice 9-c); `Core/ECS/Components/` (`CombatStateComponent` — cross-cutting transient)
+
+---
+
+## Description
+
+Introduces the core combat loop: a player sends `kill <mob>`, which initiates melee combat between the player and the target mob. Combat state is tracked through two complementary layers introduced by prerequisite slices: `EntityStateComponent` (centralized state flag, slice 9-a) records that an entity is `InCombat`; `CombatStateComponent` (combat-specific metadata) records the opponent's entity id. Combat rounds are driven by the `HeartbeatTickEvent` (slice 9-b) — a `CombatTickHandler` subscribes to each tick, processes all active combat pairs, and publishes per-round results. Effective stats (attack power, defense) are computed by `IStatSystem` (slice 9-c), which aggregates base attributes and equipment bonuses without the caller knowing the sources.
+
+Combat ends when either participant's HP reaches zero: a mob at zero HP dies (entity destroyed, blueprint slot freed per INV-21, `CombatEndedEvent` published with `Outcome=MobDied`); a player at zero HP is reduced to 1 HP and combat ends (`CombatEndedEvent` with `Outcome=PlayerIncapacitated`), deferring true player death mechanics to slice 10. The `flee` command always succeeds and exits combat immediately.
+
+**Design scope.** No spell casting, no skills, no group combat, no faction checks, no mob aggro. Weapon equipped in `MainHand` contributes attack power via `IStatSystem.GetEffectiveAttackPower` (reads `ItemDataComponent.DamageBonus` defined in slice 9-c). Round cadence is the global `Heartbeat:IntervalMs` config key — no `setroundtime` command.
+
+**Prerequisites:** Slices 1–8a complete. Slices 9-a (entity state management), 9-b (time system), and 9-c (stat computation system) complete.
+
+---
+
+## Preconditions
+
+- Slices 1–8a complete. Reused surfaces: `EntityService`, `IEventBus`, `IBroadcastSystem`, `IPersistenceSystem`, `ISessionManager`, `ICommandDispatcher`, `IAdminAuthorizer`, `AdminRequirement`, `MobDataComponent`, `BlueprintComponent`, `LocationComponent`, `AttributesComponent`, `PoolsComponent`, `EquipmentComponent`, `ItemDataComponent`.
+- **Slice 9-a complete:** `EntityStateComponent`, `IEntityStateService` (`TryEnterState`, `ExitState`, `IsInState`, `GetStates`), `[Flags] EntityState { None, InCombat, Resting, Incapacitated }`.
+- **Slice 9-b complete:** `HeartbeatBackgroundService`, `HeartbeatTickEvent { TickId: long, Timestamp: DateTimeOffset, Elapsed: TimeSpan }`, config key `Heartbeat:IntervalMs` (default 2000).
+- **Slice 9-c complete:** `IStatSystem` (`GetEffectiveAttackPower`, `GetEffectiveDefense`, `GetCurrentHp`, `GetMaxHp`); `IAttributeSystem.SetCurrentHp(uint, int)` with `[0, MaxHp]` clamp; `ItemDataComponent.DamageBonus: int` (default 0); `setitem dmg <n>` admin command.
+- Every player and mob entity carries `AttributesComponent` and `PoolsComponent` (slice 8a guaranteed).
+- Every mob entity carries `MobDataComponent`, `LocationComponent`, `BlueprintComponent`.
+
+---
+
+## Postconditions
+
+- `CombatStateComponent { OpponentEntityId: uint }` exists at `Core/ECS/Components/CombatStateComponent.cs` — cross-cutting, not `[Persistent]`. Metadata companion to `EntityState.InCombat`; holds who this entity is fighting.
+- `ICombatSystem` (domain, `Core/Modules/Combat/Systems/`) computes attack resolution using `IStatSystem` and mutates HP via `IAttributeSystem.SetCurrentHp`. Returns `CombatRoundResult` records; never touches the event bus or persistence (INV-5, INV-8).
+- `CombatTickHandler` (priority 20, `Core/Modules/Combat/Handlers/`, subscribes to `HeartbeatTickEvent`) queries all entities with `CombatStateComponent`, deduplicates pairs, calls `ICombatSystem.ExecuteRound`, and publishes `CombatRoundEvent` and optionally `CombatEndedEvent`. This handler is the bridge between the time system and the combat domain.
+- `kill <mob>`: calls `IEntityStateService.TryEnterState(InCombat)` and `ICombatSystem.StartCombat`; publishes `CombatStartedEvent`.
+- `flee`: calls `ICombatSystem.EndCombat` + `IEntityStateService.ExitState(InCombat)` on both participants; publishes `CombatEndedEvent(Outcome=PlayerFled)`.
+- On `MobDied`: `CombatMobDeathHandler` calls `IEntityStateService.ExitState(InCombat)` on the surviving player, clears `BlueprintComponent` on the mob (INV-21), calls `EntityService.DestroyEntity(mobEntityId)`.
+- On `PlayerIncapacitated`: `CombatTickHandler` clamps player HP to 1, calls `ICombatSystem.EndCombat` + `IEntityStateService.ExitState` on both, publishes `CombatEndedEvent(PlayerIncapacitated)`.
+- `CombatHandler` (priority 20) handles `CombatStartedEvent`, `CombatRoundEvent`, `CombatEndedEvent` for output fan-out only. Does not call systems or mutate state.
+- `AdminAuditHandler` extended to log `CombatEndedEvent`.
+- `CombatModule` DI entry point (`Core/Modules/Combat/CombatModule.cs`), called from `Server/Program.cs`.
+
+---
+
+## Main Flow
+
+### Flow C-1 — `kill <mob>` (combat initiation)
+
+1. Player sends `kill <mob>`. `KillCommand.ExecuteAsync` runs (no privilege requirement).
+2. **State guard.** Calls `IEntityStateService.IsInState(playerEntityId, EntityState.InCombat)`. If true → "You are already fighting!" and return.
+3. **Target resolution.** Reads invoker's `LocationComponent.RoomEntityId`. Calls `ICombatSystem.TryFindTargetInRoom(roomId, token, out uint mobEntityId)` — prefix-matches `token` against `MobDataComponent.Name` and `MobDataComponent.Keywords` for all entities with `MobDataComponent` whose `LocationComponent.RoomEntityId == roomId`. No match → "You don't see that here."
+4. **State transition (player).** Calls `IEntityStateService.TryEnterState(playerEntityId, EntityState.InCombat, out failReason)`. On failure → writes `failReason` and returns. (Guards against racing state changes between steps 2 and 4.)
+5. **State transition (mob).** Calls `IEntityStateService.TryEnterState(mobEntityId, EntityState.InCombat, out _)`. Mobs do not reject; failure is a warn log and a no-op (mob has no player session to write errors to).
+6. **Combat metadata.** Calls `ICombatSystem.StartCombat(playerEntityId, mobEntityId)` — attaches `CombatStateComponent { OpponentEntityId }` to both entities. No persistence call (transient).
+7. **Event.** Publishes `CombatStartedEvent(AttackerEntityId: playerEntityId, DefenderEntityId: mobEntityId, RoomEntityId)`.
+8. **Output.** `CombatHandler` (priority 20) handles `CombatStartedEvent`: writes "You attack <mob>!" to the attacker; broadcasts "<PlayerName> attacks <mob>!" to other room occupants.
+
+### Flow C-2 — Combat round pulse (heartbeat-driven)
+
+1. `HeartbeatBackgroundService` (slice 9-b) publishes `HeartbeatTickEvent` every `Heartbeat:IntervalMs` ms (default 2000).
+2. `CombatTickHandler` (priority 20, subscribes to `HeartbeatTickEvent`) queries all entities with `CombatStateComponent`. Deduplicates into unique attacker→defender pairs: for each entity with `CombatStateComponent`, process the pair only when `entityId < OpponentEntityId` (prevents A→B and B→A from both being processed as separate pairs).
+3. For each pair, calls `ICombatSystem.ExecuteRound(attackerEntityId, defenderEntityId)` → `CombatRoundResult`.
+4. Publishes `CombatRoundEvent(AttackerEntityId, DefenderEntityId, RoomEntityId, Result)`.
+5. `CombatHandler` (priority 20) handles `CombatRoundEvent`: broadcasts hit/miss/damage narrative to all players in the room.
+6. **Mob death path** (if `result.Outcome == MobDied`): `CombatTickHandler` reads `MobDataComponent.Name` from the mob entity **before** publishing (point-in-time capture), then publishes `CombatEndedEvent(Outcome=MobDied, DefenderName=mobName)`. `CombatHandler` (priority 20) receives the event first and broadcasts "You have slain <mob>!" using `DefenderName` from the payload. `CombatMobDeathHandler` (priority 80) receives the event after, calls `IEntityStateService.ExitState(attackerEntityId, InCombat)`, clears `BlueprintComponent` (INV-21), and calls `EntityService.DestroyEntity(mobEntityId)`. Priority ordering ensures output before destruction.
+7. **Player incapacitation path** (if `result.Outcome == PlayerIncapacitated`): `CombatTickHandler` calls `IAttributeSystem.SetCurrentHp(playerEntityId, 1)` (clamp to 1 instead of 0 — stub for slice 10), then `ICombatSystem.EndCombat` + `IEntityStateService.ExitState(InCombat)` on both entities, then publishes `CombatEndedEvent(Outcome=PlayerIncapacitated)`. `CombatHandler` broadcasts incapacitation narrative.
+
+### Flow C-3 — `flee` (player-initiated combat exit)
+
+1. Player sends `flee`. `FleeCommand.ExecuteAsync` runs (no privilege requirement).
+2. Checks `IEntityStateService.IsInState(playerEntityId, EntityState.InCombat)`. If not → "You are not in combat."
+3. Reads `CombatStateComponent.OpponentEntityId` to identify the mob.
+4. Calls `ICombatSystem.EndCombat(playerEntityId, mobEntityId)` — removes `CombatStateComponent` from both entities.
+5. Calls `IEntityStateService.ExitState(playerEntityId, EntityState.InCombat)` and `IEntityStateService.ExitState(mobEntityId, EntityState.InCombat)`.
+6. Publishes `CombatEndedEvent(AttackerEntityId: playerEntityId, DefenderEntityId: mobEntityId, Outcome: PlayerFled, RoomEntityId)`.
+7. `CombatHandler` broadcasts "<PlayerName> flees from combat!" to the room; writes "You flee from combat!" to the player.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Payload | Purpose |
+|---|---|---|---|
+| `CombatStartedEvent` | `KillCommand` | `uint AttackerEntityId, uint DefenderEntityId, uint RoomEntityId` | Initiates combat; future AI/faction hooks subscribe |
+| `CombatRoundEvent` | `CombatTickHandler` | `uint AttackerEntityId, uint DefenderEntityId, uint RoomEntityId, CombatRoundResult Result` | Per-round narrative and outcome routing |
+| `CombatEndedEvent` | `CombatTickHandler`, `FleeCommand` | `uint AttackerEntityId, uint DefenderEntityId, CombatEndOutcome Outcome, uint RoomEntityId, string? DefenderName` | Outcome routing; `CombatMobDeathHandler` responds to `MobDied`; slice 10 responds to `PlayerIncapacitated`. `DefenderName` is captured at publish time (before any entity destruction) so `CombatHandler` can render the death narrative without re-reading a potentially destroyed entity. |
+
+`CombatEndOutcome` enum: `MobDied`, `PlayerIncapacitated`, `PlayerFled`.
+
+---
+
+## Systems / Handlers Involved
+
+### New: `ICombatSystem` (domain, `Core/Modules/Combat/Systems/`)
+
+```csharp
+public interface ICombatSystem
+{
+    bool TryFindTargetInRoom(uint roomEntityId, string token, out uint mobEntityId);
+    void StartCombat(uint attackerEntityId, uint defenderEntityId);
+    void EndCombat(uint attackerEntityId, uint defenderEntityId);
+    CombatRoundResult ExecuteRound(uint attackerEntityId, uint defenderEntityId);
+}
+
+public readonly record struct CombatRoundResult(
+    uint AttackerEntityId,
+    uint DefenderEntityId,
+    int DamageDealt,
+    bool AttackerHit,
+    CombatRoundOutcome Outcome);
+
+public enum CombatRoundOutcome { Hit, Miss, MobDied, PlayerIncapacitated }
+```
+
+`ExecuteRound` formula (pure math; no events; no persistence — INV-5/INV-8):
+
+- **Hit check:** `roll = Random.Shared.Next(1, 21) + IStatSystem.GetEffectiveDexterity(attackerEntityId) / 2`. Hit if `roll >= 10 + IStatSystem.GetEffectiveDefense(defenderEntityId)`. Miss → `DamageDealt = 0`.
+- **Damage:** `base = Random.Shared.Next(1, IStatSystem.GetEffectiveAttackPower(attackerEntityId) + 2)`. Calls `IAttributeSystem.SetCurrentHp(defenderEntityId, currentHp - damage)` — clamp to `[0, MaxHp]` enforced in the setter (INV-8).
+- **Outcome determination:** `MobDied` if defender has `MobDataComponent` and `IStatSystem.GetCurrentHp(defenderEntityId) == 0`. `PlayerIncapacitated` if defender has `CharacterComponent` and HP == 0.
+- `TryFindTargetInRoom`: iterates entities with `MobDataComponent` + matching `LocationComponent.RoomEntityId`; prefix-matches `token` against `MobDataComponent.Keywords` and `MobDataComponent.Name`.
+- `StartCombat` / `EndCombat`: attaches / removes `CombatStateComponent` via `EntityService`. Does not call `IEntityStateService` — cohesion preference; commands and handlers coordinate both layers. See Design Notes.
+
+### New: `CombatTickHandler` (priority 20, `Core/Modules/Combat/Handlers/`)
+
+**Subscribes to:** `HeartbeatTickEvent`
+
+Bridge between the time system and combat. On each tick: queries all entities with `CombatStateComponent`, deduplicates pairs (lower entity id = attacker in pair), calls `ICombatSystem.ExecuteRound` for each, publishes `CombatRoundEvent`, and handles terminal outcomes inline (publishes `CombatEndedEvent`, calls cleanup methods before publishing so subscribers see a clean state).
+
+### New: `CombatHandler` (priority 20, `Core/Modules/Combat/Handlers/`)
+
+**Subscribes to:** `CombatStartedEvent`, `CombatRoundEvent`, `CombatEndedEvent`
+
+Pure output fan-out. On `CombatStartedEvent`: broadcasts attack announcement. On `CombatRoundEvent`: broadcasts hit/miss/damage narrative. On `CombatEndedEvent(PlayerFled)`: broadcasts flee text. On `CombatEndedEvent(PlayerIncapacitated)`: broadcasts incapacitation narrative and writes personal message to the player. Does not call systems, does not mutate state.
+
+### New: `CombatMobDeathHandler` (priority 80, `Core/Modules/Combat/Handlers/`)
+
+**Subscribes to:** `CombatEndedEvent` where `Outcome == MobDied`
+
+Priority 80 — deliberately lower than `CombatHandler` (priority 20). This ordering guarantee ensures `CombatHandler` reads the mob's name from `CombatEndedEvent.DefenderName` (point-in-time capture) and broadcasts the death narrative **before** `CombatMobDeathHandler` destroys the mob entity. Calls `IEntityStateService.ExitState(attackerEntityId, EntityState.InCombat)`, clears `BlueprintComponent` on the mob entity (INV-21), calls `EntityService.DestroyEntity(mobEntityId)`. Does not publish events. Loot drop deferred to slice 10.
+
+### New: `KillCommand` (`Core/Modules/Combat/Commands/`)
+
+Verb: `kill`, alias: `k`. `MatchingMode.Partial`. No `RequiredPrivileges`. Argument: `string target` (free text). Uses `IEntityStateService.IsInState` for in-combat guard; `ICombatSystem.TryFindTargetInRoom` for target resolution; `IEntityStateService.TryEnterState` + `ICombatSystem.StartCombat` for initiation; publishes `CombatStartedEvent`.
+
+### New: `FleeCommand` (`Core/Modules/Combat/Commands/`)
+
+Verb: `flee`. `MatchingMode.Partial`. No `RequiredPrivileges`. No arguments. Uses `IEntityStateService.IsInState` for guard; `ICombatSystem.EndCombat` + `IEntityStateService.ExitState` for cleanup; publishes `CombatEndedEvent(PlayerFled)`.
+
+### Reused: `IStatSystem` (slice 9-c)
+
+`ExecuteRound` calls `GetEffectiveAttackPower(attackerEntityId)`, `GetEffectiveDefense(defenderEntityId)`, `GetEffectiveDexterity(attackerEntityId)`, and `GetCurrentHp`. Never reads `IAttributeSystem` or `EquipmentComponent` directly — stat aggregation is entirely `IStatSystem`'s concern.
+
+### Reused: `IAttributeSystem.SetCurrentHp` (slice 9-c)
+
+Write seam for HP mutation. Clamp to `[0, MaxHp]` enforced by the setter; `CombatSystem` passes the raw subtracted value and trusts the clamp.
+
+### Reused: `IEntityStateService` (slice 9-a)
+
+`KillCommand` and `FleeCommand` call `TryEnterState`/`ExitState`/`IsInState`. `CombatMobDeathHandler` calls `ExitState(InCombat)` on the surviving player. `CombatTickHandler` calls `ExitState` on both participants for `PlayerIncapacitated`.
+
+### Reused: `IBroadcastSystem`
+
+`CombatHandler` uses `SendToRoomAsync` for all room-scope narrative.
+
+### Extended: `AdminAuditHandler`
+
+Subscribes to `CombatEndedEvent`; logs outcome + participant entity ids for audit visibility during testing.
+
+---
+
+## Content Tooling Impact
+
+- **`setitem dmg <n>`** — defined and shipped in slice 9-c. Sets `ItemDataComponent.DamageBonus` on a weapon entity. YAML field `damageBonus` in item templates. No new admin command added in this slice.
+- **No `setroundtime` command.** Round cadence is `Heartbeat:IntervalMs` in `appsettings.json` (slice 9-b). Tuning for local development: set `Heartbeat:IntervalMs` in `appsettings.Development.json`. Runtime mutation is not needed for Phase 3.
+- **Designer workflow:** `mkmob` to create a mob, `setmob level/hp/str/dex/con` to configure it, `mkitem` to create a weapon, `setitem dmg <n>` to set its bonus, `kill <mob>` to fight it. No new YAML schema changes in this slice.
+
+---
+
+## Cross-Cutting Surfaces Stressed
+
+### Commands — Adequate
+
+`KillCommand` and `FleeCommand` follow the existing `ICommand` + `ICommandDispatcher` pattern exactly. No framework change needed.
+
+### Output — Adequate
+
+All narrative routed through `IBroadcastSystem.SendToRoomAsync` and `IOutputWriter.WriteAsync` with `PlainMessage`. No new `IOutputMessage` shape required — combat narrative is plain text for Phase 3.
+
+### Event bus — Adequate
+
+Three new event types follow the thin-payload past-tense pattern. `KillCommand` and `FleeCommand` are Initiators; `CombatTickHandler` subscribes to `HeartbeatTickEvent` and publishes round events (handler-as-secondary-publisher is an established pattern). INV-5 satisfied throughout.
+
+### ECS queries — Adequate for Phase 3
+
+`CombatTickHandler` performs a component-typed scan on each heartbeat tick to find all entities with `CombatStateComponent`. This is the same linear scan `PersistenceSystem` relies on. Adequate for Phase 3 entity counts (low thousands). Phase 4 performance pass covers hot-path LINQ.
+
+### Broadcast — Adequate
+
+Room-scope combat narrative via existing `SendToRoomAsync` with no audience filter (all room occupants see combat events). No new broadcast mode required.
+
+### Time / heartbeat — Adequate (slice 9-b prerequisite)
+
+`HeartbeatBackgroundService` publishes `HeartbeatTickEvent`; `CombatTickHandler` subscribes. Round cadence is `Heartbeat:IntervalMs`. If per-combat-type cadence is needed in future, a `Combat:RoundEveryNTicks` config key can filter which ticks `CombatTickHandler` processes — deferred.
+
+### Entity state — Adequate (slice 9-a prerequisite)
+
+`IEntityStateService.TryEnterState`/`ExitState`/`IsInState` gate all state transitions. `EntityState.InCombat` is the flag. Transition rules from slice 9-a enforce incompatibilities (e.g., cannot rest while `InCombat`).
+
+### Stat computation — Adequate (slice 9-c prerequisite)
+
+`IStatSystem` aggregates base stats + equipment bonus. `ICombatSystem.ExecuteRound` calls only `IStatSystem` methods — never reads attribute or equipment components directly. Future effects plug into `IStatSystem` without changing `ICombatSystem`.
+
+### Persistence — Adequate
+
+`CombatStateComponent` is not `[Persistent]` — transient state clears on restart by design. `PoolsComponent.CurrentHp` mutations persist via the area-scoped periodic flush (up to `Persistence:FlushIntervalSeconds` staleness on non-graceful exit — acceptable for Phase 3).
+
+### Thread safety — Acknowledged debt
+
+`CombatTickHandler` executes on the heartbeat background thread. `EntityService` and `IEventBus` must be safe for concurrent reads from player sessions and writes from the tick. Phase 4 thread-safety review now has a concrete starting point (`backlog.md`).
+
+### Modules — Adequate
+
+`CombatModule` (new, `Core/Modules/Combat/CombatModule.cs`) registers `ICombatSystem`, `CombatTickHandler`, `CombatHandler`, `CombatMobDeathHandler`, `KillCommand`, `FleeCommand`. Called from `Server/Program.cs`. Pattern mirrors `AddMobsModule`, `AddItemsModule`.
+
+---
+
+### Persistence opt-in audit
+
+| Entity / component | Level 1 (PersistentEntity)? | Level 2 ([Persistent])? | Rationale |
+|---|---|---|---|
+| `CombatStateComponent` | n/a | No | Transient: stale combat state on restart would reference entities that may not exist. Cleared on crash by design. |
+| `PoolsComponent.CurrentHp` | Existing | Yes (existing) | HP changes flushed by periodic timer. Up to 60 s potential loss on crash; acceptable Phase 3. |
+| Mob entity (destroyed on death) | Existing | Yes (existing) | `DestroyEntity` removes the entity; pending flush cycles skip it. Stale entity files are harmless (ignored on next startup). Cleanup deferred to slice 10. |
+
+---
+
+## Flows Introduced or Modified
+
+### New: Flow 16 — `kill <mob>` (combat initiation)
+
+Added to `docs/architecture/flows/README.md`. Trigger: player sends `kill <mob>`. Covers: `KillCommand` → `IEntityStateService.TryEnterState(InCombat)` + `ICombatSystem.StartCombat` → `CombatStartedEvent` → `CombatHandler` (output).
+
+### New: Flow 17 — Combat round pulse (heartbeat-driven)
+
+Added to `docs/architecture/flows/README.md`. Trigger: `HeartbeatBackgroundService` publishes `HeartbeatTickEvent`. Covers: `CombatTickHandler` → `ICombatSystem.ExecuteRound` → `CombatRoundEvent` → `CombatHandler` (output) → optional `CombatEndedEvent` → `CombatMobDeathHandler` or `PlayerIncapacitated` cleanup.
+
+### New: Flow 18 — `flee` (combat exit)
+
+Added to `docs/architecture/flows/README.md`. Trigger: player sends `flee`. Covers: `FleeCommand` → `ICombatSystem.EndCombat` + `IEntityStateService.ExitState(InCombat)` → `CombatEndedEvent(PlayerFled)` → `CombatHandler` (output).
+
+### Modified: Flow 1 — Server startup
+
+`HeartbeatBackgroundService` is already registered by slice 9-b. This slice registers `CombatModule` which adds `CombatTickHandler` as a `HeartbeatTickEvent` subscriber — no startup ordering change beyond the existing `AddCombatModule()` call in `Program.cs`.
+
+### Reference catalog updates
+
+The implementation PR for this slice must update:
+- `docs/reference/components.md` — add `CombatStateComponent` row (cross-cutting, transient, not persistent).
+- `docs/reference/systems.md` — add `ICombatSystem` / `CombatSystem` entry.
+- `docs/reference/handlers.md` — add `CombatTickHandler`, `CombatHandler`, `CombatMobDeathHandler` entries.
+- `docs/reference/commands.md` — add `kill` (alias `k`, Partial, no privilege) and `flee` (Partial, no privilege) rows.
+
+---
+
+## Design Notes
+
+- **Two-layer state model.** `EntityStateComponent` (slice 9-a) holds the `InCombat` flag; `CombatStateComponent` holds the metadata (opponent entity id). Commands gate on the flag via `IEntityStateService`; systems query the metadata via `CombatStateComponent`. `ICombatSystem` does not call `IEntityStateService` — this is a cohesion choice, not an INV-2 obligation (INV-2 constrains Core → Domain, not Domain → Domain; `01-layers.md` explicitly permits Domain → Domain). The separation is chosen because `IEntityStateService` is a lateral peer service that may trigger downstream reactions; commands and handlers are the right coordinators between two peer domain systems.
+
+- **`CombatStateComponent` is not `[Persistent]`.** A crash or restart drops all active combat. Players reconnect with HP at the last flush; mobs re-spawn from templates at full HP on next startup or `reload`. This avoids orphaned state (an entity fighting an opponent that no longer exists) and is the correct MUD convention.
+
+- **Mob death clears `BlueprintComponent` (INV-21).** `CombatMobDeathHandler` clears `BlueprintComponent` before calling `DestroyEntity`. This frees the blueprint slot so `WorldContentLoader.SpawnMissingEntities` (at startup or on `reload`) sees no live entity for that blueprint id and seeds a fresh mob. Destroy-and-re-seed is the chosen INV-21 path. Live timer-driven respawn is deferred to a future TimeSystem + respawn-manager slice.
+
+- **Player death is stubbed.** When the player's HP would reach 0, it is clamped to 1 and combat ends with `CombatEndedEvent(PlayerIncapacitated)`. No death penalty, no corpse, no respawn flow. Slice 10 subscribes to `PlayerIncapacitated` to add the full mechanic. The event payload is shaped now so slice 10 needs no event-structure changes.
+
+- **`flee` always succeeds.** No failure roll. Revisit in the skills slice if a chance-to-fail-flee is wanted.
+
+- **No mob aggro.** Mobs do not initiate combat. A player must `kill <mob>` to start. Mob aggro (an AI tick that checks player proximity and calls `StartCombat`) belongs to the mob-wandering/AI slice.
+
+- **`CombatTickHandler` is a handler, not an Initiator.** It subscribes to `HeartbeatTickEvent` and publishes `CombatRoundEvent`/`CombatEndedEvent`. Handlers publishing downstream events is an established pattern (INV-5 restricts *systems*, not handlers). If the event bus becomes a tick-frequency bottleneck this can be revisited in Phase 4 profiling.
+
+- **`MobInRoomResolver` deferred.** `ICombatSystem.TryFindTargetInRoom` handles target resolution directly in this slice. An `IArgumentResolver`-backed `MobInRoomResolver` should be extracted when a second command needs mob-in-room resolution (e.g., `look <mob>`, `talk <mob>`). INV-19: extract at ≥3 uses.
+
+- **Round deduplication.** Lower entity id is designated the "attacker" in the pair ordering. This prevents A→B and B→A from being processed as two separate rounds per tick.
+
+- **Area-scoped flush covers `CurrentHp` mutations.** Save-on-change is not used for combat HP (round frequency ~0.5 Hz would make it prohibitive). Periodic flush (default 60 s) covers it.
+
+---
+
+## Open Questions
+
+1. **`CombatTickHandler` at tick frequency.** The handler runs on every heartbeat tick even if no combat is active (scan returns empty). This is a fast no-op for Phase 3 scale. If the heartbeat is used for many other purposes at higher frequency, a "skip if no active combat" fast-path may be warranted — deferred to Phase 4 profiling.
+
+2. **Thread safety of `EntityService` under concurrent heartbeat + sessions.** Phase 4 thread-safety review has this as a concrete entry point. Acknowledged for Phase 3.
+
+3. **Mob respawn timing.** `BlueprintComponent` clearing and `DestroyEntity` free the slot; re-spawn happens on next startup or `reload` only. Live respawn deferred to `backlog.md` ("Mob death / respawn and `BlueprintComponent` clearing (INV-21)").
+
+---
+
+## Related
+
+- [`entity-state-management.md`](entity-state-management.md) — slice 9-a; `IEntityStateService` and `EntityState.InCombat` used for state gating in `KillCommand` and `FleeCommand`.
+- [`time-system.md`](time-system.md) — slice 9-b; `HeartbeatTickEvent` is the trigger for `CombatTickHandler`.
+- [`stat-system.md`](stat-system.md) — slice 9-c; `IStatSystem` computes effective stats; `ItemDataComponent.DamageBonus` and `IAttributeSystem.SetCurrentHp` defined here.
+- [`attributes.md`](attributes.md) — slice 8a; `AttributesComponent` and `PoolsComponent` are the data ground truth.
+- [`mobs.md`](mobs.md) — slice 8; `MobDataComponent`, `BlueprintComponent`, and the destroy/re-seed INV-21 obligation originate here.
+- [`equipment.md`](equipment.md) — slice 7; `WornSlot.MainHand` read by `IStatSystem` for weapon bonus.
+- [`items-and-inventory.md`](items-and-inventory.md) — slice 6; `ItemDataComponent` extended with `DamageBonus` in slice 9-c.
+- [`persistence-two-level-model.md`](persistence-two-level-model.md) — slice 5b; explains why non-persistent `CombatStateComponent` is safe.
+
+For the slice queue, see [`../roadmap/plan.md`](../roadmap/plan.md).

--- a/docs/use-cases/entity-state-management.md
+++ b/docs/use-cases/entity-state-management.md
@@ -1,0 +1,310 @@
+# Use Case: Entity State Management
+
+**Status:** planned
+**Actors:** System (domain service); Player, Mob (as state subjects); Commands and Handlers (as state callers)
+**Module:** `Core/Modules/EntityState/` (new)
+
+---
+
+## Description
+
+Introduces a unified, flag-based entity state layer that complements (does not replace) metadata components. Before this slice, determining whether an entity is "in combat," "resting," or "incapacitated" requires knowing the exact component type to query — an implicit, undocumented contract that grows harder to manage as state combinations multiply. This slice introduces `EntityStateComponent` (a cross-cutting `[Flags]` enum holder) and `IEntityStateService` (a domain system that enforces transition rules, attaches/removes the component, and returns structured failure reasons). `EntityStateChangedEvent` is published by command and handler callers — not by the service (INV-5). The combat slice (9) is the primary consumer; `IEntityStateService` provides the authoritative "is this entity in state X?" query surface for all future state-gated commands.
+
+**Design scope.** `EntityState` flags for MVP: `None`, `InCombat`, `Resting`, `Incapacitated`. Transition rules are a static lookup table — no state machine framework. No admin commands in this slice; the `state` debug command is acknowledged debt.
+
+---
+
+## Preconditions
+
+- Slices 1–8a complete.
+- `EntityService` (via `HasComponent<T>`, `TryGet<T>`, `AddComponent`, `RemoveComponent`) is the only mechanism used to attach/remove `EntityStateComponent` — no new ECS infrastructure required.
+- `IEventBus` is available to callers (commands, handlers) that will publish `EntityStateChangedEvent` after service calls.
+
+---
+
+## Postconditions
+
+- `EntityState` `[Flags]` enum exists in `Core/ECS/Components/` with values `None = 0`, `InCombat = 1 << 0`, `Resting = 1 << 1`, `Incapacitated = 1 << 2`.
+- `EntityStateComponent { EntityState ActiveStates }` exists in `Core/ECS/Components/`. Not `[Persistent]`. Attached by `IEntityStateService.TryEnterState`; removed (when empty) by `IEntityStateService.ExitState`.
+- `IEntityStateService` (domain system, `Core/Modules/EntityState/Systems/`) is registered as a singleton and satisfies:
+  - `TryEnterState(uint entityId, EntityState state, out string? failReason)` — validates transition rules, attaches or updates `EntityStateComponent`, returns `true` on success.
+  - `ExitState(uint entityId, EntityState state)` — removes the flag; removes the component when no flags remain.
+  - `IsInState(uint entityId, EntityState state)` — flag check; returns `false` if the entity has no `EntityStateComponent`.
+  - `GetStates(uint entityId)` — returns the full `ActiveStates` flags value, or `EntityState.None` if the component is absent.
+- `EntityStateChangedEvent(uint EntityId, EntityState OldStates, EntityState NewStates)` exists in `Core/Modules/EntityState/Events/`.
+- `EntityStateModule` (`Core/Modules/EntityState/EntityStateModule.cs`) exposes `AddEntityStateModule(IServiceCollection)` and is called from `Server/Program.cs`.
+- Transition rule table is enforced by `TryEnterState`:
+
+  | State to enter | Blocked while any of these are active | `failReason` (example) |
+  |---|---|---|
+  | `Resting` | `InCombat`, `Incapacitated` | `"You cannot rest while in combat."` / `"You cannot rest while incapacitated."` |
+  | `InCombat` | `Incapacitated` | `"You cannot enter combat while incapacitated."` |
+  | `Incapacitated` | *(no block)* | n/a |
+
+  All other `state` values not listed above have no entry-block rules in MVP. `ExitState` never fails.
+
+---
+
+## Main Flow
+
+### Flow ES-1 — Entering a state (example: `InCombat`)
+
+1. A command (e.g. `KillCommand`) calls `IEntityStateService.TryEnterState(playerEntityId, EntityState.InCombat, out failReason)`.
+2. The service reads `EntityStateComponent` from the entity (or treats `ActiveStates` as `None` if the component is absent).
+3. The service checks the transition rule table for `InCombat`. If `Incapacitated` flag is set → returns `false`, `failReason = "You cannot enter combat while incapacitated."`.
+4. On success: if the entity lacks `EntityStateComponent`, the service calls `EntityService.AddComponent(entityId, new EntityStateComponent { ActiveStates = state })`. If the component exists, it OR-assigns the flag: `component.ActiveStates |= state`. Returns `true`, `failReason = null`.
+5. The calling command captures `OldStates` before the call and publishes `EntityStateChangedEvent(entityId, oldStates, newStates)` after a successful `TryEnterState` (INV-5 — event publication is in the command, not the service).
+
+### Flow ES-2 — Exiting a state (example: combat ends)
+
+1. A command or handler (e.g. `FleeCommand` or `CombatMobDeathHandler`) calls `IEntityStateService.ExitState(entityId, EntityState.InCombat)`.
+2. The service reads `EntityStateComponent`. If absent, the call is a no-op.
+3. The service clears the flag: `component.ActiveStates &= ~state`. If `ActiveStates == None` after the operation, the service calls `EntityService.RemoveComponent<EntityStateComponent>(entityId)`.
+4. The calling command or handler publishes `EntityStateChangedEvent(entityId, oldStates, newStates)`.
+
+### Flow ES-3 — State-gated command guard (example: `rest`)
+
+1. Player sends `rest`. `RestCommand.ExecuteAsync` calls `IEntityStateService.IsInState(playerEntityId, EntityState.InCombat)`.
+2. If `true`, the command writes `PlainMessage("You cannot rest while in combat.")` and returns without attempting `TryEnterState`. (The command can read the guard before calling `TryEnterState`, or rely on `TryEnterState`'s `failReason` return — both patterns are valid. The guard-read pattern is preferred when a crisply worded player message is needed before the service call incurs side-effects.)
+3. If `false`, the command calls `IEntityStateService.TryEnterState(playerEntityId, EntityState.Resting, out failReason)`.
+4. On success, the command publishes `EntityStateChangedEvent` and writes a confirmation message.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Payload | Purpose |
+|---|---|---|---|
+| `EntityStateChangedEvent` | Commands and handlers that call `IEntityStateService` | `uint EntityId, EntityState OldStates, EntityState NewStates` | Observable hook for future AI, effect, and UI systems; not consumed by any handler in this slice |
+
+No handler subscribes to `EntityStateChangedEvent` in this slice. The event is published now to establish the observable surface; the combat slice (9) will be the first consumer.
+
+---
+
+## Systems / Handlers Involved
+
+### New: `IEntityStateService` (domain, `Core/Modules/EntityState/Systems/`)
+
+```csharp
+public interface IEntityStateService
+{
+    bool TryEnterState(uint entityId, EntityState state, out string? failReason);
+    void ExitState(uint entityId, EntityState state);
+    bool IsInState(uint entityId, EntityState state);
+    EntityState GetStates(uint entityId);
+}
+```
+
+Implementation notes:
+- `TryEnterState`: reads current `ActiveStates` (or `None` if component absent), evaluates the static transition-rule table, on success attaches or OR-assigns, returns `true`. On block, returns `false` with a caller-displayable `failReason` string. Never calls `IEventBus` (INV-5).
+- `ExitState`: AND-NOT clears the flag; removes the component when `ActiveStates == None`. Never fails. Never calls `IEventBus` (INV-5).
+- `IsInState`: returns `(GetStates(entityId) & state) != 0`.
+- `GetStates`: returns `EntityStateComponent.ActiveStates` or `EntityState.None`.
+- No async methods — all operations are synchronous in-memory mutations on `EntityService`.
+- **Dependencies:** `EntityService` only.
+
+### New: `EntityStateComponent` (cross-cutting, `Core/ECS/Components/`)
+
+```csharp
+public class EntityStateComponent : IComponent
+{
+    public EntityState ActiveStates { get; set; }
+}
+```
+
+Not `[Persistent]`. Rationale: transient state surviving a crash would be stale and potentially corrupt — the opponent entity in a combat pair may not exist on the next boot. All flag state is re-established by the gameplay actions that create it (entering a room, initiating combat, etc.) at runtime. Absent on entity construction; created on first `TryEnterState` call; destroyed by `ExitState` when `ActiveStates` reaches `None`.
+
+### New: `EntityState` enum (co-located with `EntityStateComponent`, `Core/ECS/Components/`)
+
+```csharp
+[Flags]
+public enum EntityState
+{
+    None         = 0,
+    InCombat     = 1 << 0,   // 1
+    Resting      = 1 << 1,   // 2
+    Incapacitated = 1 << 2,  // 4
+}
+```
+
+### No new handlers in this slice
+
+`EntityStateChangedEvent` is published but has no subscribers in this slice. This is intentional: the event establishes the observable surface without requiring a subscriber. The combat slice (9) will add `CombatHandler` and `CombatMobDeathHandler`, both of which call `IEntityStateService.ExitState` and publish `EntityStateChangedEvent` as part of their handler body.
+
+### No new commands in this slice
+
+The `state` debug command (admin-only, displays current flags on a target entity) is explicitly deferred. It is acknowledged debt (see Open Questions).
+
+---
+
+## Content Tooling Impact
+
+**None.** This slice introduces no authored content, no YAML template kind, and no `TemplateRegistry` entries. `EntityStateComponent` is runtime-only transient state that carries no author-facing configuration. The transition rule table is a static in-code lookup with no designer-configurable parameters in this phase.
+
+Justification (INV-18): the slice is pure infrastructure — a domain service and a transient component. It produces no gameplay state that a designer must author or inspect. The first content-facing concern (which mobs or players can enter which states) belongs to the combat slice (9) and later AI/effect slices, which will surface configuration at that point if needed.
+
+---
+
+## Cross-Cutting Surfaces Stressed
+
+### Commands — Adequate
+
+No new commands in this slice. Future command bodies call `IEntityStateService` as a domain service and publish `EntityStateChangedEvent` using the existing `IEventBus` injection pattern. No command-framework change needed.
+
+### Output — Adequate
+
+No new `IOutputMessage` shapes required. State-gated commands write `PlainMessage` via existing `IOutputWriter`. The `failReason` string from `TryEnterState` is rendered as a `PlainMessage` by the calling command.
+
+### Persistence — see sub-check below.
+
+### Event bus — Adequate
+
+`EntityStateChangedEvent` follows the existing thin-payload past-tense event pattern (INV-6). Publishers are commands and handlers (INV-5). No handler subscribes in this slice — the bus tolerates zero-subscriber events without error; this pattern is already established by events published in the login flow before `CharacterHydrationHandler` was added.
+
+### ECS queries — Adequate
+
+`IEntityStateService` calls `EntityService.HasComponent<EntityStateComponent>`, `TryGet<EntityStateComponent>`, `AddComponent`, and `RemoveComponent` — all existing `EntityService` interface methods used throughout the codebase. No new query pattern introduced.
+
+The combat pulse (slice 9 — `CombatPulseService`) will query `GetAllComponents<EntityStateComponent>()` or `GetAllComponents<CombatStateComponent>()` to enumerate active combatants. That query surface is already used by `PersistenceSystem` and is documented as adequate-for-Phase-3 in `combat.md`. Not a gap introduced here.
+
+### Broadcast — Adequate
+
+No room-scope broadcast in this slice. State-change messages are single-recipient `PlainMessage` output from the calling command.
+
+### Time — Not exercised
+
+No scheduled work in this slice.
+
+### Content templates — Not exercised
+
+No YAML, no `TemplateRegistry` entries, no `ITemplateDeserializer`.
+
+### Configuration — Not exercised
+
+No new `appsettings.json` keys. The transition rule table is a static in-code data structure with no external configuration in this phase.
+
+### Sessions — Adequate
+
+`IEntityStateService` is keyed on `uint entityId`, never on `ISession`. Session fan-out (broadcast to witnesses) is deferred to the calling command or handler. No change to `ISessionManager`.
+
+### Modules — Adequate
+
+`EntityStateModule` follows the existing `AddXModule(IServiceCollection)` DI extension pattern used by `AddMobsModule`, `AddItemsModule`, etc. Registered in `Server/Program.cs`. No new hosting-service infrastructure.
+
+---
+
+### Persistence opt-in audit
+
+**Level 1 — entity opt-in.**
+
+`EntityStateComponent` is attached to entities that already carry `PersistentEntity` (player entities, mob entities). The component's attachment does not change the entity's persistence opt-in status — `PersistentEntity` was placed at construction time for players (slice 5, `AccountSystem.CreateCharacterAsync`) and for template-spawned mobs (slice 8, `WorldContentLoader`). No new construction paths in this slice; no `PersistentEntity` placement to audit.
+
+**Level 2 — component `[Persistent]` status.**
+
+| Component | `[Persistent]`? | Rationale |
+|---|---|---|
+| `EntityStateComponent` | No | Transient: flags represent runtime combat, rest, and incapacitation state. Persisting these flags would leave entities stuck in states whose context (opponent entities, event triggers) may not exist after restart. Cleared on restart by design. |
+| `EntityState` (enum) | n/a | Enum value stored in `EntityStateComponent`; persistence controlled by the component tag above. |
+
+No existing components are introduced, modified, or newly tagged in this slice. `PlayerComponent`, `MobDataComponent`, `AttributesComponent`, and `PoolsComponent` — which are read by callers of this service — retain their existing `[Persistent]` status unchanged.
+
+**Level 3 — entity ID stability.**
+
+No new entity types are spawned by `WorldContentLoader.SpawnMissingEntities`. Not applicable.
+
+**Level 4 — restore vs. spawn placement guard.**
+
+No `PlaceXInRooms`-style placement logic in this slice. Not applicable.
+
+---
+
+## Flows Introduced or Modified
+
+### New: Flow 16 — Entity state transition (TryEnterState / ExitState)
+
+This flow is introduced here and referenced by the combat slice (9). It is a micro-flow invoked inside command and handler bodies; it is not a standalone player-command flow. Because it is embedded inside other flows (combat initiation, flee, mob death), it does not get a top-level `flows/README.md` entry in isolation — it is documented as a sub-step of the flows that consume it (Flow 16 for `kill`, Flow 17 for combat round pulse, Flow 18 for `flee` in the combat use case).
+
+**`flows/README.md` update required:** none in this slice. The flows that will reference `IEntityStateService` calls (combat initiation, combat round, flee) are defined in the combat slice (9) as Flows 16–18. The `flows/README.md` index update ships with slice 9.
+
+**Rationale for deferral:** `IEntityStateService` is infrastructure — it has no player-visible flow of its own. It is a sub-step within flows whose triggers and outputs are owned by the combat slice. Adding a standalone flow entry for an internal service call with no player-visible trigger would violate INV-D1 (one fact, one home) by splitting the combat flow narrative across two slices.
+
+### No modifications to existing flows
+
+`IEntityStateService` does not change the server-startup, player-command, or persistence-flush flows. No hosted service is added.
+
+---
+
+## Design Notes
+
+- **`TryEnterState` returns `failReason`, not throws.** Command bodies receive a displayable string and choose how to surface it — either write it directly or compose their own message. This avoids exception-as-control-flow while keeping the service pure (no I/O, no event bus). The pattern is consistent with `IAccountSystem.AuthenticateAsync` returning `AuthResult` rather than throwing on invalid credentials.
+
+- **`ExitState` is unconditional.** It never returns a failure. Combat ending, death, and disconnect all need to unconditionally clear state; a failure path would require every caller to handle a case that should never logically occur (exiting a state the entity is not in is a benign no-op).
+
+- **Transition rules are a static table, not a state machine.** MVP has three flags and four rule entries. A general state machine (`IState`, `ITransition`, guard delegates) would be premature engineering for three values. If flag count reaches ~8 or transition complexity requires guard chains, the implementation replaces the table with a proper transition graph without changing the `IEntityStateService` interface.
+
+- **`EntityStateComponent` is removed when empty.** Keeping a zero-flag component attached to every entity that has ever entered any state would bloat the entity query surface. Removing on `ExitState` when `ActiveStates == None` keeps entity state lean. This means `HasComponent<EntityStateComponent>` is a reliable "entity is in at least one state" check.
+
+- **No `[Persistent]` on `EntityStateComponent` — this is the decisive design choice.** A crash or restart drops all active state flags. Players reconnect with their last-flushed HP and inventory; combat and rest state is re-established by player action. This avoids orphaned state (an entity in `InCombat` whose opponent was destroyed and whose `CombatStateComponent` never matched), removes the need for a startup migration guard for state flags, and matches the MUD convention that crashes reset in-progress actions. The downside (a resting player reconnects without the rest flag) is acceptable for Phase 3 — rest mechanics do not yet produce ongoing effects that would be disrupted.
+
+- **`EntityState` as `[Flags]` enum, not a `HashSet<EntityState>`.** Flags enum enables O(1) bitwise checks and direct comparison without allocation. The limit of ~30 named values for a single `int`-backed `[Flags]` enum is not a concern at the projected flag count for this engine.
+
+- **Combat slice (9) interaction.** The combat use case (`combat.md`) currently specifies `CombatStateComponent { OpponentEntityId: uint }` as the metadata component tracking who the combatant is fighting. This slice does not replace that component. The relationship is: `EntityStateComponent.InCombat` is the observable flag (guarding `rest`, `flee`, re-`kill`); `CombatStateComponent.OpponentEntityId` is the metadata (telling the pulse who to fight). Both coexist. `KillCommand` attaches both; the combat pulse checks `CombatStateComponent`; state-gated commands check `EntityStateComponent` via `IEntityStateService.IsInState`. This dual-component design preserves separation between "is in a state" (observable, cross-cutting) and "what is the state's parameters" (domain-specific metadata).
+
+- **Why `IEntityStateService` instead of direct `HasComponent` calls in command bodies.** The transition rule table must be enforced centrally. Without a service, every command that enters or exits a state must re-implement the rule check — a pattern that fails when a new rule is added and some commands miss the update. The service is the single enforcement point. Commands that only *read* state (`IsInState`) could safely call `HasComponent<EntityStateComponent>` directly, but routing all state access through `IEntityStateService` keeps the call pattern uniform and makes the service the authoritative query surface for any future rule changes.
+
+---
+
+## Open Questions
+
+1. **Admin `state` debug command (deferred).** An admin `state <target>` command that displays `EntityStateComponent.ActiveStates` as a formatted flag list (e.g. `"InCombat | Resting"`) would be useful during combat testing. This is deferred because: (a) there is no player-facing state to inspect in this slice alone; (b) the useful inspection target is a player or mob in active combat — a scenario that only exists after slice 9. **Disposition: acknowledged debt.** Tracked for inclusion in slice 9 or as a standalone admin-tooling pass. No backlog entry required — the combat use case's admin commands section (`setroundtime`) is the natural landing point.
+
+2. **Future flags (e.g. `Invisible`, `Stunned`, `Dead`).** The `EntityState` enum is designed for extension. Adding a new flag requires: (a) a new enum value, (b) a new row in the transition rule table if the flag blocks any existing state, (c) commands that enter/exit the flag. No interface change, no migration guard. **Disposition: no action now; the design accommodates extension.**
+
+3. **`Incapacitated` flag usage in slice 9.** The combat use case currently specifies that player HP reaching zero results in the player being clamped to 1 HP and auto-fleeing, with `CombatEndedEvent(Outcome=PlayerIncapacitated)` published. If the combat slice sets the `Incapacitated` flag via `IEntityStateService.TryEnterState` at this point, the `InCombat` transition rule (blocked while `Incapacitated`) would prevent re-entering combat until the flag is cleared. **This is the intended integration,** but it requires the combat slice to call both `ExitState(InCombat)` and `TryEnterState(Incapacitated)` on the incapacitated player — the order and caller (handler vs. service) should be decided when slice 9 is implemented. **No blocker for this spec.**
+
+---
+
+## Reference Catalog Updates
+
+### `docs/reference/components.md`
+
+Add to the **Infrastructure (cross-cutting)** table:
+
+| Component | Shape | Used by | Persisted? |
+|---|---|---|---|
+| `EntityStateComponent` | `ActiveStates: EntityState` — tracks active state flags for any entity; absent when `ActiveStates == None` | `IEntityStateService`; commands and handlers that guard on entity state | no — transient; cleared on restart by design |
+
+Add enum note:
+
+| `EntityState` | `[Flags]` enum `{ None=0, InCombat=1, Resting=2, Incapacitated=4 }` — co-located with `EntityStateComponent` in `Core/ECS/Components/` | n/a (enum, not a component) |
+
+### `docs/reference/systems.md`
+
+Add to **Domain / feature Systems**:
+
+**EntityStateService**
+**Purpose:** Centralized transition-rule enforcement for entity state flags. Attaches and removes `EntityStateComponent`; validates flag combinations against a static transition table; returns structured failure reasons to callers. Never touches the event bus or persistence (INV-5).
+**Location:** `Core/Modules/EntityState/Systems/EntityStateService.cs`
+**Dependencies:** `EntityService`.
+
+```csharp
+public interface IEntityStateService
+{
+    bool TryEnterState(uint entityId, EntityState state, out string? failReason);
+    void ExitState(uint entityId, EntityState state);
+    bool IsInState(uint entityId, EntityState state);
+    EntityState GetStates(uint entityId);
+}
+```
+
+---
+
+## Related
+
+- [`combat.md`](combat.md) — slice 9; the primary consumer of `IEntityStateService`. `KillCommand` calls `TryEnterState(InCombat)`; `FleeCommand` calls `ExitState(InCombat)`; state guards on `kill` (already in combat) and `flee` (not in combat) use `IsInState`.
+- [`attributes.md`](attributes.md) — slice 8a; `PoolsComponent.CurrentHp` reaching zero is the trigger for the `Incapacitated` flag in the combat slice. `IAttributeSystem` is the read/write surface for HP; `IEntityStateService` is the state-flag surface.
+- [`mobs.md`](mobs.md) — slice 8; mob entities are state subjects — `IEntityStateService` is called with mob entity ids as well as player entity ids.
+- [`persistence-two-level-model.md`](persistence-two-level-model.md) — slice 5b; the two-level opt-in is why `EntityStateComponent` omits `[Persistent]` safely without affecting other components on the same entity.
+- [`command-framework.md`](command-framework.md) — slice 3; state-gated commands follow the existing `ICommand` pattern; `failReason` is rendered as `PlainMessage` via `IOutputWriter`.
+
+For the slice queue, see [`../roadmap/plan.md`](../roadmap/plan.md).

--- a/docs/use-cases/stat-system.md
+++ b/docs/use-cases/stat-system.md
@@ -1,0 +1,313 @@
+# Use Case: Stat Computation System
+
+**Status:** planned
+**Actors:** Player, Mob, System, Administrator
+**Module:** `Core/Modules/Stats/` (new); `Core/ECS/Components/` (`ItemDataComponent` extended); `Core/Modules/Attributes/` (`IAttributeSystem` extended); `Core/Modules/Items/` (`ItemTemplate`, `ItemTemplateDeserializer`, `IItemContentWriter`, `SetItemCommand` extended)
+
+---
+
+## Description
+
+Introduces a dedicated `IStatSystem` that aggregates effective stat values from multiple sources (base attributes and equipment bonuses) into a single read seam for the combat slice and future consumers. Currently `IAttributeSystem` returns raw component values; combat needs *effective* values that sum base + equipment modifiers + future buff/effect modifiers. Without an aggregation seam, every consumer (combat, skills, UI) would repeat the same inline summation and would each need to change whenever a new modifier source is added. `IStatSystem` owns that seam permanently.
+
+The slice also adds the first equipment-sourced modifier: a flat `DamageBonus` field on `ItemDataComponent` that contributes to `GetEffectiveAttackPower` when the item is equipped in `MainHand`. Future modifier sources (active effects, buffs, auras) will plug into `StatSystem` without changing the interface. Additionally, `IAttributeSystem` gains `SetCurrentHp`, the write-seam the combat slice will use to apply damage — decoupling write-path clamping from callers (INV-8).
+
+**Prerequisite:** Slices 1–8a complete. `IAttributeSystem`, `IEquipmentSystem`, `ItemDataComponent`, `WornSlot.MainHand`, `AttributesComponent`, `PoolsComponent` must exist.
+
+---
+
+## Preconditions
+
+- Slices 1–8a complete. Reused: `EntityService`, `IAttributeSystem`, `IEquipmentSystem`, `ItemDataComponent`, `InventoryComponent`, `EquipmentComponent`, `AttributesComponent`, `PoolsComponent`, `WornSlot`, `ITemplateRegistry`, `IContentSerializer`, `IItemContentWriter`, `SetItemCommand`, `AdminRequirement`, `IPersistenceSystem`.
+- `IAttributeSystem` exists with `GetStrength`, `GetDexterity`, `GetConstitution`, `GetCurrentHp`, `GetMaxHp`, `SetLevel`, `SetStrength`, `SetDexterity`, `SetConstitution`, `SetMaxHp` (slice 8a).
+- `IEquipmentSystem.GetEquippedItems(entityId)` exists and returns item entity ids (slice 7).
+- `ItemDataComponent` has `Name`, `Description`, `Keywords`, `ItemType`, `WornSlots` (`[Persistent]`).
+- `WornSlot.MainHand` enum value exists (slice 7).
+
+---
+
+## Postconditions
+
+- `ItemDataComponent` gains `DamageBonus: int` (default 0). Tagged `[Persistent]` (already is as part of `ItemDataComponent`). Non-weapon items carry the default 0 — no discriminator needed; the field is harmless on non-weapons.
+- `ItemTemplate`, `ItemTemplateDeserializer`, and `IItemContentWriter` gain optional `damageBonus` YAML field (absent or 0 = no bonus).
+- `IAttributeSystem` gains `void SetCurrentHp(uint entityId, int value)`. The setter clamps `value` to `[0, MaxHp]` — the clamp game rule lives in the system, not in callers (INV-8). No events, no persistence (INV-5).
+- `IStatSystem` (domain, `Core/Modules/Stats/Systems/`) exists with `StatSystem` implementation (see interface shape in Systems / Handlers section).
+- `StatsModule` DI entry point exists (`Core/Modules/Stats/StatsModule.cs`), exposes `AddStatsModule(IServiceCollection)`, registers `IStatSystem` / `StatSystem` as singleton, called from `Server/Program.cs`.
+- Admin `setitem <blueprintId> dmg <n>` extends `SetItemCommand` — sets `ItemDataComponent.DamageBonus` on the live item entity and updates the `ItemTemplate` record; calls `IItemContentWriter.WriteAsync` to write YAML; publishes `ItemPropertySetByAdminEvent` (extended `PropertyName = "damageBonus"`); calls `IPersistenceSystem.SaveEntityAsync`.
+
+---
+
+## Main Flow
+
+### Flow A-1 — Effective stat read (combat slice consumer)
+
+1. Combat system (or any consumer) calls `IStatSystem.GetEffectiveAttackPower(attackerEntityId)`.
+2. `StatSystem.GetEffectiveAttackPower` calls `IAttributeSystem.GetStrength(entityId)` → `strength`. Computes base: `strength / 2`.
+3. Calls `IEquipmentSystem.GetEquippedItems(entityId)` to obtain all equipped item entity ids. For each, checks `EntityService.TryGetComponent<ItemDataComponent>` and whether the item occupies `WornSlot.MainHand` (by checking `ItemDataComponent.WornSlots` contains `MainHand`). If the `EquipmentComponent.Slots` key `MainHand` resolves to an item entity, reads `ItemDataComponent.DamageBonus` on that item.
+4. Returns `strength / 2 + mainHandDamageBonus` (0 if no weapon in `MainHand` or weapon has no bonus).
+
+### Flow A-2 — Effective defense read
+
+1. Combat system calls `IStatSystem.GetEffectiveDefense(defenderEntityId)`.
+2. `StatSystem.GetEffectiveDefense` calls `IAttributeSystem.GetDexterity(entityId)`. Returns `dexterity / 4`. (Armor-slot bonus is future; no equipment loop in this slice for defense.)
+
+### Flow A-3 — HP mutation (combat write path)
+
+1. Combat system calls `IAttributeSystem.SetCurrentHp(entityId, newValue)`.
+2. `AttributeSystem.SetCurrentHp` clamps `newValue` to `[0, GetMaxHp(entityId)]` and writes `PoolsComponent.CurrentHp`. No events, no persistence (INV-5). The caller (`CombatPulseService`, a future Initiator) is responsible for event publication.
+
+### Flow B-1 — Admin `setitem <blueprintId> dmg <n>`
+
+1. **Privilege gate.** `AdminRequirement` checked by `CommandDispatcher` via `IAuthorizationChecker`.
+2. `SetItemCommand.ExecuteAsync` parses `dmg <n>` as property=`dmg`, value=int. Not a recognized property → error.
+3. Resolves the blueprint in `ITemplateRegistry` and live item entity via `BlueprintComponent`. Not found → error.
+4. Validates `n >= 0`. Negative → "Damage bonus must be non-negative."
+5. Sets `ItemDataComponent.DamageBonus = n` on the live entity. Updates `ItemTemplate.DamageBonus = n` in the registry.
+6. Calls `IItemContentWriter.WriteAsync(template)` — writes YAML atomically.
+7. Publishes `ItemPropertySetByAdminEvent(adminEntityId, itemEntityId, blueprintId, "damageBonus", n.ToString())`. `AdminAuditHandler` logs.
+8. Calls `IPersistenceSystem.SaveEntityAsync(itemEntityId)`.
+9. Writes confirmation `PlainMessage`.
+
+### Flow C-1 — Content loading (YAML → DamageBonus)
+
+1. `WorldContentLoader.LoadAndSpawnAsync` calls `ItemTemplateDeserializer.Deserialize(fileBody)`.
+2. Deserializer reads optional `damageBonus: int` (default 0). Populates `ItemTemplate.DamageBonus`.
+3. `ItemTemplate.Apply(entity, entityService)` attaches `ItemDataComponent` with `DamageBonus` from template. Existing path unchanged; new field just added.
+
+---
+
+## Events Fired
+
+| Event | Publisher | Payload | Purpose |
+|---|---|---|---|
+| `ItemPropertySetByAdminEvent` (extended) | `SetItemCommand` | `uint AdminEntityId, uint ItemEntityId, string BlueprintId, string PropertyName, string NewValue` | Existing event, new `PropertyName="damageBonus"` case. Audit log. |
+
+No new events. `IStatSystem` and `IAttributeSystem.SetCurrentHp` never publish events (INV-5).
+
+---
+
+## Systems / Handlers Involved
+
+### New: `IStatSystem` (domain, `Core/Modules/Stats/Systems/`)
+
+```csharp
+public interface IStatSystem
+{
+    int GetEffectiveStrength(uint entityId);
+    int GetEffectiveDexterity(uint entityId);
+    int GetEffectiveConstitution(uint entityId);
+    /// Strength / 2 + MainHand item DamageBonus (0 if none).
+    int GetEffectiveAttackPower(uint entityId);
+    /// Dexterity / 4. Armor-slot bonus deferred (future).
+    int GetEffectiveDefense(uint entityId);
+    int GetCurrentHp(uint entityId);
+    int GetMaxHp(uint entityId);
+}
+```
+
+`StatSystem` implementation rules:
+- `GetEffectiveStrength` → `IAttributeSystem.GetStrength(entityId)`.
+- `GetEffectiveDexterity` → `IAttributeSystem.GetDexterity(entityId)`.
+- `GetEffectiveConstitution` → `IAttributeSystem.GetConstitution(entityId)`.
+- `GetEffectiveAttackPower` → `IAttributeSystem.GetStrength(entityId) / 2` + MainHand item `ItemDataComponent.DamageBonus`. Reads `EquipmentComponent.Slots[WornSlot.MainHand]` via `EntityService.TryGetComponent<EquipmentComponent>`, then reads `ItemDataComponent.DamageBonus` via `EntityService.TryGetComponent<ItemDataComponent>` on the equipped item — no `is`/`as` (INV-4).
+- `GetEffectiveDefense` → `IAttributeSystem.GetDexterity(entityId) / 4`.
+- `GetCurrentHp` → `IAttributeSystem.GetCurrentHp(entityId)`.
+- `GetMaxHp` → `IAttributeSystem.GetMaxHp(entityId)`.
+- Never publishes events, never calls persistence (INV-5). Pure aggregation.
+- **Future extension point:** when `ActiveEffectsComponent` lands, `StatSystem` sums modifiers from that component into the same getter implementations without changing the interface.
+
+### Extended: `IAttributeSystem` (`Core/Modules/Attributes/Systems/`)
+
+New method added:
+```csharp
+/// Sets CurrentHp, clamped to [0, MaxHp]. Game rule enforced here (INV-8). No events, no persistence (INV-5).
+void SetCurrentHp(uint entityId, int value);
+```
+
+`AttributeSystem.SetCurrentHp` implementation:
+- Reads `PoolsComponent.MaxHp` (via `GetMaxHp(entityId)`).
+- Clamps `value` to `[0, maxHp]`.
+- Writes `PoolsComponent.CurrentHp = clampedValue`.
+- No event bus call, no persistence call.
+
+### Extended: `IItemBuilderSystem` / `SetItemCommand` (`Core/Modules/Items/`)
+
+`SetItemCommand` extended with `dmg` property keyword. Delegates mutation to a new `IItemBuilderSystem.SetItemDamageBonus(uint itemEntityId, int value, ItemTemplate template)` method (or equivalent inline mutation following the `SetAttribute` pattern from `IMobBuilderSystem`). Updates both live `ItemDataComponent.DamageBonus` and `ItemTemplate.DamageBonus`. Does not call persistence or events (INV-5).
+
+### Extended: `ItemTemplate` / `ItemTemplateDeserializer` / `IItemContentWriter`
+
+- `ItemTemplate` gains `int DamageBonus { get; init; }` (default 0).
+- `ItemTemplateDeserializer` reads optional `damageBonus: int` YAML key (absent = 0).
+- `IItemContentWriter.WriteAsync` writes `damageBonus: <n>` to YAML (omit when 0 is acceptable but explicit write is also fine for readability).
+- `ItemTemplate.Apply` attaches `ItemDataComponent { ..., DamageBonus = template.DamageBonus }`.
+
+### Extended: `ItemDataComponent` (`Core/ECS/Components/`)
+
+New field: `int DamageBonus { get; set; }` = 0. `[Persistent]` (inherited from `ItemDataComponent` class attribute).
+
+### Reused (no change): `IEquipmentSystem`, `EquipmentComponent`, `WornSlot`, `AdminAuditHandler`, `IPersistenceSystem`, `IAuthorizationChecker`
+
+---
+
+## Content Tooling Impact
+
+**New gameplay state:** `ItemDataComponent.DamageBonus` (authored per-item attack power contribution). INV-18 requires tooling in the same slice.
+
+**Admin command extended:** `setitem <blueprintId> dmg <n>` — lets designers set weapon damage bonus on any item entity. `n` is a non-negative integer. The value is persisted to the item YAML file immediately (save-on-change pattern).
+
+**YAML field extended (items):** Optional `damageBonus: int` in item YAML files. Zero (or absent) means no contribution to attack power. Example:
+
+```yaml
+kind: item
+blueprintId: item.sword.short
+name: a short sword
+keywords: [sword, short sword]
+type: Weapon
+wornSlots: [MainHand]
+damageBonus: 3
+```
+
+**Designer workflow:** author a weapon via `mkitem`, set `dmg` via `setitem <blueprintId> dmg 3`, equip it in-game — `score` (slice 8a) will still show base stats; effective attack power is visible in combat narrative (slice 9).
+
+**`IItemContentWriter` extended** to write the `damageBonus` field; `ItemTemplateDeserializer` extended to read it. No new YAML `kind`; no new file extension.
+
+---
+
+## Cross-Cutting Surfaces Stressed
+
+### Commands — Adequate
+
+`setitem dmg` is a new property on the existing `SetItemCommand`. The command follows the established `ICommand` + `ICommandDispatcher` + `AdminRequirement` + `IAuthorizationChecker` pattern. No framework change needed.
+
+### Output — Adequate
+
+`SetItemCommand` writes a `PlainMessage` confirmation via `IOutputWriter`. No new message shape required. `IStatSystem` is a pure read layer with no output responsibility.
+
+### Persistence — see sub-check below.
+
+### Event bus — Adequate
+
+No new events. `ItemPropertySetByAdminEvent` with `PropertyName="damageBonus"` is an existing event shape reused. `IStatSystem` and `AttributeSystem.SetCurrentHp` are never publishers (INV-5).
+
+### ECS queries — Adequate
+
+`StatSystem.GetEffectiveAttackPower` reads `EquipmentComponent` then `ItemDataComponent` — two `TryGetComponent` calls per invocation. Called per combat round (future), not per tick globally. At Phase 3 scale, linear lookups are acceptable. No new query pattern introduced.
+
+### Broadcast — Not stressed
+
+`IStatSystem` is a read layer; no broadcast.
+
+### Time / heartbeat — Not stressed
+
+No timed behavior in this slice.
+
+### Content templates — Adequate (extended)
+
+`ItemTemplate` + `ItemTemplateDeserializer` + `IItemContentWriter` gain one optional `damageBonus` int field. This follows the established extension pattern from slice 8a (`MobTemplate` gained attribute fields). No new serializer, no new `kind`.
+
+### Configuration — Not stressed
+
+No new config keys.
+
+### Sessions — Not stressed
+
+`IStatSystem` is entity-keyed, not session-keyed.
+
+### Modules — Adequate
+
+`StatsModule` is new, following the `Add*Module(IServiceCollection)` extension pattern. Registered in `Server/Program.cs` after `AttributesModule`. No new DI infrastructure.
+
+---
+
+### Persistence opt-in audit
+
+**Level 1 — entity opt-in.**
+
+No new entity construction paths. Item entities already carry `PersistentEntity` from `IItemBuilderSystem.CreateItem` and `WorldContentLoader.SpawnMissingEntities`. This slice only adds a field to `ItemDataComponent`; the opt-in decision was made in slice 6.
+
+**Level 2 — component `[Persistent]` status.**
+
+| Component | `[Persistent]`? | Rationale |
+|---|---|---|
+| `ItemDataComponent` (existing, extended) | Yes (already tagged) | `DamageBonus` is authored weapon state. It must survive restart — a weapon that loses its damage bonus on restart is broken. No change to the tag; the field is included automatically. |
+| `EquipmentComponent` (existing, read-only) | Yes (already tagged, slice 7) | Not modified by this slice. `StatSystem` reads it; no change. |
+| `AttributesComponent` (existing, read-only) | Yes (already tagged, slice 8a) | `SetCurrentHp` writes `PoolsComponent`, not `AttributesComponent`. No change. |
+| `PoolsComponent` (existing, written by `SetCurrentHp`) | Yes (already tagged, slice 8a) | `CurrentHp` mutations are covered by the area-scoped periodic flush. `SetCurrentHp` does not call persistence itself — the combat pulse Initiator (slice 9) owns the save cadence. No change to persistence rules. |
+
+**Level 3 — entity ID stability.**
+
+`ItemDataComponent.DamageBonus` is a new field on existing item entities. Items spawned by `WorldContentLoader.SpawnMissingEntities` already have their IDs saved immediately at startup (Level 3 guard from slice 6). No new entities of this type are introduced; no change needed.
+
+**Level 4 — restore vs. spawn placement guard.**
+
+No new `PlaceXInRooms`-style logic. Not applicable.
+
+---
+
+## Flows Introduced or Modified
+
+### Modified: Flow 5 — Content reload (`reload`)
+
+`ItemTemplateDeserializer` now reads `damageBonus`. Newly spawned items from templates with `damageBonus > 0` will have `ItemDataComponent.DamageBonus` set correctly. Existing live item entities are not mutated (additive-only reload constraint is unchanged). The flow description in `flows/README.md` does not need a structural change — the YAML field is an extension of the existing item deserialization step in step 4.
+
+### Modified: Flow 12 — Admin item creation (`mkitem`)
+
+`IItemBuilderSystem.CreateItem` now attaches `ItemDataComponent` with `DamageBonus = 0` (the default). No flow step changes; the component shape note in the flow references catalog should mention the new field. `flows/README.md` step 3 updated to add `DamageBonus` to the `ItemDataComponent` field list.
+
+The implementation PR must update `flows/README.md` Flow 12 step 3 to add `DamageBonus: 0` to the `ItemDataComponent` shape note.
+
+No new canonical flow is introduced by this slice. `IStatSystem` is a read layer called by the combat system (slice 9, Flow 17 — Combat round pulse) — that flow is owned by slice 9 and will reference `IStatSystem`.
+
+### Reference catalog updates (INV-16)
+
+The implementation PR must update the following reference catalogs in the same PR:
+
+- **`docs/reference/systems.md`** — Add `IStatSystem` / `StatSystem` entry (domain, `Core/Modules/Stats/Systems/`, interface shape, dependencies). Update the `IAttributeSystem` entry to add `SetCurrentHp(uint entityId, int value)` with its clamp behavior note.
+- **`docs/reference/components.md`** — Update the `ItemDataComponent` row to include `DamageBonus: int` (default 0, `[Persistent]` via class-level attribute).
+- **`docs/use-cases/README.md`** — Already updated (index row added by the planner).
+
+---
+
+## Design Notes
+
+- **`DamageBonus` on `ItemDataComponent`, not a separate `CombatItemDataComponent`.** `combat.md` (the planned combat spec, not yet implemented) proposed a `CombatItemDataComponent` for weapon damage to avoid adding a combat-specific field to the general-purpose `ItemDataComponent`. This slice takes the opposite approach: `DamageBonus` belongs on `ItemDataComponent` because (a) it is authored alongside the item's other stats, (b) the YAML file is already the item authoring surface, (c) separating it would require two components to describe one authored weapon and two YAML write paths for one `setitem dmg` command, and (d) `ItemDataComponent` already carries `WornSlots`, which is equally "gear-mechanic" data. `combat.md` must be updated before implementation: replace all references to `CombatItemDataComponent` and `WeaponDamageBonus` with `ItemDataComponent.DamageBonus`. The open-question section calls this out explicitly.
+
+- **`IStatSystem` is the read seam; `IAttributeSystem.SetCurrentHp` is the write seam.** The combat slice reads HP via `IStatSystem.GetCurrentHp` and writes via `IAttributeSystem.SetCurrentHp`. These are distinct concerns at distinct layers: `IStatSystem` aggregates (may apply modifiers in future); `IAttributeSystem` mutates the raw component. Callers never write `PoolsComponent` directly.
+
+- **`GetEffectiveAttackPower` implementation detail.** Rather than calling `IEquipmentSystem.GetEquippedItems` and iterating the list, `StatSystem` reads `EquipmentComponent.Slots[WornSlot.MainHand]` directly via `EntityService.TryGetComponent<EquipmentComponent>`. This is a direct dictionary lookup rather than a list scan. Both approaches are INV-4-compliant; direct component access is cheaper for the single-slot case.
+
+- **`SetCurrentHp` clamp is the system's responsibility (INV-8).** The rule "`CurrentHp` must stay in `[0, MaxHp]`" is enforced inside `AttributeSystem.SetCurrentHp`, not inside `ICombatSystem.ExecuteRound`. The combat system passes the raw computed value; the attribute system enforces the invariant. This prevents the rule from being duplicated across every future caller.
+
+- **`GetEffectiveDefense` is dexterity-only for now.** Armor slot bonuses are acknowledged debt — the slot enum exists but no armor contributes defense yet. `GetEffectiveDefense` returns `dexterity / 4`; when armor lands, `StatSystem` sums armor bonuses here without changing the interface.
+
+- **`IStatSystem` has no setter methods.** It is a pure read layer. All writes go through `IAttributeSystem` (raw component write) or `IEquipmentSystem` (slot mutation). This separates the aggregation concern from the mutation concern cleanly.
+
+- **No events in `StatSystem` (INV-5).** `StatSystem` never publishes events. It is a computation layer, not an Initiator or handler.
+
+- **`StatsModule` is a thin DI registration.** No hosted service, no event handler, no configuration binding. Its only job is `services.AddSingleton<IStatSystem, StatSystem>()` and any dependencies that `StatSystem` needs that aren't already registered.
+
+- **Combat.md divergence.** The `combat.md` use case (already planned, not yet implemented) references `CombatItemDataComponent` and `WeaponDamageBonus`. That spec was written before this aggregation seam was designed. The implementation PR for slice 9-c must update `combat.md` Design Notes to reflect `ItemDataComponent.DamageBonus` as the canonical field and remove the `CombatItemDataComponent` design. The `combat.md` Systems / Handlers section references to `CombatItemDataComponent` in `ExecuteRound` must be replaced with `IStatSystem.GetEffectiveAttackPower`.
+
+---
+
+## Open Questions
+
+1. **`combat.md` alignment.** `combat.md` (planned, not implemented) specifies `CombatItemDataComponent.WeaponDamageBonus` and proposes that `ICombatSystem.ExecuteRound` reads it directly. This slice chooses `ItemDataComponent.DamageBonus` aggregated by `IStatSystem`. The architecture reviewer must confirm that `combat.md` is updated before slice 9 implementation begins — the two specs must not coexist with conflicting field names. **Resolution needed before any slice-9 code is written.**
+
+2. **`IStatSystem.GetEffectiveAttackPower` MainHand lookup strategy.** The spec says `StatSystem` reads `EquipmentComponent.Slots[WornSlot.MainHand]` directly rather than using `IEquipmentSystem.GetEquippedItems`. This couples `StatSystem` to `EquipmentComponent` directly. Alternative: call `IEquipmentSystem.GetEquippedItems` and filter by `WornSlot.MainHand`. Either is INV-4-compliant. The architecture reviewer should confirm which dependency relationship is preferred (`IEquipmentSystem` vs. direct `EntityService` query). Recommendation: direct `EntityService.TryGetComponent<EquipmentComponent>` + slot dictionary lookup is simpler and avoids the list allocation from `GetEquippedItems`.
+
+3. **`IItemBuilderSystem` extension shape.** The spec calls for `IItemBuilderSystem.SetItemDamageBonus(uint itemEntityId, int value, ItemTemplate template)`. This follows the `IMobBuilderSystem.SetAttribute` pattern. Alternative: the `SetItemCommand` mutates `ItemDataComponent.DamageBonus` inline (no new builder method). The architecture reviewer should confirm which pattern to follow — the builder method is cleaner (INV-2 discipline), the inline mutation is simpler given that there's only one new property. If a `SetItemDamageBonus` method is added, `IItemBuilderSystem` needs a catalog update.
+
+---
+
+## Related
+
+- [`attributes.md`](attributes.md) — slice 8a; `IAttributeSystem`, `AttributesComponent`, `PoolsComponent` are extended here with `SetCurrentHp`.
+- [`equipment.md`](equipment.md) — slice 7; `IEquipmentSystem`, `EquipmentComponent`, `WornSlot.MainHand` are read by `StatSystem`.
+- [`items-and-inventory.md`](items-and-inventory.md) — slice 6; `ItemDataComponent` is extended with `DamageBonus`; `IItemBuilderSystem`, `IItemContentWriter`, `SetItemCommand` are extended.
+- [`combat.md`](combat.md) — slice 9; primary consumer of `IStatSystem.GetEffectiveAttackPower`, `GetEffectiveDefense`, `GetCurrentHp`, and `IAttributeSystem.SetCurrentHp`. **`combat.md` must be updated before slice 9 implementation to remove `CombatItemDataComponent` references.**
+- [`persistence-two-level-model.md`](persistence-two-level-model.md) — slice 5b; `[Persistent]` on `ItemDataComponent` ensures `DamageBonus` survives restart automatically.
+- [`output-framework.md`](output-framework.md) — slice 4; `SetItemCommand` writes `PlainMessage` confirmation via `IOutputWriter`.
+- [`command-framework.md`](command-framework.md) — slice 3; `SetItemCommand` extends an existing `ICommand` registration.
+
+For the slice queue, see [`../roadmap/plan.md`](../roadmap/plan.md).

--- a/docs/use-cases/time-system.md
+++ b/docs/use-cases/time-system.md
@@ -1,0 +1,236 @@
+# Time System (Heartbeat) — Phase 3 slice 9-b
+
+## Status
+
+`planned`
+
+## Actors
+
+- **System** — `HeartbeatBackgroundService` (Initiator; drives the tick on a background `PeriodicTimer`)
+- **System** — any future handler that subscribes to `HeartbeatTickEvent` (combat round processor, mob AI ticker, effect expiry checker)
+
+## Module
+
+`Core/Modules/Time/` (new module)
+
+## Description
+
+A minimal heartbeat infrastructure that publishes `HeartbeatTickEvent` at a configurable interval. This is the shared clock that combat rounds (slice 9), mob AI ticks (slice 11+), and future effect-expiry tracking will all subscribe to. The slice ships only the heartbeat itself — no named timers, no per-entity cooldowns, no effect expiry. Subscribers attach to the event bus independently; the heartbeat is model-agnostic.
+
+## Preconditions
+
+- The generic host is running with the DI container fully built (all handlers subscribed before the first tick fires — existing startup ordering guarantee).
+- `appsettings.json` may or may not supply `Heartbeat:IntervalMs`; absence means the default of 2000 ms applies.
+
+## Postconditions
+
+- `HeartbeatBackgroundService` is running a `PeriodicTimer` at the configured interval.
+- On each tick, `HeartbeatTickEvent { TickId, Timestamp, Elapsed }` is published to `IEventBus`.
+- Any handler subscribed to `HeartbeatTickEvent` (e.g. the combat round handler in slice 9) receives the event and executes its logic.
+- The service stops cleanly when the host shutdown `CancellationToken` fires; the in-flight tick (if any) completes normally.
+
+## Main flow
+
+1. **Host startup.** `HeartbeatBackgroundService.StartAsync` is called by the .NET generic host. The service is registered last (after `PersistenceBootstrap`, `WorldContentBootstrap`, `PersistenceFlushTimer`, and `TelnetServer`) so the first tick cannot land on a half-built world. Assumption: `HeartbeatBackgroundService` is added to the DI service collection after `TelnetServer` in `Server/Program.cs` so it starts after the listener is open and the world is fully seeded.
+2. **Tick loop begins.** `ExecuteAsync` creates a `PeriodicTimer` with period read from `IConfiguration["Heartbeat:IntervalMs"]` (default 2000). The timer's `WaitForNextTickAsync` awaits the first tick.
+3. **Tick fires.** `HeartbeatBackgroundService` increments its internal `long _tickId` counter, captures `DateTimeOffset.UtcNow` as `Timestamp`, and computes `Elapsed = Timestamp - _lastTimestamp` (initialized to `StartedAt` so tick 1 has an accurate elapsed). This is purely mechanical bookkeeping — no game logic.
+4. **Event published.** The service calls `IEventBus.PublishAsync(new HeartbeatTickEvent { TickId, Timestamp, Elapsed })`. This is the only cross-thread operation: a background thread publishing to the event bus. The Phase 4 thread-safety review will evaluate the event bus under concurrent ticks; acknowledged here.
+5. **Handlers execute.** The event bus dispatches `HeartbeatTickEvent` to all subscribed handlers in priority order. In slice 9, `CombatRoundHandler` is the first subscriber; future slices add further handlers. Each handler does its own work (e.g. query `CombatStateComponent` entities, call `ICombatSystem.ExecuteRound`). None of this logic lives in `HeartbeatBackgroundService`.
+6. **Loop continues.** Control returns to `WaitForNextTickAsync`. The next tick is scheduled relative to the timer's period, not relative to when handler execution completed — `PeriodicTimer` does not drift on handler overrun. A handler overrun that exceeds the tick period causes the next tick to fire immediately after the current one completes (standard `PeriodicTimer` behavior).
+7. **Shutdown.** When the host sends the `CancellationToken`, `WaitForNextTickAsync` returns `false` and `ExecuteAsync` exits normally. The `BackgroundService` base class calls `StopAsync`, which awaits the task. No cleanup is needed — no registered subscribers, no timers to cancel beyond the `PeriodicTimer` lifetime.
+
+## Events fired
+
+| Event | Publisher | Payload | Notes |
+|---|---|---|---|
+| `HeartbeatTickEvent` | `HeartbeatBackgroundService` | `long TickId`, `DateTimeOffset Timestamp`, `TimeSpan Elapsed` | Published on every tick; past-tense thin fact (INV-6). `TickId` is a monotonically increasing counter starting at 1. |
+
+No events are published on startup or shutdown — the tick loop produces all events.
+
+## Systems / handlers involved
+
+| Piece | New / Reuse | Notes |
+|---|---|---|
+| `HeartbeatBackgroundService` (`Server/`) | New | Initiator; `BackgroundService`; owns `PeriodicTimer`, reads `IConfiguration`, publishes `HeartbeatTickEvent`. Not a domain system — no return values, no game logic (INV-5, INV-8). |
+| `IHeartbeatService` | New | Minimal interface for `HeartbeatBackgroundService`. See Design notes for why this is intentionally thin (may be absent entirely). |
+| `HeartbeatTickEvent` | New | In `Core/Modules/Time/Events/HeartbeatTickEvent.cs`. Thin past-tense payload. |
+| `TimeModule` | New | `Core/Modules/Time/TimeModule.cs`; exposes `AddTimeModule(IServiceCollection)`. Registers `HeartbeatBackgroundService` as a `BackgroundService` (via `AddHostedService`). Called from `Server/Program.cs`. |
+| `IEventBus` | Reuse | Existing cross-cutting bus; `HeartbeatBackgroundService` injects it directly (no domain system intermediary). |
+
+No domain system is needed — the heartbeat is pure infrastructure. No handler is introduced in this slice; the first handler (`CombatRoundHandler`) lands in slice 9.
+
+## Content tooling impact
+
+None. This slice adds no gameplay state, no authored content, no YAML schemas, no admin commands, no `TemplateRegistry` entries. The only authoring surface is the `Heartbeat:IntervalMs` key in `appsettings.json`, which is Category 1 operational configuration (see `docs/architecture/05-configuration.md`). Justification for "none": the heartbeat is pure infrastructure; it publishes a tick event and nothing else. Any gameplay state gated on the heartbeat belongs to the slice that introduces it.
+
+## Cross-cutting surfaces stressed
+
+### Commands
+**Adequate.** No new commands. The heartbeat is not player-visible in this slice. No admin command to change the interval is introduced (deferred; if needed, it is a slice 9 or later concern).
+
+### Output
+**Adequate.** No output in this slice. `HeartbeatBackgroundService` does not write to any session.
+
+### Persistence
+**Adequate.** No entities are created. No components are introduced. No persistence calls are made. The heartbeat has no persistent state.
+
+Persistence opt-in audit (mandatory sub-check):
+- **No entities:** `HeartbeatBackgroundService` creates no entities. `PersistentEntity` is irrelevant.
+- **No components:** `HeartbeatTickEvent` is an event record, not a component. No `[Persistent]` decisions are needed.
+- **Level 3 / 4 not applicable:** No `SpawnMissingEntities` path, no `LocationComponent` placement.
+
+### Event bus
+**Adequate.** `IEventBus.PublishAsync` is called from a background thread (`PeriodicTimer` callback). This is the **same cross-thread pattern already used by every `BackgroundService` in the codebase** (`PersistenceFlushTimer` already calls persistence methods from a background thread; `WorldContentBootstrap` fires `WorldContentReadyEvent` from its `StartAsync`). However, the event bus has not been explicitly reviewed for concurrent publish from multiple background threads at the same time. Classification: **Acknowledged debt.** The Phase 4 thread-safety review (`backlog.md`) already tracks this. Since `HeartbeatBackgroundService` has a single `PeriodicTimer` and does not publish concurrently with itself, and the existing services already cross the thread boundary once on startup, no new concurrency shape is introduced by this slice. The thread-safety review is the appropriate venue.
+
+### ECS queries
+**Adequate.** `HeartbeatBackgroundService` makes no ECS queries. Future handlers (combat, AI) will query ECS; that is their concern.
+
+### Broadcast
+**Adequate.** No broadcast in this slice.
+
+### Time
+**Gap exposed (this slice IS the time surface).** `HeartbeatBackgroundService` is the time framework. It defines the canonical shared clock via `HeartbeatTickEvent`. Any future "named timer" or "per-entity cooldown" is a subscriber to this event. The slice ships the framework before any consumer; no hand-rolled pattern is needed downstream. INV-19 satisfied: the framework lands with this slice.
+
+### Content templates
+**Adequate.** No templates introduced.
+
+### Configuration
+**Adequate.** `Heartbeat:IntervalMs` is a Category 1 operational key read from `IConfiguration` via the existing DI-provided `IConfiguration` instance. This follows the established pattern from `Persistence:FlushIntervalSeconds` and `Server:Port` (see `docs/architecture/05-configuration.md`). No new infrastructure needed.
+
+### Sessions
+**Adequate.** `HeartbeatBackgroundService` does not interact with `ISessionManager` or any session directly.
+
+### Modules
+**Adequate.** `TimeModule` follows the existing module pattern (`AddXModule(IServiceCollection)`), matching `AddItemModule`, `AddMobModule`, etc. No new infrastructure.
+
+## Flows introduced or modified
+
+### New: Flow 16 — Heartbeat tick
+
+**Introduced by this slice.** Must be added to `docs/architecture/flows/README.md` in the same PR.
+
+**Trigger.** `PeriodicTimer` fires in `HeartbeatBackgroundService.ExecuteAsync`.
+
+```mermaid
+sequenceDiagram
+    participant Timer as PeriodicTimer
+    participant HBS as HeartbeatBackgroundService
+    participant Bus as IEventBus
+    participant H1 as CombatRoundHandler (slice 9)
+    participant H2 as (future handlers...)
+
+    Timer->>HBS: WaitForNextTickAsync → true
+    HBS->>HBS: increment _tickId, capture Timestamp, compute Elapsed
+    HBS->>Bus: PublishAsync(HeartbeatTickEvent{TickId, Timestamp, Elapsed})
+    Bus->>H1: HandleAsync (priority N) [slice 9+]
+    Bus->>H2: HandleAsync (priority N) [future slices]
+    HBS->>HBS: WaitForNextTickAsync (next tick)
+```
+
+**Steps.**
+
+1. `PeriodicTimer.WaitForNextTickAsync` returns `true` (or `false` on cancellation → exit).
+2. `HeartbeatBackgroundService` increments `_tickId`, captures `DateTimeOffset.UtcNow`, computes `Elapsed = now - _lastTimestamp`, updates `_lastTimestamp = now`.
+3. Publishes `HeartbeatTickEvent { TickId, Timestamp, Elapsed }` via `IEventBus.PublishAsync`.
+4. Event bus dispatches to all subscribed handlers in priority order. In this slice, no handlers are registered; the first registers in slice 9.
+5. Loop returns to `WaitForNextTickAsync`.
+
+**Cross-references.**
+- `Core/Modules/Time/Events/HeartbeatTickEvent.cs`
+- `Server/HeartbeatBackgroundService.cs` (or `Core/Modules/Time/HeartbeatBackgroundService.cs` — see Design notes)
+- `docs/architecture/flows/README.md` — add to index as Flow 16.
+
+### Modified: Flow 1 — Server startup
+
+The `HeartbeatBackgroundService` is added as the last hosted service, after `TelnetServer`. The startup mermaid diagram and step 1 (DI registration) must be updated to include `HeartbeatBackgroundService` in the hosted-service queue.
+
+## Design notes
+
+### `IHeartbeatService` interface — minimal or absent
+
+The original prompt specifies `IHeartbeatService` with `Start()` / `Stop()` lifecycle methods. In practice, `BackgroundService.StartAsync` / `StopAsync` are called by the .NET host automatically — callers do not need to invoke `Start`/`Stop` directly. There are no in-game subscribers to a registry; subscribers use `IEventBus` directly. Therefore `IHeartbeatService` may be empty (a marker interface) or absent entirely. **Recommendation:** omit it unless a concrete caller other than the host needs to reference the heartbeat by interface. If needed for testability (mocking the heartbeat in unit tests), it can be introduced alongside the test framework (Phase 4). This is an open question for the implementation — see Open questions.
+
+### Background service placement: `Server/` vs. `Core/`
+
+`BackgroundService` is a .NET hosting abstraction (`Microsoft.Extensions.Hosting`), which belongs at the server/host layer. `HeartbeatBackgroundService` lives in `Server/` (analogous to `PersistenceFlushTimer`, `WorldContentBootstrap`, `TelnetServer`). `HeartbeatTickEvent` lives in `Core/Modules/Time/Events/` so handlers anywhere in `Core` can subscribe without a `Server/` dependency. `TimeModule` is split: the event + interface (if any) are in `Core/`; the hosted service registration is in `Server/Program.cs`.
+
+### Multiple combat model support
+
+`HeartbeatBackgroundService` is combat-model-agnostic. It publishes a tick; the combat handler subscribes. Switching from autocombat (background timer drives rounds) to freeform (player input drives rounds) means the combat handler un-subscribes or is not registered — the heartbeat continues for effect expiry, mob AI, and other consumers. No change to this slice is required when the combat model changes.
+
+### Per-entity cooldown tracking (future)
+
+An `ICooldownSystem` (future) would subscribe to `HeartbeatTickEvent`, query entities with a `CooldownComponent`, decrement counters, and publish `CooldownExpiredEvent`. Not in scope for this slice. The heartbeat event payload is intentionally minimal — `ICooldownSystem` derives all timing from `Elapsed` and `Timestamp`.
+
+### Named timers (future)
+
+Respawn timers, buff expiry, shop restocking — all would subscribe to `HeartbeatTickEvent` and maintain their own state (timestamps, countdown values). They do not need a separate timer abstraction; they consume the shared clock and handle their own expiry logic.
+
+### Thread safety acknowledgment
+
+`HeartbeatBackgroundService.ExecuteAsync` runs on a background thread managed by the .NET host. `IEventBus.PublishAsync` is called from that thread. This is acknowledged debt consistent with the Phase 4 thread-safety review entry in `backlog.md`. The single-threaded `PeriodicTimer` pattern means the heartbeat does not publish concurrently with itself; risk is from overlap with other background services, which is the same risk already present (e.g. `PersistenceFlushTimer`). No new concurrency shape.
+
+### Startup ordering constraint
+
+`HeartbeatBackgroundService` must be registered **after** `TelnetServer` in `Server/Program.cs`. This ensures the first tick cannot fire before the world is fully seeded and the listener is open. The host runs `StartAsync` to completion for each service in registration order; this is an existing guarantee, not a new mechanism.
+
+### `TickId` starts at 1
+
+`_tickId` is initialized to 0 and incremented before publishing, so the first event carries `TickId = 1`. This makes `TickId = 0` an unambiguous sentinel for "no tick has fired yet."
+
+### `Elapsed` on the first tick
+
+`_lastTimestamp` is set to `DateTimeOffset.UtcNow` in `ExecuteAsync` before the loop (i.e., at service start time). The first tick's `Elapsed` is approximately equal to `IntervalMs` — accurate enough for effect expiry and combat round pacing; combat does not need sub-millisecond precision on the first tick.
+
+## Reference catalog updates (in-flight only)
+
+### New: `HeartbeatTickEvent` (`Core/Modules/Time/Events/HeartbeatTickEvent.cs`)
+
+```
+public sealed record HeartbeatTickEvent
+{
+    public long TickId { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+    public TimeSpan Elapsed { get; init; }
+}
+```
+
+Not a component. Not persisted. Past-tense thin fact (INV-6).
+
+### New module: `TimeModule`
+
+`Core/Modules/Time/TimeModule.cs` — exposes `AddTimeModule(IServiceCollection)`. Registers:
+- `HeartbeatTickEvent` (no registration needed — it's an event record)
+- *(Optional)* `IHeartbeatService` → `HeartbeatBackgroundService` if the interface is retained
+
+`Server/Program.cs` — calls `services.AddTimeModule()` and adds `HeartbeatBackgroundService` via `services.AddHostedService<HeartbeatBackgroundService>()`.
+
+### `docs/reference/handlers.md` — no change in this slice
+
+No handler is introduced. The combat round handler (slice 9) will add the first `HeartbeatTickEvent` subscriber.
+
+### `docs/architecture/flows/README.md`
+
+Add Flow 16 to the index table and the flow body (see Flows section above).
+
+Update Flow 1 (Server startup) to include `HeartbeatBackgroundService` in the hosted-service queue.
+
+## Open questions
+
+1. **`IHeartbeatService` interface.** Should it exist? If the only consumer is the host's `BackgroundService` lifecycle, the interface is noise. Recommended: omit unless a test-double use case is demonstrated. Decide before implementation begins.
+
+2. **Startup ordering — is "after `TelnetServer`" the right gate?** The intent is "after the world is fully seeded." `TelnetServer.StartAsync` opens the TCP listener, which is the last step of world assembly (Flow 1). Placing `HeartbeatBackgroundService` after `TelnetServer` achieves this. Confirm this registration order is enforced in `Server/Program.cs` and does not conflict with any other hosted-service ordering constraint introduced by slices 9-a or 9-c.
+
+3. **`PeriodicTimer` overrun behavior.** If a handler subscribed to `HeartbeatTickEvent` takes longer than `IntervalMs`, the next tick fires immediately after the current one completes (standard `PeriodicTimer` semantics). This is acceptable for the MVP autocombat model but may require a backpressure mechanism if tick handlers become expensive. Acknowledged for Phase 4 hardening; no action in this slice.
+
+4. **`IEventBus.PublishAsync` — is it `async` or sync?** The current `IEventBus` shape (verify in code) should clarify whether `PublishAsync` is truly awaited by the caller or fire-and-forget. `HeartbeatBackgroundService` should `await _eventBus.PublishAsync(...)` so handler exceptions surface in the background service's error handling rather than being silently swallowed. Confirm the event bus implementation supports this.
+
+## Related
+
+- [`combat.md`](combat.md) — slice 9 (blocked on this slice); first consumer of `HeartbeatTickEvent`
+- [`entity-state-management.md`](entity-state-management.md) — slice 9-a (parallel prerequisite)
+- [`stat-system.md`](stat-system.md) — slice 9-c (parallel prerequisite)
+- [`attributes.md`](attributes.md) — slice 8a; establishes `PoolsComponent` that combat reads
+- [`mobs.md`](mobs.md) — slice 8; mob AI future consumers will subscribe to `HeartbeatTickEvent`
+- [`persistence-substrate.md`](persistence-substrate.md) — `PersistenceFlushTimer` is the existing `PeriodicTimer`-based `BackgroundService` this slice mirrors
+- [`docs/roadmap/backlog.md`](../roadmap/backlog.md) — thread-safety review entry covers the event bus under concurrent ticks


### PR DESCRIPTION
## Summary

Splits the upcoming combat work into four independent use-case specs and runs each through the Phase 3 spec-review gate (architecture-reviewer in spec mode) before any code is written. All four specs are `planned`; slices 9-a, 9-b, and 9-c can be implemented in parallel; slice 9 (combat) is blocked on all three.

### New use-case specs

| Slice | File | Status | Key surfaces |
|---|---|---|---|
| **9-a — Entity state management** | `docs/use-cases/entity-state-management.md` | planned | `EntityStateComponent` ([Flags], not `[Persistent]`), `IEntityStateService { TryEnterState, ExitState, IsInState, GetStates }`, `EntityState { None, InCombat, Resting, Incapacitated }` |
| **9-b — Time system (heartbeat)** | `docs/use-cases/time-system.md` | planned | `HeartbeatBackgroundService`, `HeartbeatTickEvent { TickId, Timestamp, Elapsed }`, config `Heartbeat:IntervalMs` (default 2000); no `IHeartbeatService` interface |
| **9-c — Stat computation system** | `docs/use-cases/stat-system.md` | planned | `IStatSystem` (effective stat pipeline: base + equipment bonus + future effects seam), `IAttributeSystem.SetCurrentHp` (new setter, clamped to `[0, MaxHp]`), `ItemDataComponent.DamageBonus: int` (default 0), `setitem dmg <n>` admin command |
| **9 — Combat** | `docs/use-cases/combat.md` | planned | `ICombatSystem`, `CombatTickHandler` (subscribes to `HeartbeatTickEvent`), `CombatEndedEvent { DefenderName: string? }` (point-in-time name capture before entity destruction), `CombatMobDeathHandler` (priority 80, after `CombatHandler` priority 20) |

### Design decisions captured in the specs

- **State management**: `EntityStateComponent` ([Flags]) provides centralized state gating for all commands; `CombatStateComponent` holds combat-specific metadata (opponent id). Commands coordinate both layers; `ICombatSystem` does not call `IEntityStateService` (cohesion preference, not an INV-2 obligation).
- **Combat model**: Autocombat for Phase 3 (heartbeat-driven rounds). Architecture is resilient to future pivot to freeform or realtime-with-cooldowns.
- **Stat pipeline**: `IStatSystem` is the single read seam for effective stats in `ICombatSystem.ExecuteRound`. Future effects/buffs plug into `IStatSystem` without touching combat code.
- **Handler ordering**: `CombatMobDeathHandler` at priority 80 guarantees `CombatHandler` (priority 20) reads the mob name from `CombatEndedEvent.DefenderName` before the entity is destroyed (INV-7).
- **Mob death**: destroy-and-re-seed path (INV-21). `BlueprintComponent` cleared before `DestroyEntity`; live respawn deferred.
- **Player death**: stubbed — HP clamped to 1, `CombatEndedEvent(PlayerIncapacitated)` published. Slice 10 adds the full mechanic.

### Other changes

- **`docs/roadmap/plan.md`**: Adds 9-a/9-b/9-c to the slice queue as parallel next entries; marks slice 9 blocked on all three.
- **`docs/roadmap/backlog.md`**: Promotes TimeSystem from deferred to active (slice 9-b).
- **`docs/use-cases/README.md`**: Adds index rows for all four new specs.
- **`.claude/skills/add-domain-system/SKILL.md`**: Corrects an incorrect "no domain-on-domain" prohibition. `docs/architecture/01-layers.md` explicitly permits `Domain → Domain (same or lower level)`; the hard prohibition is `Core → Domain` only (INV-2). Fixed to match the authoritative checklist (INV-20).

## Spec-review gate results

All four specs passed architecture-reviewer (spec mode):
- **9-a**: APPROVE WITH NITS — no blocking findings
- **9-b**: APPROVE WITH NITS — no blocking findings
- **9-c**: APPROVE WITH NITS — no blocking findings
- **9**: Two-pass review. First pass had 4 blocking findings (handler ordering, skill drift, INV-2 mis-citation, missing commands.md reference). All resolved; second pass returned APPROVE WITH NITS, no blockers.

## Test plan

- [x] Confirm all four use-case docs render correctly in GitHub
- [x] Confirm `docs/roadmap/plan.md` slice queue reads correctly (9-a/9-b/9-c parallel, 9 blocked)
- [x] Confirm `docs/use-cases/README.md` index has all four new rows
- [x] Confirm `add-domain-system` skill no longer has the domain-on-domain prohibition

🤖 Generated with [Claude Code](https://claude.ai/claude-code)