### PR TITLE
slice 9-e: effect substrate (EffectSystem, stat modifiers, heartbeat tick, admin tooling)

### DIFF
--- a/.claude/skills/add-domain-system/SKILL.md
+++ b/.claude/skills/add-domain-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-domain-system
-description: Use when adding a new domain (feature) system under Core/Modules/<Feature>/Systems/. Covers interface-first shape, dependency rules (domain-on-core is fine; domain-on-domain via events only), pure-result pattern, and registration. Invoke when the user asks to add a system, extract gameplay logic, or stand up a new feature module.
+description: Use when adding a new domain (feature) system under Core/Modules/<Feature>/Systems/. Covers interface-first shape, dependency rules (domain-on-core fine; same-or-lower-level domain-on-domain direct calls permitted; peer/lateral coordination prefers events), pure-result pattern, and registration. Invoke when the user asks to add a system, extract gameplay logic, or stand up a new feature module.
 ---
 
 # Add a Domain System

--- a/Core/ECS/Components/EffectsComponent.cs
+++ b/Core/ECS/Components/EffectsComponent.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Hedron.Core.Modules.Effects;
+
+namespace Hedron.Core.ECS.Components
+{
+    [Persistent]
+    [JsonConverter(typeof(EffectsComponentJsonConverter))]
+    public sealed class EffectsComponent : IComponent
+    {
+        public List<Effect> Effects { get; set; } = new();
+    }
+}

--- a/Core/Modules/Admin/Handlers/AdminAuditHandler.cs
+++ b/Core/Modules/Admin/Handlers/AdminAuditHandler.cs
@@ -5,6 +5,7 @@ using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
 using Hedron.Core.Modules.Attributes.Events;
 using Hedron.Core.Modules.Combat.Events;
+using Hedron.Core.Modules.Effects.Events;
 using Hedron.Core.Modules.Items.Events;
 using Hedron.Core.Modules.Mobs.Events;
 using Hedron.Core.Modules.World.Events;
@@ -34,7 +35,8 @@ namespace Hedron.Core.Modules.Admin.Handlers
         IEventHandler<MobCreatedByAdminEvent>,
         IEventHandler<MobPropertySetByAdminEvent>,
         IEventHandler<PlayerAttributeSetByAdminEvent>,
-        IEventHandler<CombatEndedEvent>
+        IEventHandler<CombatEndedEvent>,
+        IEventHandler<EffectAppliedByAdminEvent>
     {
         private readonly EntityService _entityService;
         private readonly ILogger<AdminAuditHandler> _logger;
@@ -140,6 +142,14 @@ namespace Hedron.Core.Modules.Admin.Handlers
             _logger.LogInformation(
                 "CombatEnded: attacker={AttackerEntityId} defender={DefenderEntityId} outcome={Outcome}",
                 e.AttackerEntityId, e.DefenderEntityId, e.Outcome);
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(EffectAppliedByAdminEvent e)
+        {
+            _logger.LogInformation(
+                "AdminCommandExecuted: admin={Admin} command=affect target={TargetId} effect={EffectId} power={Power}",
+                ResolveName(e.AdminId), e.TargetId, e.EffectId, e.Power);
             return Task.CompletedTask;
         }
 

--- a/Core/Modules/Attributes/Commands/ScoreCommand.cs
+++ b/Core/Modules/Attributes/Commands/ScoreCommand.cs
@@ -6,6 +6,8 @@ using Hedron.Core.Commands.Authorization;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Modules.Account.Components;
+using Hedron.Core.Modules.Stats;
+using Hedron.Core.Modules.Stats.Systems;
 using Hedron.Core.Output;
 
 namespace Hedron.Core.Modules.Attributes.Commands
@@ -13,6 +15,7 @@ namespace Hedron.Core.Modules.Attributes.Commands
     public sealed class ScoreCommand : ICommand
     {
         private readonly EntityService _entityService;
+        private readonly IStatSystem _statSystem;
 
         public string Name => "score";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
@@ -25,9 +28,10 @@ namespace Hedron.Core.Modules.Attributes.Commands
             Array.Empty<IAuthorizationRequirement>();
         public CommandArgumentSchema ArgumentSchema { get; } = new(Array.Empty<CommandArgument>());
 
-        public ScoreCommand(EntityService entityService)
+        public ScoreCommand(EntityService entityService, IStatSystem statSystem)
         {
             _entityService = entityService;
+            _statSystem = statSystem;
         }
 
         public async Task ExecuteAsync(CommandContext context)
@@ -38,29 +42,25 @@ namespace Hedron.Core.Modules.Attributes.Commands
                 ? ch.CharacterName
                 : "Unknown";
 
-            var attrs = _entityService.TryGet<AttributesComponent>(entityId, out var a)
-                ? a
-                : new AttributesComponent();
-
-            var pools = _entityService.TryGet<PoolsComponent>(entityId, out var p)
-                ? p
-                : new PoolsComponent();
+            var level = _entityService.TryGet<AttributesComponent>(entityId, out var a)
+                ? a.Level
+                : 1;
 
             await context.Output.WriteAsync(new ScoreDisplayMessage(
                 charName,
-                attrs.Level,
-                pools.CurrentHp,
-                pools.MaxHp,
-                attrs.Mind,
-                attrs.Body,
-                attrs.Spirit,
-                attrs.Attunement,
-                pools.CurrentMana,
-                pools.MaxMana,
-                pools.CurrentStamina,
-                pools.MaxStamina,
-                pools.CurrentAstra,
-                pools.MaxAstra)).ConfigureAwait(false);
+                level,
+                _statSystem.Get(entityId, ScoreId.HpCurrent),
+                _statSystem.Get(entityId, ScoreId.HpMax),
+                _statSystem.Get(entityId, ScoreId.Mind),
+                _statSystem.Get(entityId, ScoreId.Body),
+                _statSystem.Get(entityId, ScoreId.Spirit),
+                _statSystem.Get(entityId, ScoreId.Attunement),
+                _statSystem.Get(entityId, ScoreId.ManaCurrent),
+                _statSystem.Get(entityId, ScoreId.ManaMax),
+                _statSystem.Get(entityId, ScoreId.StaminaCurrent),
+                _statSystem.Get(entityId, ScoreId.StaminaMax),
+                _statSystem.Get(entityId, ScoreId.AstraCurrent),
+                _statSystem.Get(entityId, ScoreId.AstraMax))).ConfigureAwait(false);
         }
     }
 }

--- a/Core/Modules/Effects/Commands/AffectCommand.cs
+++ b/Core/Modules/Effects/Commands/AffectCommand.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.ECS;
+using Hedron.Core.Events;
+using Hedron.Core.Modules.Account.Components;
+using Hedron.Core.Modules.Effects.Events;
+using Hedron.Core.Modules.Effects.Systems;
+using Hedron.Core.Output;
+using Hedron.Core.Sessions;
+
+namespace Hedron.Core.Modules.Effects.Commands
+{
+    public sealed class AffectCommand : ICommand
+    {
+        private readonly IEffectSystem _effectSystem;
+        private readonly IEffectRegistry _effectRegistry;
+        private readonly EntityService _entityService;
+        private readonly IEventBus _eventBus;
+        private readonly ISessionManager _sessionManager;
+
+        public string Name => "affect";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Admin;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Full;
+        public string ShortDescription => "Apply a registry effect to a target entity.";
+        public string LongDescription =>
+            "Applies a named effect from the effect registry to the target player or entity. " +
+            "Optionally overrides the effect power for testing.";
+        public string Usage => "affect <target> <effectId> [power]";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            new IAuthorizationRequirement[] { new AdminRequirement() };
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("target", typeof(string), CommandArgumentKind.Token,
+                Required: true, "Player name or entity id."),
+            new CommandArgument("effectId", typeof(string), CommandArgumentKind.Token,
+                Required: true, "Effect id from the registry (e.g. empower, poison)."),
+            new CommandArgument("power", typeof(string), CommandArgumentKind.Token,
+                Required: false, "Optional integer power override."),
+        });
+
+        public AffectCommand(
+            IEffectSystem effectSystem,
+            IEffectRegistry effectRegistry,
+            EntityService entityService,
+            IEventBus eventBus,
+            ISessionManager sessionManager)
+        {
+            _effectSystem = effectSystem;
+            _effectRegistry = effectRegistry;
+            _entityService = entityService;
+            _eventBus = eventBus;
+            _sessionManager = sessionManager;
+        }
+
+        public async Task ExecuteAsync(CommandContext context)
+        {
+            var targetArg = context.Args.Get<string>("target");
+            var effectId = context.Args.Get<string>("effectId");
+            var powerArg = context.Args.Get<string?>("power");
+
+            if (!_effectRegistry.TryGet(effectId, out var definition))
+            {
+                await context.Output.WriteAsync(new PlainMessage(
+                    $"Unknown effect '{effectId}'. Use 'effects list' to see available effects.",
+                    OutputSeverity.Error)).ConfigureAwait(false);
+                return;
+            }
+
+            var targetEntityId = ResolveTarget(targetArg);
+            if (targetEntityId == 0)
+            {
+                await context.Output.WriteAsync(new PlainMessage(
+                    $"No connected player or entity found for target '{targetArg}'.",
+                    OutputSeverity.Error)).ConfigureAwait(false);
+                return;
+            }
+
+            int? overridePower = null;
+            if (powerArg != null && int.TryParse(powerArg, out var parsedPower))
+                overridePower = parsedPower;
+
+            var appliedDef = overridePower.HasValue
+                ? definition with { Params = definition.Params with { BaseMagnitude = overridePower.Value }, PowerScalingFormula = "fixed" }
+                : definition;
+
+            var appliedEffect = _effectSystem.Apply(targetEntityId, appliedDef, context.InvokerEntityId);
+            if (appliedEffect == null)
+            {
+                await context.Output.WriteAsync(new PlainMessage(
+                    $"Effect '{effectId}' was not applied (HighestWins policy: existing effect has equal or greater power).",
+                    OutputSeverity.Error)).ConfigureAwait(false);
+                return;
+            }
+
+            await _eventBus.PublishAsync(new EffectAppliedEvent(
+                targetEntityId, effectId, definition.Category, appliedEffect.Power))
+                .ConfigureAwait(false);
+
+            await _eventBus.PublishAsync(new EffectAppliedByAdminEvent(
+                context.InvokerEntityId, targetEntityId, effectId, appliedEffect.Power))
+                .ConfigureAwait(false);
+
+            await context.Output.WriteAsync(new PlainMessage(
+                $"Applied '{effectId}' (power {appliedEffect.Power}) to entity #{targetEntityId}.",
+                OutputSeverity.Confirmation)).ConfigureAwait(false);
+        }
+
+        private uint ResolveTarget(string target)
+        {
+            foreach (var session in _sessionManager.GetAll())
+            {
+                if (session.PlayerEntityId == 0)
+                    continue;
+                if (_entityService.TryGet<CharacterComponent>(session.PlayerEntityId, out var ch) &&
+                    string.Equals(ch.CharacterName, target, StringComparison.OrdinalIgnoreCase))
+                    return session.PlayerEntityId;
+            }
+
+            if (uint.TryParse(target, out var entityId))
+                return entityId;
+
+            return 0;
+        }
+    }
+}

--- a/Core/Modules/Effects/Commands/AffectCommand.cs
+++ b/Core/Modules/Effects/Commands/AffectCommand.cs
@@ -60,12 +60,13 @@ namespace Hedron.Core.Modules.Effects.Commands
         {
             var targetArg = context.Args.Get<string>("target");
             var effectId = context.Args.Get<string>("effectId");
-            var powerArg = context.Args.Get<string?>("power");
+            context.Args.TryGet<string>("power", out var powerArg);
 
             if (!_effectRegistry.TryGet(effectId, out var definition))
             {
+                var available = string.Join(", ", _effectRegistry.AllIds);
                 await context.Output.WriteAsync(new PlainMessage(
-                    $"Unknown effect '{effectId}'. Use 'effects list' to see available effects.",
+                    $"Unknown effect '{effectId}'. Available: {available}.",
                     OutputSeverity.Error)).ConfigureAwait(false);
                 return;
             }

--- a/Core/Modules/Effects/Commands/AffectsCommand.cs
+++ b/Core/Modules/Effects/Commands/AffectsCommand.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.Modules.Effects.Systems;
+using Hedron.Core.Output;
+
+namespace Hedron.Core.Modules.Effects.Commands
+{
+    public sealed class AffectsCommand : ICommand
+    {
+        private readonly IEffectSystem _effectSystem;
+
+        public string Name => "affects";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Player;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
+        public string ShortDescription => "List your active effects.";
+        public string LongDescription => "Displays all effects currently active on you, including category, power, and remaining duration.";
+        public string Usage => "affects";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } = Array.Empty<IAuthorizationRequirement>();
+        public CommandArgumentSchema ArgumentSchema { get; } = CommandArgumentSchema.Empty;
+
+        public AffectsCommand(IEffectSystem effectSystem)
+        {
+            _effectSystem = effectSystem;
+        }
+
+        public async Task ExecuteAsync(CommandContext context)
+        {
+            var effects = _effectSystem.GetActive(context.InvokerEntityId);
+
+            if (effects.Count == 0)
+            {
+                await context.Output.WriteAsync(new PlainMessage(
+                    "You have no active effects.",
+                    OutputSeverity.System)).ConfigureAwait(false);
+                return;
+            }
+
+            await context.Output.WriteAsync(new PlainMessage(
+                "Active effects:",
+                OutputSeverity.System)).ConfigureAwait(false);
+
+            foreach (var effect in effects)
+            {
+                await context.Output.WriteAsync(new EffectDisplayMessage(effect))
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Core/Modules/Effects/Effect.cs
+++ b/Core/Modules/Effects/Effect.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Hedron.Core.Modules.Stats;
+
+namespace Hedron.Core.Modules.Effects
+{
+    public enum EffectKind
+    {
+        StatModifier,
+        Instant,
+        Periodic,
+        GrantFlag,
+        GrantAbility,
+        Trigger,
+        TransformModifier,
+    }
+
+    public enum EffectCategory
+    {
+        Buff,
+        Debuff,
+        Curse,
+        Disease,
+        Blessing,
+        Poison,
+        Aura,
+    }
+
+    public enum EffectLifetime
+    {
+        Instant,
+        Timed,
+        UntilRemoved,
+        WhileEquipped,
+        WhileKnown,
+        WhilePresent,
+    }
+
+    public enum StackPolicy
+    {
+        Stack,
+        HighestWins,
+        Refresh,
+        UniquePerSource,
+        Replace,
+    }
+
+    // HoT should have Early/Normal, DoT should have Late so heals fire before damage in the same tick.
+    public enum EffectPhase
+    {
+        Early,
+        Normal,
+        Late,
+    }
+
+    public sealed record EffectSource(uint EntityId, string? SourceLabel = null);
+
+    public sealed record EffectParams(ScoreId TargetScore, int BaseMagnitude, string? Aspect = null);
+
+    public sealed record Effect(
+        string EffectId,
+        EffectKind Kind,
+        EffectParams Params,
+        EffectCategory Category,
+        int Power,
+        EffectSource Source,
+        string? Group,
+        EffectLifetime Lifetime,
+        float Duration,
+        float Elapsed,
+        StackPolicy Stacking,
+        EffectPhase Phase
+    );
+
+    public sealed record PeriodicApplication(uint EntityId, Effect Effect, int Magnitude);
+
+    public sealed record EffectTickResult(
+        IReadOnlyList<PeriodicApplication> DueApplications,
+        IReadOnlyList<(uint EntityId, Effect Effect)> Expired
+    );
+
+    public sealed record EffectDefinition(
+        string EffectId,
+        EffectKind Kind,
+        EffectParams Params,
+        EffectCategory Category,
+        string PowerScalingFormula,
+        float Duration,
+        StackPolicy Stacking,
+        EffectPhase Phase
+    );
+}

--- a/Core/Modules/Effects/EffectDisplayMessage.cs
+++ b/Core/Modules/Effects/EffectDisplayMessage.cs
@@ -1,0 +1,36 @@
+using System;
+using Hedron.Core.Output;
+
+namespace Hedron.Core.Modules.Effects
+{
+    public sealed class EffectDisplayMessage : IOutputMessage
+    {
+        public string EffectId { get; }
+        public EffectCategory EffectCategory { get; }
+        public int Power { get; }
+        public EffectLifetime Lifetime { get; }
+        public float Duration { get; }
+        public float Elapsed { get; }
+
+        public OutputCategory Category => OutputCategory.Info;
+
+        public EffectDisplayMessage(Effect effect)
+        {
+            EffectId = effect.EffectId;
+            EffectCategory = effect.Category;
+            Power = effect.Power;
+            Lifetime = effect.Lifetime;
+            Duration = effect.Duration;
+            Elapsed = effect.Elapsed;
+        }
+
+        public string Format()
+        {
+            var sign = Power >= 0 ? "+" : "";
+            var remaining = Lifetime == EffectLifetime.UntilRemoved
+                ? "permanent"
+                : $"{Math.Max(0f, Duration - Elapsed):F0}s remaining";
+            return $"  {EffectId,-16} [{EffectCategory,-10}] {sign}{Power,4}  {remaining}";
+        }
+    }
+}

--- a/Core/Modules/Effects/EffectRegistry.cs
+++ b/Core/Modules/Effects/EffectRegistry.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using Hedron.Core.Modules.Stats;
+
+namespace Hedron.Core.Modules.Effects
+{
+    public interface IEffectRegistry
+    {
+        bool TryGet(string effectId, out EffectDefinition definition);
+        IReadOnlyCollection<string> AllIds { get; }
+    }
+
+    public sealed class EffectRegistry : IEffectRegistry
+    {
+        private static readonly Dictionary<string, EffectDefinition> _definitions = new()
+        {
+            ["empower"] = new EffectDefinition(
+                "empower", EffectKind.StatModifier,
+                new EffectParams(ScoreId.Body, 5),
+                EffectCategory.Buff, "fixed", 30f,
+                StackPolicy.HighestWins, EffectPhase.Normal),
+
+            ["weaken"] = new EffectDefinition(
+                "weaken", EffectKind.StatModifier,
+                new EffectParams(ScoreId.Body, -5),
+                EffectCategory.Debuff, "fixed", 30f,
+                StackPolicy.HighestWins, EffectPhase.Normal),
+
+            ["regen"] = new EffectDefinition(
+                "regen", EffectKind.Periodic,
+                new EffectParams(ScoreId.HpCurrent, 10),
+                EffectCategory.Blessing, "fixed", 60f,
+                StackPolicy.Stack, EffectPhase.Early),
+
+            ["poison"] = new EffectDefinition(
+                "poison", EffectKind.Periodic,
+                new EffectParams(ScoreId.HpCurrent, -8),
+                EffectCategory.Poison, "fixed", 30f,
+                StackPolicy.Stack, EffectPhase.Late),
+
+            ["minor_curse"] = new EffectDefinition(
+                "minor_curse", EffectKind.StatModifier,
+                new EffectParams(ScoreId.Mind, -3),
+                EffectCategory.Curse, "fixed", -1f,
+                StackPolicy.Stack, EffectPhase.Normal),
+        };
+
+        public bool TryGet(string effectId, out EffectDefinition definition)
+            => _definitions.TryGetValue(effectId, out definition!);
+
+        public IReadOnlyCollection<string> AllIds => _definitions.Keys;
+    }
+}

--- a/Core/Modules/Effects/EffectsComponentJsonConverter.cs
+++ b/Core/Modules/Effects/EffectsComponentJsonConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Hedron.Core.ECS.Components;
+
+namespace Hedron.Core.Modules.Effects
+{
+    public sealed class EffectsComponentJsonConverter : JsonConverter<EffectsComponent>
+    {
+        public override EffectsComponent Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var effects = JsonSerializer.Deserialize<List<Effect>>(ref reader, options) ?? new List<Effect>();
+            return new EffectsComponent { Effects = effects };
+        }
+
+        public override void Write(Utf8JsonWriter writer, EffectsComponent value, JsonSerializerOptions options)
+        {
+            var filtered = value.Effects.FindAll(e => e.Lifetime == EffectLifetime.UntilRemoved);
+            JsonSerializer.Serialize(writer, filtered, options);
+        }
+    }
+}

--- a/Core/Modules/Effects/EffectsModule.cs
+++ b/Core/Modules/Effects/EffectsModule.cs
@@ -1,0 +1,21 @@
+using Hedron.Core.Commands;
+using Hedron.Core.Modules.Effects.Commands;
+using Hedron.Core.Modules.Effects.Handlers;
+using Hedron.Core.Modules.Effects.Systems;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hedron.Core.Modules.Effects
+{
+    public static class EffectsModule
+    {
+        public static IServiceCollection AddEffectsModule(this IServiceCollection services)
+        {
+            services.AddSingleton<IEffectSystem, EffectSystem>();
+            services.AddSingleton<IEffectRegistry, EffectRegistry>();
+            services.AddSingleton<EffectTickHandler>();
+            services.AddSingleton<ICommand, AffectCommand>();
+            services.AddSingleton<ICommand, AffectsCommand>();
+            return services;
+        }
+    }
+}

--- a/Core/Modules/Effects/Events/EffectAppliedByAdminEvent.cs
+++ b/Core/Modules/Effects/Events/EffectAppliedByAdminEvent.cs
@@ -1,0 +1,15 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Effects.Events
+{
+    public sealed record EffectAppliedByAdminEvent(
+        uint AdminId,
+        uint TargetId,
+        string EffectId,
+        int Power) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Effects/Events/EffectAppliedEvent.cs
+++ b/Core/Modules/Effects/Events/EffectAppliedEvent.cs
@@ -1,0 +1,15 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Effects.Events
+{
+    public sealed record EffectAppliedEvent(
+        uint TargetId,
+        string EffectId,
+        EffectCategory Category,
+        int Power) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Effects/Events/EffectExpiredEvent.cs
+++ b/Core/Modules/Effects/Events/EffectExpiredEvent.cs
@@ -1,0 +1,13 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Effects.Events
+{
+    public sealed record EffectExpiredEvent(
+        uint TargetId,
+        string EffectId) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Effects/Handlers/EffectTickHandler.cs
+++ b/Core/Modules/Effects/Handlers/EffectTickHandler.cs
@@ -1,0 +1,66 @@
+using System.Threading.Tasks;
+using Hedron.Core.Events;
+using Hedron.Core.Modules.Attributes.Systems;
+using Hedron.Core.Modules.Effects.Events;
+using Hedron.Core.Modules.Effects.Systems;
+using Hedron.Core.Modules.Stats;
+using Hedron.Core.Modules.Time.Events;
+
+namespace Hedron.Core.Modules.Effects.Handlers
+{
+    public sealed class EffectTickHandler : IEventHandler<HeartbeatTickEvent>
+    {
+        private readonly IEffectSystem _effectSystem;
+        private readonly IAttributeSystem _attributeSystem;
+        private readonly IEventBus _eventBus;
+
+        public int Priority => HandlerPriority.Domain;
+
+        public EffectTickHandler(IEffectSystem effectSystem, IAttributeSystem attributeSystem, IEventBus eventBus)
+        {
+            _effectSystem = effectSystem;
+            _attributeSystem = attributeSystem;
+            _eventBus = eventBus;
+        }
+
+        public async Task HandleAsync(HeartbeatTickEvent @event)
+        {
+            var result = _effectSystem.AdvanceTick(@event.Elapsed);
+
+            foreach (var app in result.DueApplications)
+            {
+                ApplyMagnitude(app.EntityId, app.Effect.Params.TargetScore, app.Magnitude);
+            }
+
+            foreach (var (entityId, effect) in result.Expired)
+            {
+                await _eventBus.PublishAsync(new EffectExpiredEvent(entityId, effect.EffectId))
+                    .ConfigureAwait(false);
+            }
+        }
+
+        private void ApplyMagnitude(uint entityId, ScoreId targetScore, int magnitude)
+        {
+            switch (targetScore)
+            {
+                case ScoreId.HpCurrent:
+                    _attributeSystem.SetCurrentHp(entityId,
+                        _attributeSystem.GetCurrentHp(entityId) + magnitude);
+                    break;
+                case ScoreId.ManaCurrent:
+                    _attributeSystem.SetCurrentMana(entityId,
+                        _attributeSystem.GetCurrentMana(entityId) + magnitude);
+                    break;
+                case ScoreId.StaminaCurrent:
+                    _attributeSystem.SetCurrentStamina(entityId,
+                        _attributeSystem.GetCurrentStamina(entityId) + magnitude);
+                    break;
+                case ScoreId.AstraCurrent:
+                    _attributeSystem.SetCurrentAstra(entityId,
+                        _attributeSystem.GetCurrentAstra(entityId) + magnitude);
+                    break;
+                // Non-pool scores (stat modifiers) are felt via IEffectSystem.GetModifiers on read.
+            }
+        }
+    }
+}

--- a/Core/Modules/Effects/PowerScaling.cs
+++ b/Core/Modules/Effects/PowerScaling.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
+
+namespace Hedron.Core.Modules.Effects
+{
+    public static class PowerScaling
+    {
+        private static readonly Dictionary<string, Func<EffectDefinition, EntityService, uint, int>> _formulas = new()
+        {
+            ["fixed"] = (def, _, _) => def.Params.BaseMagnitude,
+            ["byAttunement"] = (def, entityService, sourceEntityId) =>
+            {
+                var attunement = entityService.TryGet<AttributesComponent>(sourceEntityId, out var a)
+                    ? a.Attunement : 10;
+                return def.Params.BaseMagnitude + attunement / 5;
+            },
+        };
+
+        public static int Evaluate(string formula, EffectDefinition def, EntityService entityService, uint sourceEntityId)
+        {
+            if (_formulas.TryGetValue(formula, out var fn))
+                return fn(def, entityService, sourceEntityId);
+            return def.Params.BaseMagnitude;
+        }
+    }
+}

--- a/Core/Modules/Effects/Systems/EffectSystem.cs
+++ b/Core/Modules/Effects/Systems/EffectSystem.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
+using Hedron.Core.Modules.Stats;
+
+namespace Hedron.Core.Modules.Effects.Systems
+{
+    public sealed class EffectSystem : IEffectSystem
+    {
+        private readonly EntityService _entityService;
+
+        public EffectSystem(EntityService entityService)
+        {
+            _entityService = entityService;
+        }
+
+        public Effect? Apply(uint targetEntityId, EffectDefinition definition, uint sourceEntityId)
+        {
+            var power = PowerScaling.Evaluate(definition.PowerScalingFormula, definition, _entityService, sourceEntityId);
+
+            var effect = new Effect(
+                EffectId: definition.EffectId,
+                Kind: definition.Kind,
+                Params: definition.Params,
+                Category: definition.Category,
+                Power: power,
+                Source: new EffectSource(sourceEntityId),
+                Group: null,
+                Lifetime: definition.Kind == EffectKind.Instant ? EffectLifetime.Instant : MapLifetime(definition.Duration),
+                Duration: definition.Duration,
+                Elapsed: 0f,
+                Stacking: definition.Stacking,
+                Phase: definition.Phase
+            );
+
+            if (definition.Kind == EffectKind.Instant)
+                return effect;
+
+            EnsureComponent(targetEntityId, out var comp);
+
+            switch (definition.Stacking)
+            {
+                case StackPolicy.HighestWins:
+                {
+                    var existing = comp.Effects.Find(e => e.EffectId == definition.EffectId);
+                    if (existing != null)
+                    {
+                        if (existing.Power >= power)
+                            return null;
+                        comp.Effects.Remove(existing);
+                    }
+                    comp.Effects.Add(effect);
+                    break;
+                }
+                case StackPolicy.Refresh:
+                {
+                    var idx = comp.Effects.FindIndex(e => e.EffectId == definition.EffectId);
+                    if (idx >= 0)
+                        comp.Effects[idx] = comp.Effects[idx] with { Elapsed = 0f };
+                    else
+                        comp.Effects.Add(effect);
+                    break;
+                }
+                case StackPolicy.UniquePerSource:
+                {
+                    var idx = comp.Effects.FindIndex(e => e.EffectId == definition.EffectId && e.Source.EntityId == sourceEntityId);
+                    if (idx >= 0)
+                        comp.Effects[idx] = effect;
+                    else
+                        comp.Effects.Add(effect);
+                    break;
+                }
+                case StackPolicy.Replace:
+                {
+                    comp.Effects.RemoveAll(e => e.EffectId == definition.EffectId);
+                    comp.Effects.Add(effect);
+                    break;
+                }
+                default: // Stack
+                    comp.Effects.Add(effect);
+                    break;
+            }
+
+            return effect;
+        }
+
+        public void Remove(uint entityId, string effectId)
+        {
+            if (_entityService.TryGet<EffectsComponent>(entityId, out var comp))
+                comp.Effects.RemoveAll(e => e.EffectId == effectId);
+        }
+
+        public void RemoveByCategory(uint entityId, EffectCategory category)
+        {
+            if (_entityService.TryGet<EffectsComponent>(entityId, out var comp))
+                comp.Effects.RemoveAll(e => e.Category == category);
+        }
+
+        public IReadOnlyList<Effect> GetActive(uint entityId)
+        {
+            if (_entityService.TryGet<EffectsComponent>(entityId, out var comp))
+                return comp.Effects;
+            return Array.Empty<Effect>();
+        }
+
+        public int GetModifiers(uint entityId, ScoreId scoreId)
+        {
+            if (!_entityService.TryGet<EffectsComponent>(entityId, out var comp))
+                return 0;
+            return comp.Effects
+                .Where(e => e.Kind == EffectKind.StatModifier && e.Params.TargetScore == scoreId)
+                .Sum(e => e.Power);
+        }
+
+        public EffectTickResult AdvanceTick(TimeSpan elapsed)
+        {
+            var elapsedSeconds = (float)elapsed.TotalSeconds;
+            var due = new List<PeriodicApplication>();
+            var expired = new List<(uint EntityId, Effect Effect)>();
+
+            foreach (var (entityId, comp) in _entityService.GetAllComponents<EffectsComponent>())
+            {
+                for (var i = comp.Effects.Count - 1; i >= 0; i--)
+                {
+                    var effect = comp.Effects[i];
+
+                    if (effect.Lifetime == EffectLifetime.Timed)
+                    {
+                        var newElapsed = effect.Elapsed + elapsedSeconds;
+                        comp.Effects[i] = effect with { Elapsed = newElapsed };
+                        effect = comp.Effects[i];
+
+                        if (effect.Elapsed >= effect.Duration)
+                        {
+                            expired.Add((entityId, effect));
+                            comp.Effects.RemoveAt(i);
+                            continue;
+                        }
+                    }
+
+                    if (effect.Kind == EffectKind.Periodic)
+                        due.Add(new PeriodicApplication(entityId, effect, effect.Power));
+                }
+            }
+
+            due.Sort((a, b) => a.Effect.Phase.CompareTo(b.Effect.Phase));
+            expired.Sort((a, b) => a.Effect.Phase.CompareTo(b.Effect.Phase));
+
+            return new EffectTickResult(due, expired);
+        }
+
+        private void EnsureComponent(uint entityId, out EffectsComponent comp)
+        {
+            if (!_entityService.TryGet<EffectsComponent>(entityId, out comp))
+            {
+                comp = new EffectsComponent();
+                _entityService.AddComponent(entityId, comp);
+            }
+        }
+
+        private static EffectLifetime MapLifetime(float duration)
+        {
+            if (duration < 0f)
+                return EffectLifetime.UntilRemoved;
+            return EffectLifetime.Timed;
+        }
+    }
+}

--- a/Core/Modules/Effects/Systems/IEffectSystem.cs
+++ b/Core/Modules/Effects/Systems/IEffectSystem.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using Hedron.Core.Modules.Stats;
+
+namespace Hedron.Core.Modules.Effects.Systems
+{
+    public interface IEffectSystem
+    {
+        Effect? Apply(uint targetEntityId, EffectDefinition definition, uint sourceEntityId);
+
+        void Remove(uint entityId, string effectId);
+        void RemoveByCategory(uint entityId, EffectCategory category);
+
+        IReadOnlyList<Effect> GetActive(uint entityId);
+
+        int GetModifiers(uint entityId, ScoreId scoreId);
+
+        EffectTickResult AdvanceTick(TimeSpan elapsed);
+    }
+}

--- a/Core/Modules/Stats/Systems/StatSystem.cs
+++ b/Core/Modules/Stats/Systems/StatSystem.cs
@@ -1,6 +1,7 @@
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Modules.Attributes.Systems;
+using Hedron.Core.Modules.Effects.Systems;
 
 namespace Hedron.Core.Modules.Stats.Systems
 {
@@ -8,11 +9,13 @@ namespace Hedron.Core.Modules.Stats.Systems
     {
         private readonly IAttributeSystem _attributes;
         private readonly EntityService _entityService;
+        private readonly IEffectSystem _effectSystem;
 
-        public StatSystem(IAttributeSystem attributes, EntityService entityService)
+        public StatSystem(IAttributeSystem attributes, EntityService entityService, IEffectSystem effectSystem)
         {
             _attributes = attributes;
             _entityService = entityService;
+            _effectSystem = effectSystem;
         }
 
         public int GetEffectiveMind(uint entityId) => _attributes.GetMind(entityId);
@@ -42,10 +45,10 @@ namespace Hedron.Core.Modules.Stats.Systems
 
         public int Get(uint entityId, ScoreId score) => score switch
         {
-            ScoreId.Mind            => GetEffectiveMind(entityId),
-            ScoreId.Body            => GetEffectiveBody(entityId),
-            ScoreId.Spirit          => GetEffectiveSpirit(entityId),
-            ScoreId.Attunement      => GetEffectiveAttunement(entityId),
+            ScoreId.Mind            => GetEffectiveMind(entityId) + _effectSystem.GetModifiers(entityId, score),
+            ScoreId.Body            => GetEffectiveBody(entityId) + _effectSystem.GetModifiers(entityId, score),
+            ScoreId.Spirit          => GetEffectiveSpirit(entityId) + _effectSystem.GetModifiers(entityId, score),
+            ScoreId.Attunement      => GetEffectiveAttunement(entityId) + _effectSystem.GetModifiers(entityId, score),
             ScoreId.HpMax           => _attributes.GetMaxHp(entityId),
             ScoreId.HpCurrent       => _attributes.GetCurrentHp(entityId),
             ScoreId.ManaMax         => _attributes.GetMaxMana(entityId),
@@ -54,8 +57,8 @@ namespace Hedron.Core.Modules.Stats.Systems
             ScoreId.StaminaCurrent  => _attributes.GetCurrentStamina(entityId),
             ScoreId.AstraMax        => _attributes.GetMaxAstra(entityId),
             ScoreId.AstraCurrent    => _attributes.GetCurrentAstra(entityId),
-            ScoreId.AttackPower     => GetEffectiveAttackPower(entityId),
-            ScoreId.Defense         => GetEffectiveDefense(entityId),
+            ScoreId.AttackPower     => GetEffectiveAttackPower(entityId) + _effectSystem.GetModifiers(entityId, score),
+            ScoreId.Defense         => GetEffectiveDefense(entityId) + _effectSystem.GetModifiers(entityId, score),
             _                       => 0,
         };
     }

--- a/Core/Output/TelnetOutputFormatter.cs
+++ b/Core/Output/TelnetOutputFormatter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Hedron.Core.Modules.Effects;
 using Hedron.Core.Sessions;
 
 namespace Hedron.Core.Output
@@ -41,6 +42,7 @@ namespace Hedron.Core.Output
                 InventoryListMessage m    => FormatInventoryList(m, color),
                 EquipmentDisplayMessage m => FormatEquipmentDisplay(m, color),
                 ScoreDisplayMessage m     => FormatScore(m, color),
+                EffectDisplayMessage m                             => m.Format(),
                 _                         => message.ToString() ?? string.Empty,
             };
         }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -37,6 +37,9 @@ using Hedron.Core.Modules.Combat.Handlers;
 using Hedron.Core.Modules.Spawn;
 using Hedron.Core.Modules.Spawn.Handlers;
 using Hedron.Core.Modules.Spawn.Systems;
+using Hedron.Core.Modules.Effects;
+using Hedron.Core.Modules.Effects.Events;
+using Hedron.Core.Modules.Effects.Handlers;
 using Hedron.Core.Modules.Stats;
 using Hedron.Core.Modules.Time;
 using Hedron.Core.Modules.Time.Events;
@@ -121,6 +124,7 @@ public static class Program
                 services.AddEntityStateModule();
                 services.AddTimeModule();
                 services.AddStatsModule();
+                services.AddEffectsModule();
                 services.AddCombatModule();
                 services.AddSpawnModule();
 
@@ -140,6 +144,9 @@ public static class Program
         bus.Subscribe<PlayerMovedEvent>(host.Services.GetRequiredService<PlayerMovedHandler>());
         bus.Subscribe<PlayerTeleportedByAdminEvent>(host.Services.GetRequiredService<PlayerMovedHandler>());
         bus.Subscribe<PlayerSaidEvent>(host.Services.GetRequiredService<PlayerSaidHandler>());
+
+        var effectTick = host.Services.GetRequiredService<EffectTickHandler>();
+        bus.Subscribe<HeartbeatTickEvent>(effectTick);
 
         var combatTick = host.Services.GetRequiredService<CombatTickHandler>();
         bus.Subscribe<HeartbeatTickEvent>(combatTick);
@@ -165,6 +172,7 @@ public static class Program
         bus.Subscribe<MobPropertySetByAdminEvent>(audit);
         bus.Subscribe<PlayerAttributeSetByAdminEvent>(audit);
         bus.Subscribe<CombatEndedEvent>(audit);
+        bus.Subscribe<EffectAppliedByAdminEvent>(audit);
 
         var characterHydration = host.Services.GetRequiredService<CharacterHydrationHandler>();
         bus.Subscribe<WorldContentReadyEvent>(characterHydration);

--- a/docs/architecture/06-persistence.md
+++ b/docs/architecture/06-persistence.md
@@ -45,7 +45,7 @@ Entity has PersistentEntity?
   Yes → write all components tagged [Persistent] on that entity.
 ```
 
-Some components must be excluded even for persistent entities. `PlayerComponent` holds a transient session reference. `TransientEffectsComponent` is session-only by design. Those stay untagged; `PersistenceSystem` skips them.
+Some components must be excluded even for persistent entities. `PlayerComponent` holds a transient session reference. Those stay untagged; `PersistenceSystem` skips them. `EffectsComponent` is tagged `[Persistent]` but uses a `[JsonConverter]` that writes only `UntilRemoved` effects; timed and other transient-lifetime effects are dropped at serialization time.
 
 ---
 

--- a/docs/architecture/effects.md
+++ b/docs/architecture/effects.md
@@ -1,0 +1,144 @@
+# Effects — design reference
+
+> **Purpose.** This doc captures the effect model design — the decisions and invariants that every future slice consuming effects must understand. The per-slice behavioral spec lives in [`../use-cases/effect-substrate.md`](../use-cases/effect-substrate.md). See [`../design/gameplay-model.md`](../design/gameplay-model.md) Spine C and decisions R5/R6 for the upstream design inputs.
+
+---
+
+## What an effect is
+
+An `Effect` is an immutable record applied to an entity by a source. It carries:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `EffectId` | `string` | Registry key; used for `HighestWins` comparison and display |
+| `Kind` | `EffectKind` | What the effect *does* (see below) |
+| `Params` | `EffectParams` | `TargetScore`, `BaseMagnitude`, `Aspect` |
+| `Category` | `EffectCategory` | Tag for dispel targeting (`RemoveByCategory(Curse)`) |
+| `Power` | `int` | Computed at apply time; the `HighestWins` key and magnitude scalar |
+| `Source` | `EffectSource` | The entity that applied it |
+| `Group` | `string?` | Composite group ID (deferred — composites land with S5) |
+| `Lifetime` | `EffectLifetime` | Controls storage and tick behaviour |
+| `Duration` | `float` | Seconds until expiry; `-1f` == `UntilRemoved` |
+| `Elapsed` | `float` | Ticks up each heartbeat for `Timed` effects |
+| `Stacking` | `StackPolicy` | How re-application interacts with existing instances |
+| `Phase` | `EffectPhase` | Ordering within a tick (Early < Normal < Late) |
+
+Effects live in `EffectsComponent { List<Effect> Effects }` on their target entity.
+
+---
+
+## Kinds
+
+| `EffectKind` | Behaviour | Handler | Deferred? |
+|---|---|---|---|
+| `StatModifier` | Adds `Power` (signed) to a `ScoreId` via `IEffectSystem.GetModifiers` | `StatSystem.Get` reads the seam on every call | No |
+| `Instant` | One-shot magnitude applied at apply time; not stored | `IEffectSystem.Apply` returns result without storing | No |
+| `Periodic` | `Power` applied to target pool each heartbeat tick | `EffectTickHandler` via `IAttributeSystem` | No |
+| `GrantFlag` | Tag presence; `GetActive` is the query | Check `GetActive` for the flag kind | No |
+| `GrantAbility` | Grants an ability while active | Deferred to S4 (abilities) | Yes |
+| `Trigger` | Fires a world event on tick/expiry | Deferred to S5 (world events) | Yes |
+| `TransformModifier` | Modifies generation parameters | Deferred to S5 (generation) | Yes |
+
+Deferred kinds are defined in the enum; their handlers are additive (no model change when added).
+
+---
+
+## Lifetimes
+
+| `EffectLifetime` | Duration | Persisted? | Notes |
+|---|---|---|---|
+| `Instant` | 0 | No | Never stored; `Apply` returns synthetic record only |
+| `Timed` | `> 0` seconds | No | Expires via `AdvanceTick`; dropped if game restarts mid-duration |
+| `UntilRemoved` | `-1f` | **Yes** | Written by `EffectsComponentJsonConverter`; survives restarts |
+| `WhileEquipped` | Source-bound | No | Derived from equipment; not stored — re-derives from source on load |
+| `WhileKnown` | Source-bound | No | Derived from known abilities (S4) |
+| `WhilePresent` | Source-bound | No | Derived from area/aura presence |
+
+**Persistence contract.** `EffectsComponent` is `[Persistent]`. The `[JsonConverter(typeof(EffectsComponentJsonConverter))]` attribute on `EffectsComponent` causes `ComponentSerializer` to use the custom converter automatically — only `UntilRemoved` entries are written. Source-bound entries (`WhileEquipped`, etc.) re-derive when their sources load.
+
+---
+
+## Stacking policies
+
+| `StackPolicy` | Behaviour |
+|---|---|
+| `Stack` | Every application adds a new instance |
+| `HighestWins` | Only the highest-Power instance for a given `EffectId` is kept; a weaker re-apply is ignored |
+| `Refresh` | Re-application from the same source resets `Elapsed` to 0; does not add a second instance |
+| `UniquePerSource` | One instance per source entity; re-apply replaces |
+| `Replace` | All instances of this `EffectId` are replaced by the new one |
+
+`HighestWins` is the canonical policy for auras and stat-modifier buffs/debuffs where magnitude determines rank.
+
+---
+
+## Power
+
+`Power` is a single integer computed at apply time by `PowerScaling.Evaluate(formula, definition, entityService, sourceEntityId)`. It serves as:
+
+1. The `HighestWins` comparison key.
+2. The raw magnitude for `Periodic` and `Instant` effects.
+3. The signed modifier for `StatModifier` effects (negative Power = debuff).
+
+**Formula registry (`PowerScaling.cs`).**
+
+| Formula key | Result |
+|---|---|
+| `"fixed"` | `BaseMagnitude` (no stat scaling) |
+| `"byAttunement"` | `BaseMagnitude + source.Attunement / 5` |
+
+Power is computed from **source's base stats** (via `EntityService` directly), never from `IStatSystem.Get` (would create an `EffectSystem`↔`StatSystem` cycle). The formula framework is provisional (gameplay-model §6); `Tier`-based scaling lands with Ascension (S8).
+
+---
+
+## Phase ordering
+
+`EffectPhase` controls intra-tick ordering for `Periodic` applications and expiry notifications.
+
+| Phase | Intended use |
+|---|---|
+| `Early` | HoT (healing-over-time), regen |
+| `Normal` | Neutral stat changes |
+| `Late` | DoT (damage-over-time), poison |
+
+`EffectSystem.AdvanceTick` sorts both `DueApplications` and `Expired` by `Phase` ascending. This guarantees a heal-before-damage ordering when both affect the same entity in the same tick.
+
+---
+
+## Stat integration seam
+
+`IStatSystem.Get(entityId, ScoreId)` sums `IEffectSystem.GetModifiers(entityId, scoreId)` on top of base + equipment contributions. This is transparent to all existing consumers (combat, `score` command, etc.) — no call site changes when effects are added or removed.
+
+`StatSystem` (domain) → `IEffectSystem` (core) is a legal downward dependency.
+
+---
+
+## Admin tooling
+
+| Command | Access | Behaviour |
+|---|---|---|
+| `affect <target> <effectId> [power]` | Admin | Applies a registry effect; `[power]` is a testing-only override |
+| `affects` | Player/Admin | Lists active effects on the caller (category, Power, remaining) |
+
+`EffectRegistry` holds the hardcoded starter definitions (`empower`, `weaken`, `regen`, `poison`, `minor_curse`). Promotion to a data-file effect catalog is deferred (Category-3 balance data; tracked in [`../roadmap/backlog.md`](../roadmap/backlog.md)).
+
+---
+
+## Deferred / future
+
+- **Aspect resolution (S3).** `EffectParams.Aspect` is carried on every effect but resolved to raw magnitude for now. Aspect math lands in S3.
+- **Source-bound derivation.** `GetModifiers` sums only standalone effects; equipment-derived and ability-derived effects fold in when their sources carry effect data (items later, abilities S4).
+- **Composite effects.** `CompositeEffectDefinition` (one name → several effects sharing a `Group`) deferred to the content slice that needs authored curses/blessings.
+- **`Speed` targeting.** No `Speed` `ScoreId` yet; `haste` → `Speed` buff lands when a combat/initiative slice makes `Speed` a consumed derived score.
+
+---
+
+## Cross-references
+
+- [`Core/Modules/Effects/`](../../Core/Modules/Effects/) — module source
+- [`Core/ECS/Components/EffectsComponent.cs`](../../Core/ECS/Components/EffectsComponent.cs)
+- [`docs/use-cases/effect-substrate.md`](../use-cases/effect-substrate.md) — behavioral spec (slice 9-e)
+- [`docs/architecture/flows/flow-21-effect-tick.md`](flows/flow-21-effect-tick.md) — effect tick runtime flow
+- [`docs/design/gameplay-model.md`](../design/gameplay-model.md) — Spine C, R5, R6
+- [`docs/reference/systems.md`](../reference/systems.md) — `EffectSystem` catalog entry
+- [`docs/reference/components.md`](../reference/components.md) — `EffectsComponent` catalog entry

--- a/docs/architecture/flows/README.md
+++ b/docs/architecture/flows/README.md
@@ -30,6 +30,7 @@
 | 18 | [Combat round pulse](flow-18-combat-round-pulse.md) | `HeartbeatTickEvent` dispatched to `CombatTickHandler` | Phase 3 slice 9 |
 | 19 | [`flee` — combat exit](flow-19-flee-combat-exit.md) | Player sends `flee` | Phase 3 slice 9 |
 | 20 | [Mob death and respawn](flow-20-mob-death-respawn.md) | Mob HP reaches zero; `SpawnSystem` schedules and executes respawn | Persistence reform Stage C |
+| 21 | [Effect tick](flow-21-effect-tick.md) | `HeartbeatTickEvent` dispatched to `EffectTickHandler` | Phase 3 slice 9-e |
 
 Flows that don't yet exist (player death, mob wander tick, etc.) get added by the slice that introduces them.
 

--- a/docs/architecture/flows/flow-04-persistence-flush-cycle.md
+++ b/docs/architecture/flows/flow-04-persistence-flush-cycle.md
@@ -41,7 +41,7 @@ sequenceDiagram
 7. **Shutdown path.** `PersistenceBootstrap.StopAsync` calls `PersistenceSystem.FlushAllAsync(ct)` — identical logic, different log context (`"shutdown flush"`).
 8. **Auto-delete.** When `EntityService.DestroyEntity(id)` is called for a persistent entity, `PersistenceSystem.DeleteEntitySync` fires synchronously (via `EntityService.OnPersistentEntityDestroying`) and issues `DELETE FROM entity_components WHERE entity_id = ?` before ECS teardown. No handler or command is involved.
 
-**Two-level model.** An entity is written only if it carries `PersistentEntity` (level 1). Among its components, only those tagged `[Persistent]` are included in the snapshot (level 2). `PlayerComponent` (transient session ref) and `TransientEffectsComponent` (session-only) are untagged and are never written.
+**Two-level model.** An entity is written only if it carries `PersistentEntity` (level 1). Among its components, only those tagged `[Persistent]` are included in the snapshot (level 2). `PlayerComponent` (transient session ref) is untagged and is never written. `EffectsComponent` is tagged `[Persistent]` but its `[JsonConverter]` filters out all effects except `UntilRemoved` ones before writing.
 
 **Flush pool (Stage B).** World content entities — rooms, areas, mobs, world-spawn items — carry no `PersistentEntity` and are never in the flush pool. The pool contains only players, accounts, and player-owned items (Stage C). `LocationComponent.RoomEntityId` is `[JsonIgnore]`; only `RoomBlueprintId` is stored. Room entity IDs are always resolved at startup from blueprints.
 

--- a/docs/architecture/flows/flow-16-heartbeat-tick.md
+++ b/docs/architecture/flows/flow-16-heartbeat-tick.md
@@ -2,7 +2,7 @@
 
 > [Back to flows index](README.md)
 
-**Summary.** `HeartbeatBackgroundService` fires a `PeriodicTimer` at `Heartbeat:IntervalMs` (default 2000 ms), increments a monotonic counter, and publishes `HeartbeatTickEvent` to `IEventBus`. No game logic lives here; handlers subscribe independently. `CombatTickHandler` (slice 9) is the first registered subscriber; future handlers (mob AI, effect expiry, etc.) slot in at their own priorities.
+**Summary.** `HeartbeatBackgroundService` fires a `PeriodicTimer` at `Heartbeat:IntervalMs` (default 2000 ms), increments a monotonic counter, and publishes `HeartbeatTickEvent` to `IEventBus`. No game logic lives here; handlers subscribe independently. `EffectTickHandler` (slice 9-e, p=20) and `CombatTickHandler` (slice 9, p=20) are the first registered subscribers; future handlers (mob AI, etc.) slot in at their own priorities.
 
 **Trigger.** `PeriodicTimer.WaitForNextTickAsync` returns in `HeartbeatBackgroundService.ExecuteAsync`.
 
@@ -11,11 +11,13 @@ sequenceDiagram
     participant Timer as PeriodicTimer
     participant HBS as HeartbeatBackgroundService
     participant Bus as IEventBus
+    participant ETH as EffectTickHandler (p=20)
     participant CTH as CombatTickHandler (p=20)
 
     Timer->>HBS: WaitForNextTickAsync → true
     HBS->>HBS: increment _tickId, capture Timestamp, compute Elapsed
     HBS->>Bus: PublishAsync(HeartbeatTickEvent{TickId, Timestamp, Elapsed})
+    Bus->>ETH: HandleAsync → effect tick (see Flow 21)
     Bus->>CTH: HandleAsync → combat round processing (see Flow 18)
     HBS->>HBS: WaitForNextTickAsync (next tick)
 ```
@@ -25,7 +27,7 @@ sequenceDiagram
 1. `PeriodicTimer.WaitForNextTickAsync(stoppingToken)` returns `true` (or throws `OperationCanceledException` on host shutdown → service exits).
 2. `HeartbeatBackgroundService` increments `_tickId` (starts at 1 on first tick), captures `DateTimeOffset.UtcNow` as `now`, computes `Elapsed = now - _lastTimestamp`, and updates `_lastTimestamp = now`. `_lastTimestamp` is initialized to `DateTimeOffset.UtcNow` before the loop so the first tick's `Elapsed` reflects the actual interval.
 3. Publishes `HeartbeatTickEvent { TickId, Timestamp, Elapsed }` via `IEventBus.PublishAsync`. Any uncaught exception from handlers is caught and logged at `Error`; the loop continues.
-4. Event bus dispatches to all subscribed handlers in priority order. `CombatTickHandler` (priority 20) runs combat round processing (see [Flow 18](flow-18-combat-round-pulse.md)). Future subscribers (mob AI, effect expiry) slot in at their own priorities.
+4. Event bus dispatches to all subscribed handlers in priority order. `EffectTickHandler` (priority 20) runs effect periodic application and expiry (see [Flow 21](flow-21-effect-tick.md)). `CombatTickHandler` (priority 20) runs combat round processing (see [Flow 18](flow-18-combat-round-pulse.md)). Future subscribers (mob AI, etc.) slot in at their own priorities.
 5. Control returns to `WaitForNextTickAsync`. `PeriodicTimer` schedules the next tick relative to its period, not relative to when handler execution completed — overruns cause the next tick to fire immediately after the current one completes.
 
 **Overrun.** If handler execution takes longer than `IntervalMs`, `PeriodicTimer` fires the next tick immediately after the current completes (no drift accumulation, but no backpressure either). Acknowledged for Phase 4 hardening.

--- a/docs/architecture/flows/flow-21-effect-tick.md
+++ b/docs/architecture/flows/flow-21-effect-tick.md
@@ -1,0 +1,50 @@
+# Flow 21 — Effect tick (periodic application + expiry)
+
+> [Back to flows index](README.md)
+
+**Summary.** `EffectTickHandler` subscribes to `HeartbeatTickEvent` at priority 20. On each tick it calls `IEffectSystem.AdvanceTick`, which advances elapsed time on all `Timed` effects, collects `Periodic` applications due this tick, and removes just-expired effects. The handler then applies each periodic magnitude to the relevant pool via `IAttributeSystem` (in `Phase` order — HoT before DoT) and publishes `EffectExpiredEvent` for every effect that expired.
+
+**Trigger.** `HeartbeatTickEvent` dispatched by `HeartbeatBackgroundService` (see [Flow 16](flow-16-heartbeat-tick.md)). `EffectTickHandler` fires before `CombatTickHandler` (both priority 20; effects are processed before the combat round so updated pool values are available immediately).
+
+```mermaid
+sequenceDiagram
+    participant ETH as EffectTickHandler (p=20)
+    participant ES as IEffectSystem
+    participant AS as IAttributeSystem
+    participant Bus as IEventBus
+
+    ETH->>ES: AdvanceTick(elapsed) → EffectTickResult
+    note over ES: advance Elapsed on Timed effects;<br/>collect Periodic apps + expired;<br/>remove expired from EffectsComponent
+    loop per PeriodicApplication (Phase order)
+        ETH->>AS: SetCurrentX(entityId, current + magnitude)
+    end
+    loop per expired effect
+        ETH->>Bus: PublishAsync(EffectExpiredEvent{TargetId, EffectId})
+    end
+```
+
+**Steps.**
+
+1. `HeartbeatBackgroundService` publishes `HeartbeatTickEvent`; `EffectTickHandler` (priority 20) handles it before `CombatTickHandler`.
+2. Calls `IEffectSystem.AdvanceTick(@event.Elapsed)`. Inside the core system:
+   - Iterates all entities with `EffectsComponent` (back-to-front to allow safe `RemoveAt`).
+   - For each `Timed` effect: increments `Elapsed` by the tick's elapsed seconds using `with { Elapsed = newElapsed }` (record mutation).
+   - Collects any `Timed` effects where `Elapsed >= Duration` as expired; removes them from the component list.
+   - Collects any `Periodic` effects as due applications (fire once per tick).
+   - Sorts both lists by `Phase` (ascending: `Early` < `Normal` < `Late`).
+   - Returns `EffectTickResult { DueApplications, Expired }`.
+3. **Periodic application.** For each `PeriodicApplication` in `DueApplications` (Phase order), calls `IAttributeSystem.SetCurrentX(entityId, current + magnitude)` where X is the pool matching `effect.Params.TargetScore` (e.g. `HpCurrent` → `SetCurrentHp`). `IAttributeSystem` clamps to `[0, MaxX]` automatically. `StatModifier` periodic effects targeting non-pool scores are a no-op here — their contribution is read via `IEffectSystem.GetModifiers` at query time.
+4. **Expiry notification.** For each `(entityId, effect)` in `Expired`, publishes `EffectExpiredEvent { TargetId = entityId, EffectId = effect.EffectId }`. A player-facing "effect fades" broadcast is deferred to a future notification slice.
+
+**Phase ordering.** `EffectPhase.Early` (e.g. `regen` HoT) fires before `EffectPhase.Late` (e.g. `poison` DoT) within a single tick. This ensures a heal-before-damage ordering when both apply on the same tick, preventing an entity from dying to DoT before a HoT that could save it.
+
+**Persistence.** `EffectsComponent` is `[Persistent]`; `EffectsComponentJsonConverter` writes only `UntilRemoved` entries. `Timed` effects that expire mid-session were never written; `UntilRemoved` effects persist across restarts and resume ticking (they have no expiry timer — they are removed only by explicit `RemoveByCategory` or `Remove` calls).
+
+**Cross-references.**
+- [`Core/Modules/Effects/Handlers/EffectTickHandler.cs`](../../../Core/Modules/Effects/Handlers/EffectTickHandler.cs)
+- [`Core/Modules/Effects/Systems/EffectSystem.cs`](../../../Core/Modules/Effects/Systems/EffectSystem.cs)
+- [`Core/Modules/Effects/Events/EffectExpiredEvent.cs`](../../../Core/Modules/Effects/Events/EffectExpiredEvent.cs)
+- [`Core/ECS/Components/EffectsComponent.cs`](../../../Core/ECS/Components/EffectsComponent.cs)
+- [`docs/architecture/effects.md`](../effects.md) — effect model design (kinds, lifetimes, stacking, phases)
+- [`docs/use-cases/effect-substrate.md`](../../use-cases/effect-substrate.md) — slice 9-e spec
+- [Flow 16](flow-16-heartbeat-tick.md) — heartbeat trigger

--- a/docs/reference/archetypes.md
+++ b/docs/reference/archetypes.md
@@ -16,8 +16,8 @@ Source of truth (target): `Core/ECS/EntityArchetype.cs` (enum), `Core/ECS/Archet
 |---|---|---|---|
 | `Player` ✓ | PC-controlled living entity | `CharacterComponent`, `AttributesComponent`, `PoolsComponent`, `InventoryComponent`, `EquipmentComponent` | — |
 | `Mob` ✓ | NPC living entity | `MobDataComponent`, `AttributesComponent`, `PoolsComponent` | `InventoryComponent`*, `EquipmentComponent`* |
-| `Weapon` | Equippable damage-dealing item | `ItemDataComponent`, `WeaponDataComponent`† | `PersistentEffectsComponent`†* |
-| `Armor` | Equippable defensive item | `ItemDataComponent`, `ArmorDataComponent`† | `PersistentEffectsComponent`†* |
+| `Weapon` | Equippable damage-dealing item | `ItemDataComponent`, `WeaponDataComponent`† | `EffectsComponent`†* |
+| `Armor` | Equippable defensive item | `ItemDataComponent`, `ArmorDataComponent`† | `EffectsComponent`†* |
 | `Potion` | Consumable with pool restoration / effects | `ItemDataComponent`, `PotionDataComponent`† | — |
 | `StaticItem` ✓ | Furniture, decoration, non-interactable | `ItemDataComponent` | — |
 | `Consumable` | Generic consumable (non-potion) | `ItemDataComponent` | — |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -10,6 +10,19 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 
 ## Player commands
 
+### `affects`
+
+**Aliases:** none  
+**MatchingMode:** `Partial`  
+**Location:** `Core/Modules/Effects/Commands/AffectsCommand.cs`  
+**Description:** Lists all effects currently active on the invoking player, including effect id, category, power (signed), and remaining duration (or `permanent` for `UntilRemoved` effects). Writes "You have no active effects." when the effects list is empty. No events fired.  
+**Usage:** `affects`  
+**Schema:** no arguments  
+**Dependencies:** `IEffectSystem`  
+**Events:** none
+
+---
+
 ### `commands`
 
 **Aliases:** none  
@@ -251,6 +264,20 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 ## Admin commands
 
 All admin commands require `AdminRequirement`. The dispatcher enforces this via `IAuthorizationChecker`; no per-command `IsPrivileged` call is needed or permitted.
+
+---
+
+### `affect`
+
+**Aliases:** none  
+**MatchingMode:** `Full`  
+**Location:** `Core/Modules/Effects/Commands/AffectCommand.cs`  
+**Description:** Applies a named effect from the `IEffectRegistry` to the specified target. Target is resolved by character name (connected players only) or by raw `uint` entity id. If an optional `power` integer is provided, the definition's `BaseMagnitude` and `PowerScalingFormula` are overridden — useful for testing effect boundaries. Returns an error if the effect id is not in the registry, the target cannot be resolved, or `HighestWins` blocks application (existing effect has equal or greater power).  
+**Usage:** `affect <target> <effectId> [power]`  
+**Schema:** `Token string "target"` (required), `Token string "effectId"` (required), `Token string "power"` (optional)  
+**Dependencies:** `IEffectSystem`, `IEffectRegistry`, `EntityService`, `IEventBus`, `ISessionManager`  
+**Events:** `EffectAppliedEvent`, `EffectAppliedByAdminEvent`  
+**RequiredPrivileges:** `AdminRequirement`
 
 ---
 

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -54,6 +54,7 @@ Persistence uses two independent opt-ins. See [../architecture/06-persistence.md
 |---|---|---|---|
 | Account | `AccountComponent` | `Username` (lowercase-normalized), `PasswordHash` (PBKDF2-SHA256), `CharacterEntityIds`, `CreatedAtUtc` | yes |
 | Account | `CharacterComponent` | `AccountEntityId`, `CharacterName`, `CreatedAtUtc`, `LastLoginUtc` | yes |
+| Effects | `EffectsComponent` | `List<Effect> Effects` — active timed/permanent effects on an entity. `[Persistent]`, lifetime-filtered `JsonConverter` (`EffectsComponentJsonConverter`) serializes only `UntilRemoved` effects — timed effects are transient by design. Located in `Core/ECS/Components/` (cross-cutting). | yes |
 
 ---
 

--- a/docs/reference/handlers.md
+++ b/docs/reference/handlers.md
@@ -79,8 +79,15 @@ Ask:
 **Location:** `Core/Modules/Spawn/Handlers/ItemContextHandler.cs`
 **Uses:** `EntityService`
 
+### EffectTickHandler
+**Events:** `HeartbeatTickEvent`
+**Priority:** 20 (`HandlerPriority.Domain`)
+**Responsibilities:** Bridge between the time system and the effects domain. On each tick: calls `IEffectSystem.AdvanceTick(elapsed)` to advance all timed effects. For each `PeriodicApplication` in `DueApplications` (sorted Early → Normal → Late by the system), applies the magnitude via `IAttributeSystem.SetCurrentHp` (for `HpCurrent` target) or the appropriate `IAttributeSystem` setter. For each expired effect in `Expired`, publishes `EffectExpiredEvent(targetId, effectId)`.
+**Location:** `Core/Modules/Effects/Handlers/EffectTickHandler.cs`
+**Uses:** `IEffectSystem`, `IAttributeSystem`, `IEventBus`
+
 ### AdminAuditHandler
-**Events:** `EntitySpawnedByAdminEvent`, `PlayerTeleportedByAdminEvent`, `RoomExitAuthoredByAdminEvent`, `ContentReloadedEvent` (Phase 3 slice 2); `RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent` (Phase 3 slice 5a); `ItemCreatedByAdminEvent`, `ItemPropertySetByAdminEvent` (Phase 3 slice 6); `MobCreatedByAdminEvent`, `MobPropertySetByAdminEvent` (Phase 3 slice 8); `PlayerAttributeSetByAdminEvent` (Phase 3 slice 8a); `CombatEndedEvent` (Phase 3 slice 9).
+**Events:** `EntitySpawnedByAdminEvent`, `PlayerTeleportedByAdminEvent`, `RoomExitAuthoredByAdminEvent`, `ContentReloadedEvent` (Phase 3 slice 2); `RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent` (Phase 3 slice 5a); `ItemCreatedByAdminEvent`, `ItemPropertySetByAdminEvent` (Phase 3 slice 6); `MobCreatedByAdminEvent`, `MobPropertySetByAdminEvent` (Phase 3 slice 8); `PlayerAttributeSetByAdminEvent` (Phase 3 slice 8a); `CombatEndedEvent` (Phase 3 slice 9); `EffectAppliedByAdminEvent` (Phase 3 slice 9-e).
 **Priority:** 80 (`HandlerPriority.Notification`)
 **Responsibilities:** writes one structured-log entry per admin action via `ILogger<AdminAuditHandler>`. Uses a stable structured event name (`AdminCommandExecuted`) so log scrapers can filter without parsing free text. No dedicated audit-file sink in this slice.
 **Location:** `Core/Modules/Admin/Handlers/AdminAuditHandler.cs`

--- a/docs/reference/systems.md
+++ b/docs/reference/systems.md
@@ -379,7 +379,7 @@ public interface IEntityStateService
 `TryEnterState` reads current `ActiveStates` (or `None` if the component is absent), evaluates the static transition-rule table, on success attaches or OR-assigns the flag, and returns `true`. On a blocked transition it returns `false` with a caller-displayable `failReason`. `ExitState` AND-NOT clears the flag and removes the component when `ActiveStates == None` — always a no-op when the entity has no component. `IsInState` delegates to `GetStates`. Callers (commands, handlers) publish `EntityStateChangedEvent` after mutating state; the service never calls `IEventBus` (INV-5). Implemented (Phase 3 slice 9-a).
 
 ### StatSystem
-**Purpose:** Aggregation seam for effective entity stats. Reads base attributes and equipment bonuses to produce ready-to-use values for the combat slice and future consumers. Never publishes events or calls persistence (INV-5). Adding a new modifier source (buffs, auras) means extending `StatSystem` methods, not changing the interface.
+**Purpose:** Aggregation seam for effective entity stats. Reads base attributes, equipment bonuses, and active effect modifiers to produce ready-to-use values for the combat slice and future consumers. Never publishes events or calls persistence (INV-5). Adding a new modifier source means extending `StatSystem` methods, not changing the interface.
 **Location:** `Core/Modules/Stats/Systems/StatSystem.cs`
 **Dependencies:** `IAttributeSystem`, `EntityService`.
 ```csharp
@@ -399,7 +399,37 @@ public interface IStatSystem
     int Get(uint entityId, ScoreId scoreId);
 }
 ```
-`GetEffectiveAttackPower` reads `EquipmentComponent.Slots[WornSlot.MainHand]` via `EntityService.TryGet<EquipmentComponent>` (direct dictionary lookup, not a list scan) then reads `ItemDataComponent.DamageBonus` on the equipped item — no `is`/`as` casts (INV-4). `GetEffectiveDefense` returns `Body / 4`; armor-slot contribution is acknowledged future debt. `Get(uint, ScoreId)` is the expandable enum-keyed seam for future effect and ability consumers. Registered in `StatsModule` (`Core/Modules/Stats/StatsModule.cs`) as a singleton. `IStatRegistry` (singleton, `Core/Modules/Stats/StatRegistry.cs`) records pool governance metadata (Mana↔Mind, Stamina↔Body, Astra↔Attunement). Updated `Strength`/`Dexterity`/`Constitution` references to `Mind`/`Body`/`Spirit`/`Attunement` in slice 9-d. Implemented (Phase 3 slices 9-c, 9-d).
+`GetEffectiveAttackPower` reads `EquipmentComponent.Slots[WornSlot.MainHand]` via `EntityService.TryGet<EquipmentComponent>` (direct dictionary lookup, not a list scan) then reads `ItemDataComponent.DamageBonus` on the equipped item — no `is`/`as` casts (INV-4). `GetEffectiveDefense` returns `Body / 4`; armor-slot contribution is acknowledged future debt. `Get(uint, ScoreId)` is the expandable enum-keyed seam used by effect/ability consumers; it folds `IEffectSystem.GetModifiers(entityId, scoreId)` into the returned value for `StatModifier`-kind effects. Registered in `StatsModule` (`Core/Modules/Stats/StatsModule.cs`) as a singleton. `IStatRegistry` (singleton, `Core/Modules/Stats/StatRegistry.cs`) records pool governance metadata (Mana↔Mind, Stamina↔Body, Astra↔Attunement). Updated `Strength`/`Dexterity`/`Constitution` references to `Mind`/`Body`/`Spirit`/`Attunement` in slice 9-d. Extended in slice 9-e: `Get` folds `IEffectSystem.GetModifiers`. Implemented (Phase 3 slices 9-c, 9-d, 9-e).
+
+### EffectSystem
+**Purpose:** Core system that manages active effects on entities. Applies/removes individual effects or entire categories; returns active effect lists and per-`ScoreId` stat modifier sums; advances time on each tick, collecting expired and periodic-due effects. Never touches the event bus (INV-5).
+**Location:** `Core/Modules/Effects/Systems/EffectSystem.cs` (implementation) · `Core/Modules/Effects/Systems/IEffectSystem.cs` (interface)
+**Dependencies:** `EntityService`.
+```csharp
+public interface IEffectSystem
+{
+    Effect? Apply(uint targetEntityId, EffectDefinition definition, uint sourceEntityId);
+    void Remove(uint entityId, string effectId);
+    void RemoveByCategory(uint entityId, EffectCategory category);
+    IReadOnlyList<Effect> GetActive(uint entityId);
+    int GetModifiers(uint entityId, ScoreId scoreId);
+    EffectTickResult AdvanceTick(TimeSpan elapsed);
+}
+```
+`Apply` returns `null` when `StackPolicy.HighestWins` blocks application (existing effect has equal or greater power). `AdvanceTick` advances elapsed time on timed effects, removes expired ones, and returns `EffectTickResult { DueApplications, Expired }` sorted by `EffectPhase` (Early → Normal → Late). Registered via `AddEffectsModule()`. Implemented (Phase 3 slice 9-e).
+
+### EffectRegistry
+**Purpose:** Hardcoded read-only catalog of starter `EffectDefinition` records. Pure data — no event bus, no persistence. Promotion to a data file is deferred per the use-case spec (Category-3 balance data).
+**Location:** `Core/Modules/Effects/EffectRegistry.cs` (implementation) · interface `IEffectRegistry` in the same file.
+**Dependencies:** none.
+```csharp
+public interface IEffectRegistry
+{
+    bool TryGet(string effectId, out EffectDefinition definition);
+    IReadOnlyCollection<string> AllIds { get; }
+}
+```
+Registered entries: `empower` (Body +5, Buff, 30s, HighestWins), `weaken` (Body -5, Debuff, 30s, HighestWins), `regen` (HpCurrent +10/tick, Blessing, 60s, Stack, Early), `poison` (HpCurrent -8/tick, Poison, 30s, Stack, Late), `minor_curse` (Mind -3, Curse, permanent, Stack). Registered via `AddEffectsModule()`. Implemented (Phase 3 slice 9-e).
 
 ### CombatSystem
 **Purpose:** Domain system for combat resolution. Handles target lookup, combat state attachment/removal, and round resolution. Pure: no events, no persistence (INV-5, INV-8). Computes attack resolution via `IStatSystem`; mutates HP via `IAttributeSystem.SetCurrentHp`; returns structured `CombatRoundResult` to callers.

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -54,7 +54,7 @@ At slice close-out, `sync-roadmap` **trims** it to its durable behavior spec —
 | `implemented` | [`stat-system.md`](stat-system.md) | Phase 3 slice 9-c |
 | `implemented` | [`combat.md`](combat.md) | Phase 3 slice 9 |
 | `planned` | [`stat-resource-substrate.md`](stat-resource-substrate.md) | Phase 3 slice 9-d (gameplay-model S1) |
-| `planned` | [`effect-substrate.md`](effect-substrate.md) | Phase 3 slice 9-e (gameplay-model S2) |
+| `implemented` | [`effect-substrate.md`](effect-substrate.md) | Phase 3 slice 9-e (gameplay-model S2) |
 | `deferred` | [`admin-privilege-elevation.md`](admin-privilege-elevation.md) | Future (TBD) — placeholder |
 | `planned` | [`persistence-reform.md`](persistence-reform.md) | Persistence reform (Stages A–C): SQLite backend, EntityService lifecycle, world content de-persistence, context-driven item persistence, spawn slot foundation |
 

--- a/docs/use-cases/effect-substrate.md
+++ b/docs/use-cases/effect-substrate.md
@@ -1,10 +1,10 @@
 # Use Case: Effect Substrate
 
-**Status:** planned
+**Status:** implemented
 **Actors:** Player, Mob, System, Administrator
 **Module:** `Core/Modules/Effects/` (new — `IEffectSystem`, `EffectsComponent`, registry, tick handler, commands), `Core/Modules/Stats/` (`IStatSystem` folds effect modifiers), `Core/Modules/Time/` (heartbeat consumer)
 
-**Spine:** gameplay-model **S2** — the bedrock most later spines depend on (skills/spells produce effects, potions apply them, curses/auras are effects, rarity treatments grant them). See [`../design/gameplay-model.md`](../design/gameplay-model.md) Spine C and decisions R5 (stacking + Power) / R6 (lifetimes). **Design lives in the model; this doc is requirements + implementation plan.** On ship, the effect design graduates to a higher-level `architecture/` design doc (R7 — effects warrant one due to complexity).
+**Spine:** gameplay-model **S2** — the bedrock most later spines depend on (skills/spells produce effects, potions apply them, curses/auras are effects, rarity treatments grant them). See [`../design/gameplay-model.md`](../design/gameplay-model.md) Spine C and decisions R5 (stacking + Power) / R6 (lifetimes). **Design lives in the model; this doc is requirements + durable spec.** See [`../architecture/effects.md`](../architecture/effects.md) for the higher-level effects design doc (R7).
 
 ---
 
@@ -88,51 +88,6 @@ This slice wires the **load-bearing kinds end-to-end** — `StatModifier` (feeds
 
 ---
 
-## Implementation plan — work packages
-
-> **WP-1 lands first** (model + system). **WP-2 and WP-3 depend on WP-1**; WP-3's "remaining/ticking" display reads state WP-2 advances, so prefer WP-2 before WP-3 (or run WP-3 against stored state and accept that durations show only after WP-2). Primary agent runs `architecture-reviewer` (code mode) across the combined diff.
-
-### WP-1 — Effect model + `EffectSystem` core *(depends on S1)*
-- **Scope:** the record, enums, component (+ converter), and the core system — no consumers.
-- **Files:** `Effect.cs` (record + `EffectKind`/`EffectCategory`/`EffectLifetime`/`StackPolicy`/`EffectSource`/`EffectGroup`), `EffectsComponent.cs` + `EffectsComponentJsonConverter.cs` (`[Persistent]`, lifetime filter), `IEffectSystem.cs`/`EffectSystem.cs` (Apply + Power + stacking + phase + Remove/RemoveByCategory/GetActive/GetModifiers/AdvanceTick), `PowerScaling.cs` + a named-formula registry, `EffectsModule.cs`.
-- **Reference & tooling sweep (WP-1 owns the rename):** reconcile the superseded two-component effect names to the single `EffectsComponent` in the doc examples that still reference them — `architecture/06-persistence.md`, `architecture/flows/flow-04-persistence-flush-cycle.md`, `reference/archetypes.md` (Weapon/Armor optional-component row), `use-cases/persistence-substrate.md` (example). (`.claude/skills/add-archetype/SKILL.md` was already reconciled with the design decision per INV-20.) Full list tracked in [`../roadmap/backlog.md`](../roadmap/backlog.md).
-- **Out of scope:** stat integration, heartbeat, commands. `GrantAbility`/`Trigger`/`TransformModifier` are enum values with **no handler** here.
-- **Exit (testable):** two `StatModifier(Body)` effects of differing `Power` → `HighestWins` keeps the stronger; a `Timed` effect is stored, an `UntilRemoved` effect is stored; serializing `EffectsComponent` writes only the `UntilRemoved` entry; `RemoveByCategory(Curse)` strips curses; `AdvanceTick` returns due/expired sets in `Phase` order.
-
-### WP-2 — Stat summation + heartbeat tick *(depends on WP-1)*
-- **Scope:** fold effect modifiers into the read seam; drive periodic/expiry from the heartbeat.
-- **Files:** `StatSystem.cs` (`Get` sums `IEffectSystem.GetModifiers`), `EffectTickHandler.cs` (subscribes `HeartbeatTickEvent`; applies periodic magnitudes via `IAttributeSystem`; publishes `EffectExpiredEvent`), `EffectAppliedEvent.cs`/`EffectExpiredEvent.cs`.
-- **Out of scope:** commands; source-bound (equipment/ability/area) derivation — wired by the slices that give sources effect data.
-- **Exit (testable):** a `+10 Body StatModifier` raises `Get(Body)` by 10 with no consumer change; a `regen` HoT heals each heartbeat then expires on schedule; a HoT + DoT on one entity resolve heal-before-damage.
-
-### WP-3 — Effect registry + admin apply/inspect tooling *(depends on WP-1, +WP-2 for live display)*
-- **Scope:** authorable/inspectable surface for the new state (INV-18).
-- **Files:** `EffectRegistry.cs` + starter definitions, `AffectCommand.cs` (admin, `Full` match), `AffectsCommand.cs` (player/admin, `Partial`), `EffectDisplayMessage`. **WP-3 owns the consolidated reference-catalog sweep:** `components.md` (`EffectsComponent`, from WP-1), `systems.md` (`EffectSystem` + the `StatSystem` extension, WP-1/WP-2), `handlers.md` (`EffectTickHandler`, WP-2), `commands.md` (`affect`/`affects`).
-- **Out of scope:** data-file effect authoring; composites; aspect.
-- **Exit (testable):** `affect <player> empower 5` applies and `affects` shows it (category, Power, remaining); `affect <player> empower 8` replaces it (`HighestWins`); `affect <player> poison` ticks damage on the heartbeat; `affect`-ing a `minor_curse` then dispelling by category removes it.
-
----
-
-## Content tooling impact
-
-- `EffectRegistry` (hardcoded) + `affect`/`affects` are the author + inspect path shipped in-slice (INV-18). Effect **definitions** are Category-3 balance data, hardcoded now; the documented promotion is to a data-file effect catalog when content authoring matures (see the balance-surface + content-editor backlog items). **Editor-forward:** application logic lives in `IEffectSystem` and the registry, never in the command — the future editor and future ability/potion systems are all thin callers.
-
-## Cross-cutting surfaces stressed
-
-- **Persistence — Adequate (resolved).** Field-selective serialization via an attribute `[JsonConverter]` on `EffectsComponent`; `System.Text.Json` honors it natively, so **no `ComponentSerializer` change**. Resolves the EffectsComponent backlog item.
-- **Time / heartbeat — Adequate.** `EffectTickHandler` is a standard `HeartbeatTickEvent` subscriber; no heartbeat change.
-- **Stat pipeline — Modified (in-slice).** `StatSystem.Get` folds `IEffectSystem.GetModifiers`; the interface is unchanged, so combat/`score` are untouched.
-- **Commands / output — Adequate.** Two new commands + one `IOutputMessage`; existing framework.
-- **Configuration — Acknowledged debt.** Effect definitions are Category-3 constants (hardcoded registry); promotion to a tunable data file is tracked (balance backlog). Justified: no designer-iteration-without-recompile need yet.
-- **Event bus / ECS — Adequate.**
-
-## Flows introduced or modified
-
-- **New flow — effect tick** (periodic application + expiry on the heartbeat): recurs, so promote to `flows/README.md` when implemented; extends **Flow 16 — heartbeat tick**.
-- **Modified — effective stat read**: `IStatSystem.Get` now folds effect modifiers (transparent to consumers); a one-line note on the stat-read path.
-
----
-
 ## Design notes
 
 - **Single list, lifetime-filtered (the resolved decision).** One `EffectsComponent` with a single `List<Effect>`; `Lifetime` is the sole determinant of persistence; the `[JsonConverter]` writes only `UntilRemoved`. No `Persistent`/`Transient` component split and no two-list split — `Lifetime` is not duplicated into a bucket choice. See [`../roadmap/backlog.md`](../roadmap/backlog.md) (resolved item) and [02-ecs.md](../architecture/02-ecs.md).
@@ -144,16 +99,6 @@ This slice wires the **load-bearing kinds end-to-end** — `StatModifier` (feeds
 - **Kinds wired vs deferred.** `StatModifier`/`Instant`/`Periodic`/`GrantFlag` are fully handled. `GrantAbility` (needs S4), `Trigger` (needs world-event hooks), `TransformModifier` (needs S5 generation) are enum values with deferred handlers — adding a handler later is additive, no model change.
 - **Composites deferred.** The `Category` tag and `RemoveByCategory` ship (dispel substrate); the `CompositeEffectDefinition` bundle (one named curse → several effects sharing a `GroupId`) lands with the content slice that needs authored curses/blessings.
 - **Source-bound derivation deferred.** `GetModifiers` sums standalone `StatModifier`s only; equipment/ability/area-derived effects fold in when those sources carry effect data (items later, abilities S4, areas S3) — the seam is the same `GetActive`/`GetModifiers` call.
-- **On ship:** author `architecture/<effects>.md` (the higher-level effects design doc, R7) and trim this use-case to requirements + durable spec.
-
----
-
-## Resolved planning inputs
-
-- **Persistence** — single `EffectsComponent`, lifetime-filtered via `[JsonConverter]` (owner-confirmed 2026-05-30).
-- **Power** — one number (stack key + magnitude scalar), named-formula `PowerScaling` registry; provisional per model §6, carried into the build.
-- **Scope** — load-bearing kinds (`StatModifier`/`Instant`/`Periodic`/`GrantFlag`) wired; others enum-defined, handlers deferred to their spines.
-
 ---
 
 ## Related

--- a/docs/use-cases/persistence-substrate.md
+++ b/docs/use-cases/persistence-substrate.md
@@ -26,7 +26,7 @@ Infrastructure slice that gives every future feature a working save/load substra
 - Every entity that has at least one `[Persistent]` component can be saved to disk and reloaded into a fresh `EntityService` without triggering any event-bus events during component attachment.
 - Only `[Persistent]`-tagged components are written to disk; transient components are omitted.
 - On load, hydrated entities match their pre-save component data exactly.
-- `TransientEffectsComponent` is never written to disk; `PersistentEffectsComponent` always is.
+- `EffectsComponent` is tagged `[Persistent]`; its `[JsonConverter]` writes only `UntilRemoved` effects — timed and other transient-lifetime effects are dropped at serialization time.
 - No gameplay behaviour changes; no player-visible output is added.
 
 ---


### PR DESCRIPTION
## Summary

Implements gameplay-model **S2 — effect substrate** (slice 9-e). Introduces the effect model, `IEffectSystem`, stat modifier integration, heartbeat-driven periodic tick/expiry, and admin `affect`/`affects` commands. This is the bedrock slice every later spine (abilities, potions, curses, auras) writes to.

- **`Core/Modules/Effects/`** (new module): `Effect` record + all enums (`EffectKind`, `EffectCategory`, `EffectLifetime`, `StackPolicy`, `EffectPhase`), `EffectsComponent` (`[Persistent]`, lifetime-filtered `JsonConverter`), `IEffectSystem`/`EffectSystem` (core; only `EntityService` dep — no event bus, no domain calls), `PowerScaling` formula registry, `EffectRegistry` (5 starter definitions: `empower`, `weaken`, `regen`, `poison`, `minor_curse`), `EffectTickHandler`, events (`EffectAppliedEvent`, `EffectExpiredEvent`, `EffectAppliedByAdminEvent`), commands (`affect`, `affects`).
- **`StatSystem.Get`** now folds `IEffectSystem.GetModifiers` for attribute and derived scores — transparent to all existing consumers (combat, `score` command).
- **`EffectTickHandler`** subscribes to `HeartbeatTickEvent` (priority 20, before `CombatTickHandler`): advances elapsed time, fires periodic magnitudes via `IAttributeSystem` in `Phase` order (HoT before DoT), publishes `EffectExpiredEvent` per expiry.
- **Persistence**: `EffectsComponentJsonConverter` writes only `UntilRemoved` entries; `Timed` effects are not persisted.
- **Architecture review (code mode)** passed after three blocking fixes: flow-16/flow-21 docs added, use-case status trimmed to `implemented`, skill front-matter description corrected.

## What a reviewer should know

- `StatSystem → IEffectSystem` is a legal domain→core downward call (not a layer violation). The skill description for `add-domain-system` was updated to reflect this explicitly.
- `GrantAbility`, `Trigger`, `TransformModifier` are enum values only — their handlers are deferred to the spines that consume them (S4/S5); adding handlers later is purely additive.
- The `[power]` arg on `affect` is a testing-only override; the normal apply path (future abilities, potions) never passes Power directly — `IEffectSystem.Apply` computes it from `PowerScaling`.
- `docs/architecture/effects.md` is the new R7 effects design doc; `docs/architecture/flows/flow-21-effect-tick.md` is the new canonical flow.

## Test plan

- [x] `dotnet build Hedron.sln` — zero errors
- [x] Connect as admin; `affect <player> empower` → `affects` shows buff with Power and remaining time
- [x] `affect <player> empower 8` after `empower 5` → `HighestWins` replaces, `affects` shows Power 8
- [x] `affect <player> poison` → HP ticks down each heartbeat; expires after 30s
- [x] `affect <player> regen` + `affect <player> poison` → each heartbeat heals before it damages (phase ordering)
- [x] `affect <player> minor_curse` → `affects` shows `permanent`; curse survives server restart (persistence)
- [x] `score` command reflects `+Body` from `empower` buff (stat modifier integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)