### PR TITLE
docs: add README index update step to implement-use-case skill; sync use-case statuses

### DIFF
--- a/.claude/skills/implement-use-case/SKILL.md
+++ b/.claude/skills/implement-use-case/SKILL.md
@@ -24,8 +24,9 @@ Your job is to turn those sections into real code without slipping gameplay logi
 6. **Handlers.** One handler per step that orchestrates; subscribe with priorities. See **add-handler**.
 7. **Command (if player-initiated).** Thin; delegates to the first handler. See **add-command**.
 8. **Update the use-case doc** — set Status to `implemented` if fully done, keep `partial` if only some paths are live.
-9. **Sync roadmap docs.** Run the **sync-roadmap** skill. Updates `plan.md` (phase summary, slice queue status, current focus), adds a row to `done.md`, and creates `completed/<slug>.md`. This is Phase 3 ground rule 7.
-10. **Code-review gate (mandatory).** Run the `architecture-reviewer` agent in **code mode** against the diff before this branch merges. This is Phase 3 ground rule 6. Do not skip it even for "infrastructure-only" slices — the code gate catches drift between the as-built code and the spec that the spec gate cannot see.
+9. **Update the use-cases index** — open [docs/use-cases/README.md](../../../docs/use-cases/README.md) and set the status cell in the index table to match the use-case doc's new Status value.
+10. **Sync roadmap docs.** Run the **sync-roadmap** skill. Updates `plan.md` (phase summary, slice queue status, current focus), adds a row to `done.md`, and creates `completed/<slug>.md`. This is Phase 3 ground rule 7.
+11. **Code-review gate (mandatory).** Run the `architecture-reviewer` agent in **code mode** against the diff before this branch merges. This is Phase 3 ground rule 6. Do not skip it even for "infrastructure-only" slices — the code gate catches drift between the as-built code and the spec that the spec gate cannot see.
 
 ## Guard the layer discipline
 

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -44,14 +44,14 @@ At slice close-out, `sync-roadmap` **trims** it to its durable behavior spec —
 | `implemented` | [`account-character-creation.md`](account-character-creation.md) | Phase 3 slice 5 |
 | `implemented` | [`bare-bones-content-spawning.md`](bare-bones-content-spawning.md) | Phase 3 slice 5a |
 | `implemented` | [`persistence-two-level-model.md`](persistence-two-level-model.md) | Phase 3 slice 5b |
-| `planned` | [`items-and-inventory.md`](items-and-inventory.md) | Phase 3 slice 6 |
-| `planned` | [`equipment.md`](equipment.md) | Phase 3 slice 7 |
-| `planned` | [`mobs.md`](mobs.md) | Phase 3 slice 8 |
-| `planned` | [`attributes.md`](attributes.md) | Phase 3 slice 8a |
-| `planned` | [`entity-state-management.md`](entity-state-management.md) | Phase 3 slice 9-a |
+| `implemented` | [`items-and-inventory.md`](items-and-inventory.md) | Phase 3 slice 6 |
+| `implemented` | [`equipment.md`](equipment.md) | Phase 3 slice 7 |
+| `implemented` | [`mobs.md`](mobs.md) | Phase 3 slice 8 |
+| `implemented` | [`attributes.md`](attributes.md) | Phase 3 slice 8a |
+| `implemented` | [`entity-state-management.md`](entity-state-management.md) | Phase 3 slice 9-a |
 | `implemented` | [`time-system.md`](time-system.md) | Phase 3 slice 9-b |
 | `implemented` | [`stat-system.md`](stat-system.md) | Phase 3 slice 9-c |
-| `planned` | [`combat.md`](combat.md) | Phase 3 slice 9 |
+| `implemented` | [`combat.md`](combat.md) | Phase 3 slice 9 |
 | `deferred` | [`admin-privilege-elevation.md`](admin-privilege-elevation.md) | Future (TBD) — placeholder |
 | `planned` | [`persistence-reform.md`](persistence-reform.md) | Persistence reform (Stages A–C): SQLite backend, EntityService lifecycle, world content de-persistence, context-driven item persistence, spawn slot foundation |
 


### PR DESCRIPTION
## Summary

- Adds step 9 to the `implement-use-case` skill's order of implementation: after updating the use-case doc's Status field, agents must also update the `docs/use-cases/README.md` index table to match. Existing steps 9–10 renumbered to 10–11.
- Syncs the README index table with the actual Status fields in each use-case doc: `items-and-inventory`, `equipment`, `mobs`, `attributes`, `entity-state-management`, and `combat` corrected from `planned` to `implemented`.
- `admin-privilege-elevation` remains `deferred`; `persistence-reform` remains `planned` to match its doc.

## Test plan

- [x] Verify the README index table statuses match the Status field in each linked doc
- [x] Verify `admin-privilege-elevation.md` still shows `deferred` in the table
- [x] Review the new step 9 wording in the skill file for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)