### PR TITLE
docs: fix internal contradiction in add-domain-system skill

### DIFF
--- a/.claude/skills/add-domain-system/SKILL.md
+++ b/.claude/skills/add-domain-system/SKILL.md
@@ -23,7 +23,7 @@ public class CombatSystem : ICombatSystem
 {
     private readonly EntityService _ecs;
     private readonly IDiceSystem _dice;
-    // core systems only; no other domain systems injected
+    // core systems; lower-level domain systems are also permitted (see Dependency rules)
     ...
 }
 ```
@@ -62,7 +62,7 @@ The key constraint is the same in both cases: **the system never publishes event
 ## Anti-patterns
 
 - **System that publishes events.** Delete the bus injection; return a result.
-- **System that calls another domain system.** Insert a handler between them.
+- **Lateral/peer domain system call that couples sibling features.** Same-or-lower-level domain-on-domain calls are explicitly permitted (INV-1, `01-layers.md`). Prefer event-driven coordination instead when the callee's result needs to trigger downstream event chains that only a handler can properly publish — this is a design preference, not a blanket prohibition.
 - **System that inspects commands or sessions.** Those live in handlers, not systems.
 - **Static classes full of gameplay rules.** Those were the legacy shape. Convert to injectable classes.
 


### PR DESCRIPTION
## Summary

- The `anti-patterns` section of `.claude/skills/add-domain-system/SKILL.md` contained a flat prohibition against domain systems calling other domain systems ("Insert a handler between them").
- This directly contradicted the `dependency-rules` section of the same file (which explicitly permits same-or-lower-level domain-on-domain calls) and `docs/architecture/01-layers.md` (which lists `Domain Systems → Domain Systems (same or lower level)` as **Allowed** under INV-1).
- The shape-example comment (`// core systems only; no other domain systems injected`) repeated the same false restriction.

## What changed

Replaced the blanket anti-pattern ban with a qualified rule: the concern is **lateral coupling between sibling features** — prefer event-driven coordination when the callee's result would need to trigger downstream event chains that only a handler can properly publish. This is a design preference, not an invariant. Updated the inline comment in the code example to match.

## Reviewer notes

No code changes — skill/tooling doc only. The fix brings the anti-patterns section into agreement with the dependency-rules section already present in the same file and with `01-layers.md` + INV-1 in the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)