### PR TITLE
slice 10: death and respawn

### DIFF
--- a/Core/Commands/CommandDispatcher.cs
+++ b/Core/Commands/CommandDispatcher.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Hedron.Core.Commands.Authorization;
 using Hedron.Core.Commands.Events;
+using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
+using Hedron.Core.Modules.EntityState.Systems;
 using Hedron.Core.Output;
 using Hedron.Core.Sessions;
 using Microsoft.Extensions.Logging;
@@ -32,6 +34,7 @@ namespace Hedron.Core.Commands
         private readonly ICommandArgumentParser _argumentParser;
         private readonly IOutputWriterFactory _outputWriterFactory;
         private readonly IEventBus _eventBus;
+        private readonly IEntityStateService _entityStateService;
         private readonly ILogger<CommandDispatcher> _logger;
         private readonly IServiceProvider _services;
 
@@ -41,6 +44,7 @@ namespace Hedron.Core.Commands
             ICommandArgumentParser argumentParser,
             IOutputWriterFactory outputWriterFactory,
             IEventBus eventBus,
+            IEntityStateService entityStateService,
             ILogger<CommandDispatcher> logger,
             IServiceProvider services)
         {
@@ -49,6 +53,7 @@ namespace Hedron.Core.Commands
             _argumentParser = argumentParser ?? throw new ArgumentNullException(nameof(argumentParser));
             _outputWriterFactory = outputWriterFactory ?? throw new ArgumentNullException(nameof(outputWriterFactory));
             _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            _entityStateService = entityStateService ?? throw new ArgumentNullException(nameof(entityStateService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _services = services ?? throw new ArgumentNullException(nameof(services));
 
@@ -123,6 +128,20 @@ namespace Hedron.Core.Commands
 
             // Use the canonical name for all downstream operations so log lines are stable.
             var canonicalVerb = command.Name;
+
+            // Incapacitation gate — checked before privilege so a blocked-incapacitated player
+            // does not receive a misleading "not authorized" message for commands they would
+            // normally be allowed to use.
+            if (!command.UsableWhileIncapacitated
+                && _entityStateService.IsInState(session.PlayerEntityId, EntityStateFlags.Incapacitated))
+            {
+                await output.WriteAsync(new PlainMessage(
+                    "You are incapacitated and cannot do that.", OutputSeverity.Error))
+                    .ConfigureAwait(false);
+                await PublishExecutedAsync(session.PlayerEntityId, canonicalVerb, string.Empty, CommandOutcome.Refused)
+                    .ConfigureAwait(false);
+                return;
+            }
 
             // Privilege gate
             foreach (var req in command.RequiredPrivileges)

--- a/Core/Commands/CommandOutcome.cs
+++ b/Core/Commands/CommandOutcome.cs
@@ -7,5 +7,10 @@ namespace Hedron.Core.Commands
         ParseFailed,
         Unauthorized,
         Threw,
+        /// <summary>
+        /// The command was refused because the invoker is currently incapacitated and
+        /// the command does not have <c>UsableWhileIncapacitated = true</c>.
+        /// </summary>
+        Refused,
     }
 }

--- a/Core/Commands/ICommand.cs
+++ b/Core/Commands/ICommand.cs
@@ -48,6 +48,13 @@ namespace Hedron.Core.Commands
         CommandMatchingMode MatchingMode { get; }
 
         /// <summary>
+        /// When <c>true</c>, the dispatcher allows this command to run even if the invoker is
+        /// currently incapacitated. Defaults to <c>false</c> (default-deny) — a new command
+        /// is blocked while incapacitated unless explicitly opted in.
+        /// </summary>
+        bool UsableWhileIncapacitated => false;
+
+        /// <summary>
         /// Runs the command. <paramref name="context"/> carries typed parsed arguments
         /// and the output writer — do not call <c>session.SendLineAsync</c> directly.
         /// </summary>

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="YamlDotNet" Version="15.1.6" />
   </ItemGroup>

--- a/Core/ECS/Components/RespawnComponent.cs
+++ b/Core/ECS/Components/RespawnComponent.cs
@@ -1,0 +1,19 @@
+namespace Hedron.Core.ECS.Components
+{
+    /// <summary>
+    /// Stores the player's respawn location as a stable blueprint id.
+    /// On death, <c>IDeathSystem.Respawn</c> resolves <see cref="RoomBlueprintId"/> to a
+    /// live room entity id (same resolution path as <c>CharacterHydrationHandler</c>).
+    /// Stores the blueprint id rather than the runtime entity id because room entity ids
+    /// are not stable across restarts (world content is fresh-spawned each boot).
+    /// </summary>
+    [Persistent]
+    public sealed class RespawnComponent : IComponent
+    {
+        /// <summary>
+        /// Stable blueprint id of the room where this entity respawns.
+        /// Null means "use the world starting room" (fallback behaviour in <c>IDeathSystem.Respawn</c>).
+        /// </summary>
+        public string? RoomBlueprintId { get; set; }
+    }
+}

--- a/Core/Modules/Account/Systems/AccountSystem.cs
+++ b/Core/Modules/Account/Systems/AccountSystem.cs
@@ -124,6 +124,10 @@ namespace Hedron.Core.Modules.Account.Systems
                 MaxAstra = _characterDefaults.MaxAstra,
                 CurrentAstra = _characterDefaults.MaxAstra,
             });
+            _entityService.AddComponent(entity.Id, new RespawnComponent
+            {
+                RoomBlueprintId = _worldConfig.StartingRoomBlueprintId,
+            });
             _entityService.AddComponent(entity.Id, new PersistentEntity());
 
             if (_entityService.TryGet<AccountComponent>(accountEntityId, out var account))

--- a/Core/Modules/Admin/Handlers/AdminAuditHandler.cs
+++ b/Core/Modules/Admin/Handlers/AdminAuditHandler.cs
@@ -5,6 +5,7 @@ using Hedron.Core.Events;
 using Hedron.Core.Modules.Admin.Events;
 using Hedron.Core.Modules.Attributes.Events;
 using Hedron.Core.Modules.Combat.Events;
+using Hedron.Core.Modules.Death.Events;
 using Hedron.Core.Modules.Effects.Events;
 using Hedron.Core.Modules.Items.Events;
 using Hedron.Core.Modules.Mobs.Events;
@@ -36,7 +37,8 @@ namespace Hedron.Core.Modules.Admin.Handlers
         IEventHandler<MobPropertySetByAdminEvent>,
         IEventHandler<PlayerAttributeSetByAdminEvent>,
         IEventHandler<CombatEndedEvent>,
-        IEventHandler<EffectAppliedByAdminEvent>
+        IEventHandler<EffectAppliedByAdminEvent>,
+        IEventHandler<PlayerRespawnSetByAdminEvent>
     {
         private readonly EntityService _entityService;
         private readonly ILogger<AdminAuditHandler> _logger;
@@ -150,6 +152,14 @@ namespace Hedron.Core.Modules.Admin.Handlers
             _logger.LogInformation(
                 "AdminCommandExecuted: admin={Admin} command=affect target={TargetId} effect={EffectId} power={Power}",
                 ResolveName(e.AdminId), e.TargetId, e.EffectId, e.Power);
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(PlayerRespawnSetByAdminEvent e)
+        {
+            _logger.LogInformation(
+                "AdminCommandExecuted: admin={Admin} command=setrespawn player={PlayerEntityId} roomBlueprintId={RoomBlueprintId}",
+                ResolveName(e.AdminEntityId), e.PlayerEntityId, e.RoomBlueprintId);
             return Task.CompletedTask;
         }
 

--- a/Core/Modules/Attributes/Commands/ScoreCommand.cs
+++ b/Core/Modules/Attributes/Commands/ScoreCommand.cs
@@ -6,6 +6,7 @@ using Hedron.Core.Commands.Authorization;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Modules.Account.Components;
+using Hedron.Core.Modules.EntityState.Systems;
 using Hedron.Core.Modules.Stats;
 using Hedron.Core.Modules.Stats.Systems;
 using Hedron.Core.Output;
@@ -16,22 +17,25 @@ namespace Hedron.Core.Modules.Attributes.Commands
     {
         private readonly EntityService _entityService;
         private readonly IStatSystem _statSystem;
+        private readonly IEntityStateService _entityStateService;
 
         public string Name => "score";
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Player;
         public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
+        public bool UsableWhileIncapacitated => true;
         public string ShortDescription => "Display your character stats.";
-        public string LongDescription => "Shows your level, hit points, mana, stamina, astra, and base attributes.";
+        public string LongDescription => "Shows your level, hit points, mana, stamina, astra, base attributes, respawn room, and current status.";
         public string Usage => "score";
         public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
             Array.Empty<IAuthorizationRequirement>();
         public CommandArgumentSchema ArgumentSchema { get; } = new(Array.Empty<CommandArgument>());
 
-        public ScoreCommand(EntityService entityService, IStatSystem statSystem)
+        public ScoreCommand(EntityService entityService, IStatSystem statSystem, IEntityStateService entityStateService)
         {
             _entityService = entityService;
             _statSystem = statSystem;
+            _entityStateService = entityStateService;
         }
 
         public async Task ExecuteAsync(CommandContext context)
@@ -45,6 +49,13 @@ namespace Hedron.Core.Modules.Attributes.Commands
             var level = _entityService.TryGet<AttributesComponent>(entityId, out var a)
                 ? a.Level
                 : 1;
+
+            // Respawn room — only shown for entities that have RespawnComponent.
+            string? respawnRoomBlueprintId = _entityService.TryGet<RespawnComponent>(entityId, out var respawn)
+                ? respawn.RoomBlueprintId
+                : null;
+
+            var isIncapacitated = _entityStateService.IsInState(entityId, EntityStateFlags.Incapacitated);
 
             await context.Output.WriteAsync(new ScoreDisplayMessage(
                 charName,
@@ -60,7 +71,9 @@ namespace Hedron.Core.Modules.Attributes.Commands
                 _statSystem.Get(entityId, ScoreId.StaminaCurrent),
                 _statSystem.Get(entityId, ScoreId.StaminaMax),
                 _statSystem.Get(entityId, ScoreId.AstraCurrent),
-                _statSystem.Get(entityId, ScoreId.AstraMax))).ConfigureAwait(false);
+                _statSystem.Get(entityId, ScoreId.AstraMax),
+                respawnRoomBlueprintId,
+                isIncapacitated)).ConfigureAwait(false);
         }
     }
 }

--- a/Core/Modules/Attributes/Systems/AttributeSystem.cs
+++ b/Core/Modules/Attributes/Systems/AttributeSystem.cs
@@ -1,15 +1,25 @@
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
+using Hedron.Core.Modules.Death;
+using Microsoft.Extensions.Options;
 
 namespace Hedron.Core.Modules.Attributes.Systems
 {
     public sealed class AttributeSystem : IAttributeSystem
     {
         private readonly EntityService _entityService;
+        private readonly int _hpFloor;
 
-        public AttributeSystem(EntityService entityService)
+        // NOTE: AttributeSystem reads the HP-floor clamp from DeathOptions because the death floor
+        // is the only value that changes the lower clamp on SetCurrentHp. This is a cross-module
+        // dependency (Attributes → Death) within the same project. The backlog item
+        // "IOptions<T> sweep — typed config options across Core" tracks decoupling this, either by
+        // moving HpFloor to AttributeOptions or by eliminating the clamp from AttributeSystem
+        // entirely (letting callers own the floor).
+        public AttributeSystem(EntityService entityService, IOptions<DeathOptions> deathOptions)
         {
             _entityService = entityService;
+            _hpFloor = deathOptions.Value.HpFloor;
         }
 
         public int GetLevel(uint entityId)
@@ -94,7 +104,7 @@ namespace Hedron.Core.Modules.Attributes.Systems
         {
             if (!_entityService.TryGet<PoolsComponent>(entityId, out var p))
                 return;
-            p.CurrentHp = Math.Clamp(value, 0, GetMaxHp(entityId));
+            p.CurrentHp = Math.Clamp(value, _hpFloor, GetMaxHp(entityId));
         }
 
         public void SetMaxMana(uint entityId, int value)

--- a/Core/Modules/Attributes/Systems/IAttributeSystem.cs
+++ b/Core/Modules/Attributes/Systems/IAttributeSystem.cs
@@ -5,7 +5,8 @@ namespace Hedron.Core.Modules.Attributes.Systems
     /// <see cref="ECS.Components.PoolsComponent"/>. Getters are the surface combat and stat
     /// consumers call; setters serve the admin and initialization paths.
     /// INV-5: this system never touches the event bus or persistence.
-    /// Pool invariants: SetMaxX clamps CurrentX to new MaxX; SetCurrentX clamps to [0, MaxX].
+    /// Pool invariants: SetMaxX clamps CurrentX to new MaxX; SetCurrentX clamps to [HpFloor, MaxX]
+    /// for HP (where HpFloor is <c>Death:HpFloor</c>, default -10) and [0, MaxX] for all other pools.
     /// </summary>
     public interface IAttributeSystem
     {
@@ -32,7 +33,12 @@ namespace Hedron.Core.Modules.Attributes.Systems
 
         /// <summary>Sets MaxHp; clamps CurrentHp to new MaxHp if it would exceed it.</summary>
         void SetMaxHp(uint entityId, int value);
-        /// <summary>Sets CurrentHp clamped to [0, MaxHp]. No events, no persistence (INV-5).</summary>
+        /// <summary>
+        /// Sets CurrentHp clamped to [<c>Death:HpFloor</c>, MaxHp] (default floor: -10).
+        /// No events, no persistence (INV-5). The caller is responsible for evaluating HP
+        /// threshold crossings via <c>IDeathSystem.OnHpChanged</c> — this method does NOT call it
+        /// (INV-5: core systems must not chain into domain decisions).
+        /// </summary>
         void SetCurrentHp(uint entityId, int value);
 
         void SetMaxMana(uint entityId, int value);

--- a/Core/Modules/Combat/Handlers/CombatMobDeathHandler.cs
+++ b/Core/Modules/Combat/Handlers/CombatMobDeathHandler.cs
@@ -44,7 +44,10 @@ namespace Hedron.Core.Modules.Combat.Handlers
             var blueprintId = _entityService.TryGet<BlueprintComponent>(@event.DefenderEntityId, out var bp)
                 ? bp.BlueprintId
                 : string.Empty;
-            await _eventBus.PublishAsync(new MobDiedEvent(@event.DefenderEntityId, blueprintId))
+            await _eventBus.PublishAsync(new MobDiedEvent(
+                    @event.DefenderEntityId,
+                    blueprintId,
+                    KillerEntityId: @event.AttackerEntityId))
                 .ConfigureAwait(false);
 
             _entityService.DestroyEntity(@event.DefenderEntityId);

--- a/Core/Modules/Combat/Handlers/CombatTickHandler.cs
+++ b/Core/Modules/Combat/Handlers/CombatTickHandler.cs
@@ -4,10 +4,12 @@ using System.Threading.Tasks;
 using Hedron.Core.ECS;
 using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
-using Hedron.Core.Modules.Attributes.Systems;
 using Hedron.Core.Modules.Combat.Events;
 using Hedron.Core.Modules.Combat.Systems;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Modules.Death.Systems;
 using Hedron.Core.Modules.EntityState.Systems;
+using Hedron.Core.Modules.Stats.Systems;
 using Hedron.Core.Modules.Time.Events;
 using Microsoft.Extensions.Logging;
 
@@ -24,7 +26,8 @@ namespace Hedron.Core.Modules.Combat.Handlers
         private readonly EntityService _entityService;
         private readonly ICombatSystem _combatSystem;
         private readonly IEntityStateService _entityStateService;
-        private readonly IAttributeSystem _attributeSystem;
+        private readonly IDeathSystem _deathSystem;
+        private readonly IStatSystem _statSystem;
         private readonly IEventBus _eventBus;
         private readonly ILogger<CombatTickHandler> _logger;
 
@@ -34,14 +37,16 @@ namespace Hedron.Core.Modules.Combat.Handlers
             EntityService entityService,
             ICombatSystem combatSystem,
             IEntityStateService entityStateService,
-            IAttributeSystem attributeSystem,
+            IDeathSystem deathSystem,
+            IStatSystem statSystem,
             IEventBus eventBus,
             ILogger<CombatTickHandler> logger)
         {
             _entityService = entityService;
             _combatSystem = combatSystem;
             _entityStateService = entityStateService;
-            _attributeSystem = attributeSystem;
+            _deathSystem = deathSystem;
+            _statSystem = statSystem;
             _eventBus = eventBus;
             _logger = logger;
         }
@@ -64,6 +69,9 @@ namespace Hedron.Core.Modules.Combat.Handlers
                     continue;
 
                 var roomEntityId = loc.RoomEntityId;
+
+                // Capture HP before the round so IDeathSystem.OnHpChanged has accurate previousHp.
+                var defenderHpBefore = _statSystem.GetCurrentHp(defenderEntityId);
                 var result = _combatSystem.ExecuteRound(attackerEntityId, defenderEntityId);
 
                 await _eventBus.PublishAsync(new CombatRoundEvent(
@@ -86,8 +94,6 @@ namespace Hedron.Core.Modules.Combat.Handlers
                 }
                 else if (result.Outcome == CombatRoundOutcome.PlayerIncapacitated)
                 {
-                    // Clamp the incapacitated player (the defender in this round) to 1 HP — stub for slice 10.
-                    _attributeSystem.SetCurrentHp(defenderEntityId, 1);
                     _combatSystem.EndCombat(attackerEntityId, defenderEntityId);
                     _entityStateService.ExitState(attackerEntityId, EntityStateFlags.InCombat);
                     _entityStateService.ExitState(defenderEntityId, EntityStateFlags.InCombat);
@@ -96,10 +102,20 @@ namespace Hedron.Core.Modules.Combat.Handlers
                         attackerEntityId, defenderEntityId,
                         CombatEndOutcome.PlayerIncapacitated, roomEntityId))
                         .ConfigureAwait(false);
+
+                    var defenderHpAfter = _statSystem.GetCurrentHp(defenderEntityId);
+                    var transition = _deathSystem.OnHpChanged(defenderEntityId, defenderHpBefore, defenderHpAfter);
+                    if (transition == DeathTransition.BecameIncapacitated)
+                    {
+                        await _eventBus.PublishAsync(
+                            new PlayerIncapacitatedEvent(defenderEntityId, roomEntityId))
+                            .ConfigureAwait(false);
+                    }
                 }
                 else
                 {
                     // Counterattack: the entity that was struck this round now strikes back.
+                    var attackerHpBefore = _statSystem.GetCurrentHp(attackerEntityId);
                     var counterResult = _combatSystem.ExecuteRound(defenderEntityId, attackerEntityId);
 
                     await _eventBus.PublishAsync(new CombatRoundEvent(
@@ -108,7 +124,6 @@ namespace Hedron.Core.Modules.Combat.Handlers
 
                     if (counterResult.Outcome == CombatRoundOutcome.PlayerIncapacitated)
                     {
-                        _attributeSystem.SetCurrentHp(attackerEntityId, 1);
                         _combatSystem.EndCombat(defenderEntityId, attackerEntityId);
                         _entityStateService.ExitState(defenderEntityId, EntityStateFlags.InCombat);
                         _entityStateService.ExitState(attackerEntityId, EntityStateFlags.InCombat);
@@ -117,6 +132,15 @@ namespace Hedron.Core.Modules.Combat.Handlers
                             defenderEntityId, attackerEntityId,
                             CombatEndOutcome.PlayerIncapacitated, roomEntityId))
                             .ConfigureAwait(false);
+
+                        var attackerHpAfter = _statSystem.GetCurrentHp(attackerEntityId);
+                        var transition = _deathSystem.OnHpChanged(attackerEntityId, attackerHpBefore, attackerHpAfter);
+                        if (transition == DeathTransition.BecameIncapacitated)
+                        {
+                            await _eventBus.PublishAsync(
+                                new PlayerIncapacitatedEvent(attackerEntityId, roomEntityId))
+                                .ConfigureAwait(false);
+                        }
                     }
                 }
             }

--- a/Core/Modules/Combat/Systems/CombatSystem.cs
+++ b/Core/Modules/Combat/Systems/CombatSystem.cs
@@ -89,9 +89,9 @@ namespace Hedron.Core.Modules.Combat.Systems
             var hpAfter = _statSystem.GetCurrentHp(defenderEntityId);
             CombatRoundOutcome outcome;
 
-            if (hpAfter == 0 && _entityService.HasComponent<MobDataComponent>(defenderEntityId))
+            if (hpAfter <= 0 && _entityService.HasComponent<MobDataComponent>(defenderEntityId))
                 outcome = CombatRoundOutcome.MobDied;
-            else if (hpAfter == 0 && _entityService.HasComponent<CharacterComponent>(defenderEntityId))
+            else if (hpAfter <= 0 && _entityService.HasComponent<CharacterComponent>(defenderEntityId))
                 outcome = CombatRoundOutcome.PlayerIncapacitated;
             else
                 outcome = CombatRoundOutcome.Hit;

--- a/Core/Modules/Death/Commands/SetRespawnCommand.cs
+++ b/Core/Modules/Death/Commands/SetRespawnCommand.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hedron.Core.Commands;
+using Hedron.Core.Commands.Authorization;
+using Hedron.Core.ECS;
+using Hedron.Core.Events;
+using Hedron.Core.Modules.Account.Components;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Modules.Death.Systems;
+using Hedron.Core.Output;
+using Hedron.Core.Sessions;
+using Hedron.Core.Systems;
+
+namespace Hedron.Core.Modules.Death.Commands
+{
+    /// <summary>
+    /// Admin command: <c>setrespawn &lt;playerName&gt; &lt;roomBlueprintId&gt;</c>
+    /// Sets the named player's respawn room blueprint id. Validates the blueprint exists via
+    /// <see cref="IDeathSystem.SetRespawn"/>, persists the change immediately (INV-22 admin
+    /// boundary save), then publishes <see cref="PlayerRespawnSetByAdminEvent"/> for the audit log.
+    /// </summary>
+    public sealed class SetRespawnCommand : ICommand
+    {
+        private readonly IDeathSystem _deathSystem;
+        private readonly ISessionManager _sessionManager;
+        private readonly EntityService _entityService;
+        private readonly IEventBus _eventBus;
+        private readonly IPersistenceSystem _persistence;
+
+        public string Name => "setrespawn";
+        public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
+        public CommandCategory Category => CommandCategory.Admin;
+        public CommandMatchingMode MatchingMode => CommandMatchingMode.Full;
+        public bool UsableWhileIncapacitated => false;
+        public string ShortDescription => "Set a player's respawn room.";
+        public string LongDescription =>
+            "Sets the room blueprint id that the named player will respawn into after death. " +
+            "The blueprint must exist in the template registry. " +
+            "The change is persisted immediately (admin boundary save, INV-22) and audited.";
+        public string Usage => "setrespawn <characterName> <roomBlueprintId>";
+        public IReadOnlyList<IAuthorizationRequirement> RequiredPrivileges { get; } =
+            new IAuthorizationRequirement[] { new AdminRequirement() };
+        public CommandArgumentSchema ArgumentSchema { get; } = new(new[]
+        {
+            new CommandArgument("characterName", typeof(string), CommandArgumentKind.Token,
+                Required: true, "Name of the connected character."),
+            new CommandArgument("roomBlueprintId", typeof(string), CommandArgumentKind.Token,
+                Required: true, "Blueprint id of the respawn room."),
+        });
+
+        public SetRespawnCommand(
+            IDeathSystem deathSystem,
+            ISessionManager sessionManager,
+            EntityService entityService,
+            IEventBus eventBus,
+            IPersistenceSystem persistence)
+        {
+            _deathSystem = deathSystem ?? throw new ArgumentNullException(nameof(deathSystem));
+            _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+            _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
+            _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            _persistence = persistence ?? throw new ArgumentNullException(nameof(persistence));
+        }
+
+        public async Task ExecuteAsync(CommandContext context)
+        {
+            var characterName = context.Args.Get<string>("characterName");
+            var roomBlueprintId = context.Args.Get<string>("roomBlueprintId");
+
+            // Resolve the target player entity by character name across all connected sessions.
+            uint playerEntityId = 0;
+            foreach (var session in _sessionManager.GetAll())
+            {
+                if (session.PlayerEntityId == 0)
+                    continue;
+                if (_entityService.TryGet<CharacterComponent>(session.PlayerEntityId, out var ch) &&
+                    string.Equals(ch.CharacterName, characterName, StringComparison.OrdinalIgnoreCase))
+                {
+                    playerEntityId = session.PlayerEntityId;
+                    break;
+                }
+            }
+
+            if (playerEntityId == 0)
+            {
+                await context.Output.WriteAsync(new PlainMessage(
+                    $"No connected player named '{characterName}'.",
+                    OutputSeverity.Error)).ConfigureAwait(false);
+                return;
+            }
+
+            // Delegate validation + mutation to IDeathSystem (blueprint-existence check happens there).
+            if (!_deathSystem.SetRespawn(playerEntityId, roomBlueprintId, out var failReason))
+            {
+                await context.Output.WriteAsync(new PlainMessage(
+                    failReason ?? "Failed to set respawn room.",
+                    OutputSeverity.Error)).ConfigureAwait(false);
+                return;
+            }
+
+            // Admin boundary save (INV-22) — persist the respawn room durably right away.
+            await _persistence.SaveEntityAsync(playerEntityId).ConfigureAwait(false);
+
+            // Audit event — commands are initiators and are responsible for publishing (INV-5).
+            await _eventBus.PublishAsync(new PlayerRespawnSetByAdminEvent(
+                context.InvokerEntityId,
+                playerEntityId,
+                roomBlueprintId)).ConfigureAwait(false);
+
+            await context.Output.WriteAsync(new PlainMessage(
+                $"Respawn room for {characterName} set to '{roomBlueprintId}'.",
+                OutputSeverity.Confirmation)).ConfigureAwait(false);
+        }
+    }
+}

--- a/Core/Modules/Death/DeathModule.cs
+++ b/Core/Modules/Death/DeathModule.cs
@@ -1,0 +1,24 @@
+using Hedron.Core.Commands;
+using Hedron.Core.Modules.Death.Commands;
+using Hedron.Core.Modules.Death.Handlers;
+using Hedron.Core.Modules.Death.Systems;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hedron.Core.Modules.Death
+{
+    /// <summary>
+    /// DI composition entry point for the Death module.
+    /// </summary>
+    public static class DeathModule
+    {
+        public static IServiceCollection AddDeathModule(this IServiceCollection services)
+        {
+            services.AddSingleton<IDeathSystem, DeathSystem>();
+            services.AddSingleton<DeathTickHandler>();
+            services.AddSingleton<PlayerDeathHandler>();
+            services.AddSingleton<DeathNarrationHandler>();
+            services.AddSingleton<ICommand, SetRespawnCommand>();
+            return services;
+        }
+    }
+}

--- a/Core/Modules/Death/DeathOptions.cs
+++ b/Core/Modules/Death/DeathOptions.cs
@@ -1,0 +1,26 @@
+namespace Hedron.Core.Modules.Death
+{
+    /// <summary>
+    /// Settings bound from the <c>Death:</c> configuration section.
+    /// </summary>
+    public sealed class DeathOptions
+    {
+        /// <summary>
+        /// Minimum HP a player can reach before dying. Default: -10.
+        /// Used as the lower clamp floor in <c>IAttributeSystem.SetCurrentHp</c>
+        /// and as the death threshold in <c>IDeathSystem.OnHpChanged</c>.
+        /// </summary>
+        public int HpFloor { get; set; } = -10;
+
+        /// <summary>
+        /// HP drained per heartbeat tick while the player is incapacitated. Default: 1.
+        /// </summary>
+        public int BleedPerTick { get; set; } = 1;
+
+        /// <summary>
+        /// Fraction of each pool's maximum restored on respawn. Default: 0.25 (25%).
+        /// Applied as <c>floor(Max * RespawnPoolPercent)</c> for every pool.
+        /// </summary>
+        public double RespawnPoolPercent { get; set; } = 0.25;
+    }
+}

--- a/Core/Modules/Death/Events/PlayerBleedingEvent.cs
+++ b/Core/Modules/Death/Events/PlayerBleedingEvent.cs
@@ -1,0 +1,18 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Death.Events
+{
+    /// <summary>
+    /// Published each heartbeat tick while a player is incapacitated and losing HP to bleed.
+    /// Carries the current HP and the floor so narration handlers can format a progress message.
+    /// </summary>
+    public sealed record PlayerBleedingEvent(
+        uint PlayerEntityId,
+        int CurrentHp,
+        int HpFloor) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Death/Events/PlayerDiedEvent.cs
+++ b/Core/Modules/Death/Events/PlayerDiedEvent.cs
@@ -1,0 +1,18 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Death.Events
+{
+    /// <summary>
+    /// Published when a player's HP reaches or drops below <c>Death:HpFloor</c>.
+    /// <c>KillerEntityId == 0</c> is the "no attributable killer" sentinel (e.g. bleed death).
+    /// </summary>
+    public sealed record PlayerDiedEvent(
+        uint PlayerEntityId,
+        uint DeathRoomEntityId,
+        uint KillerEntityId) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Death/Events/PlayerIncapacitatedEvent.cs
+++ b/Core/Modules/Death/Events/PlayerIncapacitatedEvent.cs
@@ -1,0 +1,18 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Death.Events
+{
+    /// <summary>
+    /// Published when a player's HP crosses from positive to zero-or-below for the first time
+    /// (i.e. the entity just became incapacitated). Thin payload — consumers that need room
+    /// context read <see cref="Hedron.Core.ECS.Components.LocationComponent"/> directly.
+    /// </summary>
+    public sealed record PlayerIncapacitatedEvent(
+        uint PlayerEntityId,
+        uint RoomEntityId) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Death/Events/PlayerRespawnSetByAdminEvent.cs
+++ b/Core/Modules/Death/Events/PlayerRespawnSetByAdminEvent.cs
@@ -1,0 +1,19 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Death.Events
+{
+    /// <summary>
+    /// Published by <c>SetRespawnCommand</c> after a successful <c>setrespawn</c> operation.
+    /// Used by <see cref="Hedron.Core.Modules.Admin.Handlers.AdminAuditHandler"/> for the
+    /// structured audit log and by any future notification consumers.
+    /// </summary>
+    public sealed record PlayerRespawnSetByAdminEvent(
+        uint AdminEntityId,
+        uint PlayerEntityId,
+        string RoomBlueprintId) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Death/Events/PlayerRespawnedEvent.cs
+++ b/Core/Modules/Death/Events/PlayerRespawnedEvent.cs
@@ -1,0 +1,18 @@
+using System;
+using Hedron.Core.Events;
+
+namespace Hedron.Core.Modules.Death.Events
+{
+    /// <summary>
+    /// Published after <see cref="Hedron.Core.Modules.Death.Systems.IDeathSystem.Respawn"/> has
+    /// completed — the player is now at their respawn room with pools partially restored and
+    /// impermanent effects cleared.
+    /// </summary>
+    public sealed record PlayerRespawnedEvent(
+        uint PlayerEntityId,
+        uint RespawnRoomEntityId) : IEvent
+    {
+        public DateTime OccurredAt { get; } = DateTime.UtcNow;
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+}

--- a/Core/Modules/Death/Handlers/DeathNarrationHandler.cs
+++ b/Core/Modules/Death/Handlers/DeathNarrationHandler.cs
@@ -1,0 +1,117 @@
+using System.Threading.Tasks;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
+using Hedron.Core.Events;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Output;
+using Hedron.Core.Systems;
+
+namespace Hedron.Core.Modules.Death.Handlers
+{
+    /// <summary>
+    /// Broadcasts and writes narrative messages for all player death lifecycle events.
+    /// Pure output: no state mutations, no system calls beyond <see cref="IBroadcastSystem"/>.
+    /// Priority 80 (<see cref="HandlerPriority.Notification"/>).
+    /// </summary>
+    public sealed class DeathNarrationHandler :
+        IEventHandler<PlayerIncapacitatedEvent>,
+        IEventHandler<PlayerBleedingEvent>,
+        IEventHandler<PlayerDiedEvent>,
+        IEventHandler<PlayerRespawnedEvent>
+    {
+        private readonly EntityService _entityService;
+        private readonly IBroadcastSystem _broadcast;
+
+        public int Priority => HandlerPriority.Notification;
+
+        public DeathNarrationHandler(EntityService entityService, IBroadcastSystem broadcast)
+        {
+            _entityService = entityService;
+            _broadcast = broadcast;
+        }
+
+        public async Task HandleAsync(PlayerIncapacitatedEvent @event)
+        {
+            var name = GetPlayerName(@event.PlayerEntityId);
+
+            // Write to the downed player personally.
+            await _broadcast.SendToRoomAsync(
+                @event.RoomEntityId,
+                new PlainMessage("You collapse, bleeding out. You cannot act — find healing fast.", OutputSeverity.System),
+                entityId => entityId == @event.PlayerEntityId)
+                .ConfigureAwait(false);
+
+            // Broadcast to everyone else in the room.
+            await _broadcast.SendToRoomAsync(
+                @event.RoomEntityId,
+                new PlainMessage($"{name} collapses, mortally wounded!", OutputSeverity.System),
+                entityId => entityId != @event.PlayerEntityId)
+                .ConfigureAwait(false);
+        }
+
+        public async Task HandleAsync(PlayerBleedingEvent @event)
+        {
+            // Resolve the room once; both sends below use it.
+            var roomEntityId = _entityService.TryGet<LocationComponent>(@event.PlayerEntityId, out var loc)
+                ? loc.RoomEntityId
+                : 0u;
+
+            if (roomEntityId == 0)
+                return;
+
+            // Personal message to the downed player.
+            await _broadcast.SendToRoomAsync(
+                roomEntityId,
+                new PlainMessage(
+                    $"You are bleeding out ({@event.CurrentHp}/{@event.HpFloor}). Without healing you will die.",
+                    OutputSeverity.System),
+                entityId => entityId == @event.PlayerEntityId)
+                .ConfigureAwait(false);
+
+            // Room broadcast (everyone except the player) so witnesses know someone is dying.
+            var name = GetPlayerName(@event.PlayerEntityId);
+            await _broadcast.SendToRoomAsync(
+                roomEntityId,
+                new PlainMessage($"{name} is bleeding out and near death.", OutputSeverity.System),
+                entityId => entityId != @event.PlayerEntityId)
+                .ConfigureAwait(false);
+        }
+
+        public async Task HandleAsync(PlayerDiedEvent @event)
+        {
+            var name = GetPlayerName(@event.PlayerEntityId);
+
+            // Broadcast death to the room where the player fell.
+            await _broadcast.SendToRoomAsync(
+                @event.DeathRoomEntityId,
+                new PlainMessage($"{name} has died.", OutputSeverity.System))
+                .ConfigureAwait(false);
+        }
+
+        public async Task HandleAsync(PlayerRespawnedEvent @event)
+        {
+            var roomName = GetRoomName(@event.RespawnRoomEntityId);
+
+            // Tell the respawning player personally.
+            await _broadcast.SendToRoomAsync(
+                @event.RespawnRoomEntityId,
+                new PlainMessage($"You awaken, weak but alive, at {roomName}.", OutputSeverity.System),
+                entityId => entityId == @event.PlayerEntityId)
+                .ConfigureAwait(false);
+
+            // Announce arrival to others in the respawn room.
+            var name = GetPlayerName(@event.PlayerEntityId);
+            await _broadcast.SendToRoomAsync(
+                @event.RespawnRoomEntityId,
+                new PlainMessage($"{name} awakens at {roomName}.", OutputSeverity.System),
+                entityId => entityId != @event.PlayerEntityId)
+                .ConfigureAwait(false);
+        }
+
+        private string GetPlayerName(uint entityId) =>
+            _entityService.TryGet<PlayerComponent>(entityId, out var p) ? p.DisplayName : "Someone";
+
+        private string GetRoomName(uint roomEntityId) =>
+            _entityService.TryGet<RoomComponent>(roomEntityId, out var room) ? room.Name : "an unknown place";
+    }
+}

--- a/Core/Modules/Death/Handlers/DeathTickHandler.cs
+++ b/Core/Modules/Death/Handlers/DeathTickHandler.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
+using Hedron.Core.Events;
+using Hedron.Core.Modules.Attributes.Systems;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Modules.Death.Systems;
+using Hedron.Core.Modules.Time.Events;
+using Microsoft.Extensions.Options;
+
+namespace Hedron.Core.Modules.Death.Handlers
+{
+    /// <summary>
+    /// Applies the bleed-out tick to every incapacitated player on each heartbeat.
+    /// Reads HP before the mutation, calls <see cref="IAttributeSystem.SetCurrentHp"/>,
+    /// then calls <see cref="IDeathSystem.OnHpChanged"/> to evaluate whether the threshold
+    /// was reached. Publishes either <see cref="PlayerBleedingEvent"/> (alive but bleeding)
+    /// or <see cref="PlayerDiedEvent"/> (floor reached). Priority 20
+    /// (<see cref="HandlerPriority.Domain"/>).
+    /// </summary>
+    public sealed class DeathTickHandler : IEventHandler<HeartbeatTickEvent>
+    {
+        private readonly EntityService _entityService;
+        private readonly IAttributeSystem _attributeSystem;
+        private readonly IDeathSystem _deathSystem;
+        private readonly IEventBus _eventBus;
+        private readonly DeathOptions _options;
+
+        public int Priority => HandlerPriority.Domain;
+
+        public DeathTickHandler(
+            EntityService entityService,
+            IAttributeSystem attributeSystem,
+            IDeathSystem deathSystem,
+            IEventBus eventBus,
+            IOptions<DeathOptions> options)
+        {
+            _entityService = entityService;
+            _attributeSystem = attributeSystem;
+            _deathSystem = deathSystem;
+            _eventBus = eventBus;
+            _options = options.Value;
+        }
+
+        public async Task HandleAsync(HeartbeatTickEvent @event)
+        {
+            // Snapshot before iterating to avoid mutation during enumeration.
+            var incapacitated = _entityService.GetAllComponents<EntityStateComponent>()
+                .Where(pair => (pair.Component.ActiveStates & EntityStateFlags.Incapacitated) != 0)
+                .Select(pair => pair.EntityId)
+                .ToList();
+
+            foreach (var entityId in incapacitated)
+            {
+                var previousHp = _attributeSystem.GetCurrentHp(entityId);
+                var newHp = previousHp - _options.BleedPerTick;
+                _attributeSystem.SetCurrentHp(entityId, newHp);
+
+                // Re-read after the clamp applied by IAttributeSystem.
+                newHp = _attributeSystem.GetCurrentHp(entityId);
+
+                var transition = _deathSystem.OnHpChanged(entityId, previousHp, newHp);
+
+                if (transition == DeathTransition.Died)
+                {
+                    var roomEntityId = _entityService.TryGet<LocationComponent>(entityId, out var loc)
+                        ? loc.RoomEntityId
+                        : 0u;
+
+                    await _eventBus.PublishAsync(
+                        new PlayerDiedEvent(entityId, roomEntityId, KillerEntityId: 0))
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    // transition == None (already incapacitated — not a new threshold crossing)
+                    await _eventBus.PublishAsync(
+                        new PlayerBleedingEvent(entityId, newHp, _options.HpFloor))
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/Core/Modules/Death/Handlers/PlayerDeathHandler.cs
+++ b/Core/Modules/Death/Handlers/PlayerDeathHandler.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
+using Hedron.Core.Events;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Modules.Death.Systems;
+
+namespace Hedron.Core.Modules.Death.Handlers
+{
+    /// <summary>
+    /// Responds to <see cref="PlayerDiedEvent"/> by calling
+    /// <see cref="IDeathSystem.Respawn"/> (which handles state reset, location,
+    /// effects, and pool restoration), then publishes
+    /// <see cref="PlayerRespawnedEvent"/>. Priority 20 (<see cref="HandlerPriority.Domain"/>).
+    /// </summary>
+    public sealed class PlayerDeathHandler : IEventHandler<PlayerDiedEvent>
+    {
+        private readonly EntityService _entityService;
+        private readonly IDeathSystem _deathSystem;
+        private readonly IEventBus _eventBus;
+
+        public int Priority => HandlerPriority.Domain;
+
+        public PlayerDeathHandler(
+            EntityService entityService,
+            IDeathSystem deathSystem,
+            IEventBus eventBus)
+        {
+            _entityService = entityService;
+            _deathSystem = deathSystem;
+            _eventBus = eventBus;
+        }
+
+        public async Task HandleAsync(PlayerDiedEvent @event)
+        {
+            _deathSystem.Respawn(@event.PlayerEntityId);
+
+            // Read the new location AFTER Respawn has already set it.
+            var respawnRoomEntityId = _entityService.TryGet<LocationComponent>(@event.PlayerEntityId, out var loc)
+                ? loc.RoomEntityId
+                : 0u;
+
+            await _eventBus.PublishAsync(
+                new PlayerRespawnedEvent(@event.PlayerEntityId, respawnRoomEntityId))
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/Core/Modules/Death/Systems/DeathSystem.cs
+++ b/Core/Modules/Death/Systems/DeathSystem.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
+using Hedron.Core.Modules.Account.Components;
+using Hedron.Core.Modules.Attributes.Systems;
+using Hedron.Core.Modules.Effects.Systems;
+using Hedron.Core.Modules.EntityState.Systems;
+using Hedron.Core.Systems;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Hedron.Core.Modules.Death.Systems
+{
+    /// <summary>
+    /// Domain system that owns the HP-threshold evaluation, respawn mutation, and
+    /// respawn-location management for the player death lifecycle.
+    /// Pure: never touches the event bus or persistence (INV-5, INV-8).
+    /// </summary>
+    public sealed class DeathSystem : IDeathSystem
+    {
+        private readonly EntityService _entityService;
+        private readonly IEntityStateService _entityStateService;
+        private readonly IAttributeSystem _attributeSystem;
+        private readonly IEffectSystem _effectSystem;
+        private readonly ITemplateRegistry _templateRegistry;
+        private readonly WorldConfiguration _worldConfig;
+        private readonly DeathOptions _options;
+        private readonly ILogger<DeathSystem> _logger;
+
+        public DeathSystem(
+            EntityService entityService,
+            IEntityStateService entityStateService,
+            IAttributeSystem attributeSystem,
+            IEffectSystem effectSystem,
+            ITemplateRegistry templateRegistry,
+            WorldConfiguration worldConfig,
+            IOptions<DeathOptions> options,
+            ILogger<DeathSystem> logger)
+        {
+            _entityService = entityService;
+            _entityStateService = entityStateService;
+            _attributeSystem = attributeSystem;
+            _effectSystem = effectSystem;
+            _templateRegistry = templateRegistry;
+            _worldConfig = worldConfig;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public DeathTransition OnHpChanged(uint entityId, int previousHp, int newHp)
+        {
+            // Only player entities (CharacterComponent) enter the death pipeline.
+            if (!_entityService.HasComponent<CharacterComponent>(entityId))
+                return DeathTransition.None;
+
+            // Died: HP is at or below the floor (and entity must be incapacitated already).
+            if (newHp <= _options.HpFloor)
+                return DeathTransition.Died;
+
+            // BecameIncapacitated: crossed from positive to zero-or-below for the first time.
+            if (newHp <= 0 && previousHp > 0 && !_entityStateService.IsInState(entityId, EntityStateFlags.Incapacitated))
+            {
+                _entityStateService.TryEnterState(entityId, EntityStateFlags.Incapacitated, out _);
+                return DeathTransition.BecameIncapacitated;
+            }
+
+            return DeathTransition.None;
+        }
+
+        /// <inheritdoc/>
+        public void Respawn(uint entityId)
+        {
+            // 1. Exit incapacitated state (and clear any other lingering runtime flags).
+            _entityStateService.ExitState(entityId, EntityStateFlags.Incapacitated);
+
+            // 2. Resolve respawn room and update LocationComponent.
+            var liveBlueprints = BuildLiveBlueprintMap();
+
+            string? targetBlueprintId = null;
+            uint targetRoomEntityId = 0;
+
+            if (_entityService.TryGet<RespawnComponent>(entityId, out var respawn) &&
+                !string.IsNullOrEmpty(respawn.RoomBlueprintId) &&
+                liveBlueprints.TryGetValue(respawn.RoomBlueprintId, out var resolvedId))
+            {
+                targetBlueprintId = respawn.RoomBlueprintId;
+                targetRoomEntityId = resolvedId;
+            }
+            else
+            {
+                // Fallback: use the world starting room.
+                _logger.LogWarning(
+                    "DeathSystem.Respawn: entity {EntityId} has unresolvable RespawnComponent.RoomBlueprintId '{BlueprintId}'; " +
+                    "falling back to starting room.",
+                    entityId, respawn?.RoomBlueprintId);
+
+                targetRoomEntityId = _worldConfig.StartingRoomEntityId;
+                targetBlueprintId = _worldConfig.StartingRoomBlueprintId;
+            }
+
+            if (_entityService.TryGet<LocationComponent>(entityId, out var location))
+            {
+                location.RoomEntityId = targetRoomEntityId;
+                location.RoomBlueprintId = targetBlueprintId;
+            }
+            else
+            {
+                _entityService.AddComponent(entityId, new LocationComponent
+                {
+                    RoomEntityId = targetRoomEntityId,
+                    RoomBlueprintId = targetBlueprintId,
+                });
+            }
+
+            // 3. Strip impermanent effects.
+            _effectSystem.RemoveImpermanent(entityId);
+
+            // 4. Restore all four pools to floor(Max * RespawnPoolPercent).
+            var hpRestore = (int)Math.Floor(_attributeSystem.GetMaxHp(entityId) * _options.RespawnPoolPercent);
+            var manaRestore = (int)Math.Floor(_attributeSystem.GetMaxMana(entityId) * _options.RespawnPoolPercent);
+            var staminaRestore = (int)Math.Floor(_attributeSystem.GetMaxStamina(entityId) * _options.RespawnPoolPercent);
+            var astraRestore = (int)Math.Floor(_attributeSystem.GetMaxAstra(entityId) * _options.RespawnPoolPercent);
+
+            _attributeSystem.SetCurrentHp(entityId, hpRestore);
+            _attributeSystem.SetCurrentMana(entityId, manaRestore);
+            _attributeSystem.SetCurrentStamina(entityId, staminaRestore);
+            _attributeSystem.SetCurrentAstra(entityId, astraRestore);
+        }
+
+        /// <inheritdoc/>
+        public bool SetRespawn(uint entityId, string roomBlueprintId, out string? failReason)
+        {
+            // Validate the blueprint exists via ITemplateRegistry (per spec: use TryGet).
+            if (!_templateRegistry.TryGet(roomBlueprintId, out _))
+            {
+                failReason = $"No blueprint with id '{roomBlueprintId}' is registered.";
+                return false;
+            }
+
+            if (_entityService.TryGet<RespawnComponent>(entityId, out var existing))
+            {
+                existing.RoomBlueprintId = roomBlueprintId;
+            }
+            else
+            {
+                _entityService.AddComponent(entityId, new RespawnComponent { RoomBlueprintId = roomBlueprintId });
+            }
+
+            failReason = null;
+            return true;
+        }
+
+        // ── Private helpers ───────────────────────────────────────────────────
+
+        private Dictionary<string, uint> BuildLiveBlueprintMap()
+        {
+            var map = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (entityId, bp) in _entityService.GetAllComponents<BlueprintComponent>())
+            {
+                if (!string.IsNullOrEmpty(bp.BlueprintId))
+                    map[bp.BlueprintId] = entityId;
+            }
+            return map;
+        }
+    }
+}

--- a/Core/Modules/Death/Systems/IDeathSystem.cs
+++ b/Core/Modules/Death/Systems/IDeathSystem.cs
@@ -1,0 +1,61 @@
+namespace Hedron.Core.Modules.Death.Systems
+{
+    /// <summary>
+    /// Result returned by <see cref="IDeathSystem.OnHpChanged"/> describing which threshold,
+    /// if any, was crossed.
+    /// </summary>
+    public enum DeathTransition
+    {
+        /// <summary>No threshold was crossed. HP changed but the entity is neither
+        /// newly incapacitated nor dead.</summary>
+        None,
+
+        /// <summary>HP crossed from above zero to zero-or-below for a non-incapacitated
+        /// entity. The entity is now incapacitated.</summary>
+        BecameIncapacitated,
+
+        /// <summary>HP reached or dropped below <c>Death:HpFloor</c>. The entity has died.</summary>
+        Died,
+    }
+
+    /// <summary>
+    /// Domain system for the player death and respawn lifecycle.
+    /// Pure: never touches the event bus or persistence (INV-5, INV-8).
+    /// Callers (handlers, initiators) are responsible for reading the returned
+    /// <see cref="DeathTransition"/> and publishing the appropriate events.
+    /// </summary>
+    public interface IDeathSystem
+    {
+        /// <summary>
+        /// Evaluates HP-threshold crossings after an HP mutation.
+        /// Must be called by the handler that mutated HP — NOT by <see cref="Hedron.Core.Modules.Attributes.Systems.IAttributeSystem"/>
+        /// (INV-5: a core system must not chain into a domain decision).
+        /// </summary>
+        /// <param name="entityId">The entity whose HP changed.</param>
+        /// <param name="previousHp">The HP value before the mutation.</param>
+        /// <param name="newHp">The HP value after the mutation.</param>
+        /// <returns>
+        /// <see cref="DeathTransition.BecameIncapacitated"/> when <paramref name="newHp"/> &lt;= 0
+        /// and <paramref name="previousHp"/> &gt; 0 and the entity is not already incapacitated.
+        /// <see cref="DeathTransition.Died"/> when <paramref name="newHp"/> &lt;= <c>Death:HpFloor</c>.
+        /// <see cref="DeathTransition.None"/> otherwise.
+        /// </returns>
+        DeathTransition OnHpChanged(uint entityId, int previousHp, int newHp);
+
+        /// <summary>
+        /// Performs the full respawn mutation on <paramref name="entityId"/>:
+        /// exits the <c>Incapacitated</c> state, relocates to the stored respawn room,
+        /// strips impermanent effects, and restores all four pools to a configured
+        /// percentage of their maxima.
+        /// </summary>
+        void Respawn(uint entityId);
+
+        /// <summary>
+        /// Validates that <paramref name="roomBlueprintId"/> exists in the template registry,
+        /// then sets <c>RespawnComponent.RoomBlueprintId</c> on <paramref name="entityId"/>.
+        /// </summary>
+        /// <returns><c>true</c> on success; <c>false</c> when the blueprint is not found,
+        /// in which case <paramref name="failReason"/> is set to a human-readable message.</returns>
+        bool SetRespawn(uint entityId, string roomBlueprintId, out string? failReason);
+    }
+}

--- a/Core/Modules/Effects/Handlers/EffectTickHandler.cs
+++ b/Core/Modules/Effects/Handlers/EffectTickHandler.cs
@@ -1,6 +1,10 @@
 using System.Threading.Tasks;
+using Hedron.Core.ECS;
+using Hedron.Core.ECS.Components;
 using Hedron.Core.Events;
 using Hedron.Core.Modules.Attributes.Systems;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Modules.Death.Systems;
 using Hedron.Core.Modules.Effects.Events;
 using Hedron.Core.Modules.Effects.Systems;
 using Hedron.Core.Modules.Stats;
@@ -10,16 +14,25 @@ namespace Hedron.Core.Modules.Effects.Handlers
 {
     public sealed class EffectTickHandler : IEventHandler<HeartbeatTickEvent>
     {
+        private readonly EntityService _entityService;
         private readonly IEffectSystem _effectSystem;
         private readonly IAttributeSystem _attributeSystem;
+        private readonly IDeathSystem _deathSystem;
         private readonly IEventBus _eventBus;
 
         public int Priority => HandlerPriority.Domain;
 
-        public EffectTickHandler(IEffectSystem effectSystem, IAttributeSystem attributeSystem, IEventBus eventBus)
+        public EffectTickHandler(
+            EntityService entityService,
+            IEffectSystem effectSystem,
+            IAttributeSystem attributeSystem,
+            IDeathSystem deathSystem,
+            IEventBus eventBus)
         {
+            _entityService = entityService;
             _effectSystem = effectSystem;
             _attributeSystem = attributeSystem;
+            _deathSystem = deathSystem;
             _eventBus = eventBus;
         }
 
@@ -29,7 +42,8 @@ namespace Hedron.Core.Modules.Effects.Handlers
 
             foreach (var app in result.DueApplications)
             {
-                ApplyMagnitude(app.EntityId, app.Effect.Params.TargetScore, app.Magnitude);
+                await ApplyMagnitudeAsync(app.EntityId, app.Effect.Params.TargetScore, app.Magnitude)
+                    .ConfigureAwait(false);
             }
 
             foreach (var (entityId, effect) in result.Expired)
@@ -39,14 +53,26 @@ namespace Hedron.Core.Modules.Effects.Handlers
             }
         }
 
-        private void ApplyMagnitude(uint entityId, ScoreId targetScore, int magnitude)
+        private async Task ApplyMagnitudeAsync(uint entityId, ScoreId targetScore, int magnitude)
         {
             switch (targetScore)
             {
                 case ScoreId.HpCurrent:
-                    _attributeSystem.SetCurrentHp(entityId,
-                        _attributeSystem.GetCurrentHp(entityId) + magnitude);
+                    var hpBefore = _attributeSystem.GetCurrentHp(entityId);
+                    _attributeSystem.SetCurrentHp(entityId, hpBefore + magnitude);
+                    var hpAfter = _attributeSystem.GetCurrentHp(entityId);
+
+                    var transition = _deathSystem.OnHpChanged(entityId, hpBefore, hpAfter);
+                    if (transition == DeathTransition.BecameIncapacitated)
+                    {
+                        var roomEntityId = _entityService.TryGet<LocationComponent>(entityId, out var loc)
+                            ? loc.RoomEntityId
+                            : 0u;
+                        await _eventBus.PublishAsync(new PlayerIncapacitatedEvent(entityId, roomEntityId))
+                            .ConfigureAwait(false);
+                    }
                     break;
+
                 case ScoreId.ManaCurrent:
                     _attributeSystem.SetCurrentMana(entityId,
                         _attributeSystem.GetCurrentMana(entityId) + magnitude);

--- a/Core/Modules/Effects/Systems/EffectSystem.cs
+++ b/Core/Modules/Effects/Systems/EffectSystem.cs
@@ -98,6 +98,12 @@ namespace Hedron.Core.Modules.Effects.Systems
                 comp.Effects.RemoveAll(e => e.Category == category);
         }
 
+        public void RemoveImpermanent(uint entityId)
+        {
+            if (_entityService.TryGet<EffectsComponent>(entityId, out var comp))
+                comp.Effects.RemoveAll(e => e.Lifetime != EffectLifetime.UntilRemoved);
+        }
+
         public IReadOnlyList<Effect> GetActive(uint entityId)
         {
             if (_entityService.TryGet<EffectsComponent>(entityId, out var comp))

--- a/Core/Modules/Effects/Systems/IEffectSystem.cs
+++ b/Core/Modules/Effects/Systems/IEffectSystem.cs
@@ -11,6 +11,13 @@ namespace Hedron.Core.Modules.Effects.Systems
         void Remove(uint entityId, string effectId);
         void RemoveByCategory(uint entityId, EffectCategory category);
 
+        /// <summary>
+        /// Removes all effects whose <see cref="EffectLifetime"/> is not
+        /// <see cref="EffectLifetime.UntilRemoved"/>. Called on player death to expire
+        /// timed and source-bound effects while preserving permanent ones (curses, disease, etc.).
+        /// </summary>
+        void RemoveImpermanent(uint entityId);
+
         IReadOnlyList<Effect> GetActive(uint entityId);
 
         int GetModifiers(uint entityId, ScoreId scoreId);

--- a/Core/Modules/Help/Commands/CommandsCommand.cs
+++ b/Core/Modules/Help/Commands/CommandsCommand.cs
@@ -21,6 +21,7 @@ namespace Hedron.Core.Modules.Help.Commands
         public IReadOnlyList<string> Aliases { get; } = Array.Empty<string>();
         public CommandCategory Category => CommandCategory.Player;
         public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
+        public bool UsableWhileIncapacitated => true;
         public string ShortDescription => "List available commands.";
         public string LongDescription => "Lists all commands available to you, grouped by category.";
         public string Usage => "commands";

--- a/Core/Modules/Help/Commands/HelpCommand.cs
+++ b/Core/Modules/Help/Commands/HelpCommand.cs
@@ -25,6 +25,7 @@ namespace Hedron.Core.Modules.Help.Commands
         public IReadOnlyList<string> Aliases { get; } = new[] { "?" };
         public CommandCategory Category => CommandCategory.Player;
         public CommandMatchingMode MatchingMode => CommandMatchingMode.Partial;
+        public bool UsableWhileIncapacitated => true;
         public string ShortDescription => "Show command help.";
         public string LongDescription =>
             "With no argument, lists all commands available to you grouped by category. " +

--- a/Core/Modules/Mobs/Events/MobDiedEvent.cs
+++ b/Core/Modules/Mobs/Events/MobDiedEvent.cs
@@ -7,10 +7,12 @@ namespace Hedron.Core.Modules.Mobs.Events
     /// Published by <c>CombatMobDeathHandler</c> immediately before the mob entity is destroyed,
     /// so systems that need to inspect entity state (e.g. <c>SpawnSystem</c>) can act while the
     /// entity is still live.
+    /// <para><c>KillerEntityId == 0</c> is the "no attributable killer" sentinel.</para>
     /// </summary>
     public sealed record MobDiedEvent(
         uint MobEntityId,
-        string BlueprintId) : IEvent
+        string BlueprintId,
+        uint KillerEntityId = 0) : IEvent
     {
         public DateTime OccurredAt { get; } = DateTime.UtcNow;
         public Guid EventId { get; } = Guid.NewGuid();

--- a/Core/Modules/World/Systems/WorldContentLoader.cs
+++ b/Core/Modules/World/Systems/WorldContentLoader.cs
@@ -296,6 +296,7 @@ namespace Hedron.Core.Modules.World.Systems
             if (liveBlueprints.TryGetValue(_startingRoomBlueprintId, out var entityId))
             {
                 _worldConfig.StartingRoomEntityId = entityId;
+                _worldConfig.StartingRoomBlueprintId = _startingRoomBlueprintId;
                 return;
             }
 
@@ -305,6 +306,7 @@ namespace Hedron.Core.Modules.World.Systems
                     "WorldContentLoader: configured starting room '{Id}' not found; falling back to void room.",
                     _startingRoomBlueprintId);
                 _worldConfig.StartingRoomEntityId = voidEntityId;
+                _worldConfig.StartingRoomBlueprintId = VoidRoomBlueprintId;
                 return;
             }
 
@@ -315,6 +317,7 @@ namespace Hedron.Core.Modules.World.Systems
                     "WorldContentLoader: configured starting room '{Id}' not found; falling back to '{Fallback}'.",
                     _startingRoomBlueprintId, anyRoom.Key);
                 _worldConfig.StartingRoomEntityId = anyRoom.Value;
+                _worldConfig.StartingRoomBlueprintId = anyRoom.Key;
             }
             else
             {

--- a/Core/Output/ScoreDisplayMessage.cs
+++ b/Core/Output/ScoreDisplayMessage.cs
@@ -17,7 +17,9 @@ namespace Hedron.Core.Output
         int CurrentStamina,
         int MaxStamina,
         int CurrentAstra,
-        int MaxAstra) : IOutputMessage
+        int MaxAstra,
+        string? RespawnRoomBlueprintId = null,
+        bool IsIncapacitated = false) : IOutputMessage
     {
         public OutputCategory Category => OutputCategory.Info;
     }

--- a/Core/Output/TelnetOutputFormatter.cs
+++ b/Core/Output/TelnetOutputFormatter.cs
@@ -160,6 +160,8 @@ namespace Hedron.Core.Output
         {
             var sb = new StringBuilder();
             sb.AppendLine(ApplyColor($"<room-name>[ {m.CharacterName} ]</room-name>", color));
+            if (m.IsIncapacitated)
+                sb.AppendLine(ApplyColor("<error>** INCAPACITATED — bleeding out **</error>", color));
             sb.AppendLine($"  Level     : {m.Level}");
             sb.AppendLine($"  HP        : {m.CurrentHp}/{m.MaxHp}");
             sb.AppendLine($"  Mana      : {m.CurrentMana}/{m.MaxMana}");
@@ -168,7 +170,11 @@ namespace Hedron.Core.Output
             sb.AppendLine($"  Mind      : {m.Mind}");
             sb.AppendLine($"  Body      : {m.Body}");
             sb.AppendLine($"  Spirit    : {m.Spirit}");
-            sb.Append($"  Attunement: {m.Attunement}");
+            sb.AppendLine($"  Attunement: {m.Attunement}");
+            var respawnLabel = string.IsNullOrEmpty(m.RespawnRoomBlueprintId)
+                ? "(starting room)"
+                : m.RespawnRoomBlueprintId;
+            sb.Append($"  Respawn   : {respawnLabel}");
             return ApplyColor(sb.ToString(), color);
         }
 

--- a/Core/WorldConfiguration.cs
+++ b/Core/WorldConfiguration.cs
@@ -7,5 +7,12 @@ namespace Hedron.Core
     {
         /// <summary>Entity id of the room new players are placed in on connect.</summary>
         public uint StartingRoomEntityId { get; set; }
+
+        /// <summary>
+        /// Blueprint id of the starting room. Populated alongside <see cref="StartingRoomEntityId"/>
+        /// by <c>WorldContentLoader.ResolveStartingRoom</c>. Used as a cross-restart-stable
+        /// fallback reference (e.g. for <c>RespawnComponent</c> at character creation).
+        /// </summary>
+        public string? StartingRoomBlueprintId { get; set; }
     }
 }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -23,6 +23,10 @@ using Hedron.Core.ECS.Components;
 using Hedron.Core.Modules.Chat.Commands;
 using Hedron.Core.Modules.Chat.Events;
 using Hedron.Core.Modules.Chat.Handlers;
+using Hedron.Core.Modules.Death;
+using Hedron.Core.Modules.Death.Commands;
+using Hedron.Core.Modules.Death.Events;
+using Hedron.Core.Modules.Death.Handlers;
 using Hedron.Core.Modules.Help;
 using Hedron.Core.Modules.Movement.Commands;
 using Hedron.Core.Modules.Movement.Events;
@@ -67,6 +71,8 @@ public static class Program
             {
                 services.Configure<OutputConfiguration>(
                     context.Configuration.GetSection("Output"));
+                services.Configure<DeathOptions>(
+                    context.Configuration.GetSection("Death"));
                 // ECS world
                 var world = new EntityService();
                 EcsManager.SetWorld(world);
@@ -127,6 +133,7 @@ public static class Program
                 services.AddEffectsModule();
                 services.AddCombatModule();
                 services.AddSpawnModule();
+                services.AddDeathModule();
 
                 // Hosted services — order matters.
                 services.AddHostedService<PersistenceBootstrap>();
@@ -159,6 +166,18 @@ public static class Program
         var combatMobDeath = host.Services.GetRequiredService<CombatMobDeathHandler>();
         bus.Subscribe<CombatEndedEvent>(combatMobDeath);
 
+        var deathTick = host.Services.GetRequiredService<DeathTickHandler>();
+        bus.Subscribe<HeartbeatTickEvent>(deathTick);
+
+        var playerDeath = host.Services.GetRequiredService<PlayerDeathHandler>();
+        bus.Subscribe<PlayerDiedEvent>(playerDeath);
+
+        var deathNarration = host.Services.GetRequiredService<DeathNarrationHandler>();
+        bus.Subscribe<PlayerIncapacitatedEvent>(deathNarration);
+        bus.Subscribe<PlayerBleedingEvent>(deathNarration);
+        bus.Subscribe<PlayerDiedEvent>(deathNarration);
+        bus.Subscribe<PlayerRespawnedEvent>(deathNarration);
+
         var audit = host.Services.GetRequiredService<AdminAuditHandler>();
         bus.Subscribe<EntitySpawnedByAdminEvent>(audit);
         bus.Subscribe<PlayerTeleportedByAdminEvent>(audit);
@@ -173,6 +192,7 @@ public static class Program
         bus.Subscribe<PlayerAttributeSetByAdminEvent>(audit);
         bus.Subscribe<CombatEndedEvent>(audit);
         bus.Subscribe<EffectAppliedByAdminEvent>(audit);
+        bus.Subscribe<PlayerRespawnSetByAdminEvent>(audit);
 
         var characterHydration = host.Services.GetRequiredService<CharacterHydrationHandler>();
         bus.Subscribe<WorldContentReadyEvent>(characterHydration);

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -26,6 +26,11 @@
     "MaxStamina": 50,
     "MaxAstra": 10
   },
+  "Death": {
+    "HpFloor": -10,
+    "BleedPerTick": 1,
+    "RespawnPoolPercent": 0.25
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docs/architecture/03-events.md
+++ b/docs/architecture/03-events.md
@@ -261,4 +261,4 @@ public class CombatHandler : IEventHandler<AttackEvent>
 | `NotificationHandler` (priority 80) | Notify witnesses |
 | `AIHandler` (priority 95) | Update NPC threat tables |
 
-> Persistence for `PlayerDeathEvent` is handled by the save-on-change model: the handler that applies the state mutation calls `IPersistenceSystem.SaveEntityAsync` directly after the mutation, rather than routing through a cross-cutting persistence handler subscription.
+> **Persistence note (slice 10 model).** Player state changes from death and respawn are not saved immediately on the event. Persistence uses the periodic-flush model: `PersistenceFlushTimer` flushes all dirty entities on a timed interval via `IPersistenceSystem.FlushDirtyEntitiesAsync`. Handlers do not call `SaveEntityAsync` directly; entity state is marked dirty automatically when components are mutated.

--- a/docs/architecture/flows/README.md
+++ b/docs/architecture/flows/README.md
@@ -31,8 +31,10 @@
 | 19 | [`flee` — combat exit](flow-19-flee-combat-exit.md) | Player sends `flee` | Phase 3 slice 9 |
 | 20 | [Mob death and respawn](flow-20-mob-death-respawn.md) | Mob HP reaches zero; `SpawnSystem` schedules and executes respawn | Persistence reform Stage C |
 | 21 | [Effect tick](flow-21-effect-tick.md) | `HeartbeatTickEvent` dispatched to `EffectTickHandler` | Phase 3 slice 9-e |
+| 22 | [Player incapacitation and bleed-out](flow-22-incapacitation-bleedout.md) | Player HP crosses zero; `DeathTickHandler` bleeds out per tick | Phase 3 slice 10 |
+| 23 | [Player death and respawn](flow-23-player-death-respawn.md) | HP reaches `Death:HpFloor`; `PlayerDeathHandler` triggers full respawn | Phase 3 slice 10 |
 
-Flows that don't yet exist (player death, mob wander tick, etc.) get added by the slice that introduces them.
+Flows that don't yet exist (mob wander tick, etc.) get added by the slice that introduces them.
 
 ---
 

--- a/docs/architecture/flows/flow-03-player-command-lifecycle.md
+++ b/docs/architecture/flows/flow-03-player-command-lifecycle.md
@@ -2,7 +2,7 @@
 
 > [Back to flows index](README.md)
 
-**Summary.** Input bytes become a verb + raw tail; the dispatcher performs a two-phase verb lookup (exact first, prefix second), checks authorization via `IAuthorizationChecker`, parses arguments via `ICommandArgumentParser`, constructs a `CommandContext`, calls `ICommand.ExecuteAsync(context)`, and publishes `CommandExecutedEvent` for every outcome. The `Verb` field in `CommandExecutedEvent` always carries the **resolved canonical name** (e.g. `look`), never the raw typed prefix (`lo`). Output goes through the formatter-backed `IOutputWriter` (see [Flow 6](flow-06-output-rendering.md) for the rendering trace).
+**Summary.** Input bytes become a verb + raw tail; the dispatcher performs a two-phase verb lookup (exact first, prefix second), checks the incapacitation gate, checks authorization via `IAuthorizationChecker`, parses arguments via `ICommandArgumentParser`, constructs a `CommandContext`, calls `ICommand.ExecuteAsync(context)`, and publishes `CommandExecutedEvent` for every outcome. The `Verb` field in `CommandExecutedEvent` always carries the **resolved canonical name** (e.g. `look`), never the raw typed prefix (`lo`). Output goes through the formatter-backed `IOutputWriter` (see [Flow 6](flow-06-output-rendering.md) for the rendering trace).
 
 **Trigger.** A line of input arrives on a session's read stream.
 
@@ -11,6 +11,7 @@ sequenceDiagram
     participant Client
     participant Sess as TelnetSession
     participant CD as CommandDispatcher
+    participant ESS as IEntityStateService
     participant Auth as IAuthorizationChecker
     participant Parser as ICommandArgumentParser
     participant Cmd as ICommand impl
@@ -31,23 +32,29 @@ sequenceDiagram
         end
     else verb exact hit (name or alias) → canonicalVerb = command.Name
     end
-    loop RequiredPrivileges
-        CD->>Auth: IsSatisfied(req, session)
-    end
-    alt unauthorized
-        CD->>Sess: WriteAsync(PlainMessage "Not authorized")
-        CD->>Bus: Publish(CommandExecutedEvent Unauthorized, Verb=canonicalVerb)
-    else authorized
-        CD->>Parser: Parse(ArgumentSchema, rawTail, resolverContext)
-        alt parse failed
-            CD->>Sess: WriteAsync(PlainMessage reason + help hint)
-            CD->>Bus: Publish(CommandExecutedEvent ParseFailed, Verb=canonicalVerb)
-        else parsed
-            CD->>Cmd: ExecuteAsync(CommandContext)
-            Cmd->>Cmd: domain call / event publish
-            Cmd->>Sess: WriteAsync(IOutputMessage) via IOutputWriter
-            CD->>Bus: Publish(CommandExecutedEvent Success, Verb=canonicalVerb)
-            Bus->>Bus: priority-ordered handlers (20 → 80 → 90 → 95)
+    CD->>ESS: IsInState(entityId, Incapacitated)
+    alt incapacitated AND !command.UsableWhileIncapacitated
+        CD->>Sess: WriteAsync(PlainMessage "You are incapacitated and cannot do that.")
+        CD->>Bus: Publish(CommandExecutedEvent Refused, Verb=canonicalVerb)
+    else not incapacitated OR command.UsableWhileIncapacitated
+        loop RequiredPrivileges
+            CD->>Auth: IsSatisfied(req, session)
+        end
+        alt unauthorized
+            CD->>Sess: WriteAsync(PlainMessage "Not authorized")
+            CD->>Bus: Publish(CommandExecutedEvent Unauthorized, Verb=canonicalVerb)
+        else authorized
+            CD->>Parser: Parse(ArgumentSchema, rawTail, resolverContext)
+            alt parse failed
+                CD->>Sess: WriteAsync(PlainMessage reason + help hint)
+                CD->>Bus: Publish(CommandExecutedEvent ParseFailed, Verb=canonicalVerb)
+            else parsed
+                CD->>Cmd: ExecuteAsync(CommandContext)
+                Cmd->>Cmd: domain call / event publish
+                Cmd->>Sess: WriteAsync(IOutputMessage) via IOutputWriter
+                CD->>Bus: Publish(CommandExecutedEvent Success, Verb=canonicalVerb)
+                Bus->>Bus: priority-ordered handlers (20 → 80 → 90 → 95)
+            end
         end
     end
 ```
@@ -58,15 +65,18 @@ sequenceDiagram
 2. **Two-phase verb lookup.**
    - **Phase 1 (exact):** `_byVerb.TryGetValue(verb)` — checks primary names and all declared aliases. If found, `canonicalVerb = command.Name` and skip to step 3. Static aliases like `d` → `down` resolve here; prefix resolution is never reached.
    - **Phase 2 (prefix):** Collect all commands where `MatchingMode == Partial` and `command.Name.StartsWith(verb, OrdinalIgnoreCase)`. Sort alphabetically. Zero matches → write `PlainMessage("Unknown command: <verb>. Type 'help' for a list.")`, publish `CommandExecutedEvent(ParseFailed)`, return. Two or more matches → write `PlainMessage("Ambiguous command '<verb>'. Did you mean: <all names, comma-separated>?")`, publish `CommandExecutedEvent(ParseFailed)`, return. Exactly one match → `canonicalVerb = command.Name`.
-3. **Privilege gate.** The dispatcher iterates `command.RequiredPrivileges` and calls `IAuthorizationChecker.IsSatisfied(req, session)` for each. Any unsatisfied requirement writes a rejection `PlainMessage` via `IOutputWriter` and publishes `CommandExecutedEvent(Unauthorized, Verb=canonicalVerb)`.
-4. **Argument parse.** `ICommandArgumentParser.Parse(command.ArgumentSchema, rawTail, resolverContext)` does single-pass tokenization (whitespace + double-quoted groups), walks the declarative argument list, and coerces each token to its CLR type (`string`, `int`, `uint`, `Direction`). Enum-prefix matching works from day one (`n`/`no`/`nor` → `North`). String `Token` arguments that declare a non-null `IArgumentResolver` have prefix matching applied against the candidate list. The resolver returns `IReadOnlyList<ResolvedCandidate>?` where each `ResolvedCandidate(string MatchString, string CanonicalValue)` allows keyword aliases to map to a canonical item name; the parser deduplicates by `CanonicalValue` after prefix matching so multiple keyword aliases for the same item do not produce false ambiguity. Concrete resolvers (`ItemInRoomResolver`, `ItemInInventoryResolver`) ship in slice 6. On failure: the reason + `"Type 'help <canonicalVerb>' for usage."` is written; `CommandExecutedEvent(ParseFailed, Verb=canonicalVerb)` is published.
-5. **Execute.** The dispatcher constructs `CommandContext(Session, InvokerEntityId, ParsedArguments, IOutputWriter, IServiceProvider)` and calls `command.ExecuteAsync(context)`. The body reads typed args via `context.Args.Get<T>(name)`, calls domain systems or publishes events via injected `IEventBus`, and writes all output via `context.Output.WriteAsync(IOutputMessage)`. No `session.SendLineAsync` in command bodies.
-6. **Formatter-backed output.** `IOutputWriter.WriteAsync` resolves the session's formatter from `IOutputFormatterRegistry`, calls `formatter.Format(message, session)` (transport-correct ANSI or stripped plain text based on `session.SupportsColor`), and awaits `session.SendLineAsync(rendered)`. See [Flow 6](flow-06-output-rendering.md) for the full rendering trace.
-7. **Exception trap.** Any uncaught exception is caught, logged at `Error` with a full stack trace, a `PlainMessage("Something went wrong. The error has been logged.")` is written, and `CommandExecutedEvent(Threw)` is published. No stack trace reaches the session.
-8. **`CommandExecutedEvent`.** Published on every dispatch path — success, parse-fail, unauthorized, threw. The `Verb` field carries the **resolved canonical command name** (e.g. `look` when the player typed `lo`), not the raw typed prefix. This makes log lines stable regardless of what the player typed. `CommandLoggingHandler` (priority 80) writes one structured-log line per command via `ILogger`. `AdminAuditHandler` keeps subscribing to the four richer slice-2 admin events and does **not** subscribe to `CommandExecutedEvent`.
+3. **Incapacitation gate.** The dispatcher calls `IEntityStateService.IsInState(session.PlayerEntityId, Incapacitated)`. If the player is incapacitated and `command.UsableWhileIncapacitated` is `false` (the default), it writes `"You are incapacitated and cannot do that."` and publishes `CommandExecutedEvent(Refused, Verb=canonicalVerb)`. Commands explicitly opting in (`help`, `commands`, `score`) bypass this gate. Incapacitation is a transient entity state, not a privilege — this gate lives in the dispatcher, not in `IAuthorizationChecker`.
+4. **Privilege gate.** The dispatcher iterates `command.RequiredPrivileges` and calls `IAuthorizationChecker.IsSatisfied(req, session)` for each. Any unsatisfied requirement writes a rejection `PlainMessage` via `IOutputWriter` and publishes `CommandExecutedEvent(Unauthorized, Verb=canonicalVerb)`.
+5. **Argument parse.** `ICommandArgumentParser.Parse(command.ArgumentSchema, rawTail, resolverContext)` does single-pass tokenization (whitespace + double-quoted groups), walks the declarative argument list, and coerces each token to its CLR type (`string`, `int`, `uint`, `Direction`). Enum-prefix matching works from day one (`n`/`no`/`nor` → `North`). String `Token` arguments that declare a non-null `IArgumentResolver` have prefix matching applied against the candidate list. The resolver returns `IReadOnlyList<ResolvedCandidate>?` where each `ResolvedCandidate(string MatchString, string CanonicalValue)` allows keyword aliases to map to a canonical item name; the parser deduplicates by `CanonicalValue` after prefix matching so multiple keyword aliases for the same item do not produce false ambiguity. Concrete resolvers (`ItemInRoomResolver`, `ItemInInventoryResolver`) ship in slice 6. On failure: the reason + `"Type 'help <canonicalVerb>' for usage."` is written; `CommandExecutedEvent(ParseFailed, Verb=canonicalVerb)` is published.
+6. **Execute.** The dispatcher constructs `CommandContext(Session, InvokerEntityId, ParsedArguments, IOutputWriter, IServiceProvider)` and calls `command.ExecuteAsync(context)`. The body reads typed args via `context.Args.Get<T>(name)`, calls domain systems or publishes events via injected `IEventBus`, and writes all output via `context.Output.WriteAsync(IOutputMessage)`. No `session.SendLineAsync` in command bodies.
+7. **Formatter-backed output.** `IOutputWriter.WriteAsync` resolves the session's formatter from `IOutputFormatterRegistry`, calls `formatter.Format(message, session)` (transport-correct ANSI or stripped plain text based on `session.SupportsColor`), and awaits `session.SendLineAsync(rendered)`. See [Flow 6](flow-06-output-rendering.md) for the full rendering trace.
+8. **Exception trap.** Any uncaught exception is caught, logged at `Error` with a full stack trace, a `PlainMessage("Something went wrong. The error has been logged.")` is written, and `CommandExecutedEvent(Threw)` is published. No stack trace reaches the session.
+9. **`CommandExecutedEvent`.** Published on every dispatch path — success, parse-fail, unauthorized, refused, threw. The `Verb` field carries the **resolved canonical command name** (e.g. `look` when the player typed `lo`), not the raw typed prefix. This makes log lines stable regardless of what the player typed. `CommandLoggingHandler` (priority 80) writes one structured-log line per command via `ILogger`. `AdminAuditHandler` keeps subscribing to the four richer slice-2 admin events and does **not** subscribe to `CommandExecutedEvent`.
 
 **Cross-references.**
 - [`Core/Commands/CommandDispatcher.cs`](../../../Core/Commands/CommandDispatcher.cs), [`Core/Commands/ICommand.cs`](../../../Core/Commands/ICommand.cs)
+- [`Core/Commands/CommandOutcome.cs`](../../../Core/Commands/CommandOutcome.cs) — `Refused` outcome added in slice 10 (incapacitation gate)
+- [`Core/Modules/EntityState/Systems/IEntityStateService.cs`](../../../Core/Modules/EntityState/Systems/IEntityStateService.cs) — incapacitation state query
 - [`Core/Commands/Authorization/IAuthorizationChecker.cs`](../../../Core/Commands/Authorization/IAuthorizationChecker.cs), [`Core/Commands/CommandArgumentParser.cs`](../../../Core/Commands/CommandArgumentParser.cs)
 - [`Core/Output/OutputWriter.cs`](../../../Core/Output/OutputWriter.cs), [`Core/Handlers/CommandLoggingHandler.cs`](../../../Core/Handlers/CommandLoggingHandler.cs)
 - [`subsystems/commands.md`](../subsystems/commands.md) — command framework design

--- a/docs/architecture/flows/flow-18-combat-round-pulse.md
+++ b/docs/architecture/flows/flow-18-combat-round-pulse.md
@@ -2,7 +2,7 @@
 
 > [Back to flows index](README.md)
 
-**Summary.** `CombatTickHandler` subscribes to `HeartbeatTickEvent`. On each tick it snapshots all entities with `CombatStateComponent`, deduplicates pairs (lower entity id = attacker), calls `ICombatSystem.ExecuteRound` for each pair, and publishes `CombatRoundEvent`. Terminal outcomes are handled inline: `MobDied` triggers cleanup + `CombatEndedEvent(MobDied)`, causing `CombatHandler` (p=20) to broadcast the kill narrative before `CombatMobDeathHandler` (p=80) destroys the entity.
+**Summary.** `CombatTickHandler` subscribes to `HeartbeatTickEvent`. On each tick it snapshots all entities with `CombatStateComponent`, deduplicates pairs (lower entity id = attacker), calls `ICombatSystem.ExecuteRound` for each pair, and publishes `CombatRoundEvent`. Terminal outcomes are handled inline: `MobDied` triggers cleanup + `CombatEndedEvent(MobDied)`, causing `CombatHandler` (p=20) to broadcast the kill narrative before `CombatMobDeathHandler` (p=80) destroys the entity. `PlayerIncapacitated` ends combat and then calls `IDeathSystem.OnHpChanged` — if `BecameIncapacitated` is returned, `PlayerIncapacitatedEvent` is published to kick off the bleed-out lifecycle.
 
 **Trigger.** `HeartbeatTickEvent` dispatched by `HeartbeatBackgroundService` (see [Flow 16](flow-16-heartbeat-tick.md)).
 
@@ -10,12 +10,15 @@
 sequenceDiagram
     participant CTH as CombatTickHandler (p=20)
     participant CS as ICombatSystem
+    participant DS as IDeathSystem
     participant Bus as IEventBus
     participant CH as CombatHandler (p=20)
     participant MDH as CombatMobDeathHandler (p=80)
+    participant DNH as DeathNarrationHandler (p=80)
 
     CTH->>CTH: snapshot all CombatStateComponent entities
     loop per deduplicated pair (entityId < opponentId)
+        CTH->>CTH: hpBefore = IStatSystem.GetCurrentHp(defenderId)
         CTH->>CS: ExecuteRound(attackerId, defenderId) → CombatRoundResult
         CTH->>Bus: PublishAsync(CombatRoundEvent)
         Bus->>CH: HandleAsync → hit/miss narrative to room
@@ -23,12 +26,14 @@ sequenceDiagram
             CTH->>CS: EndCombat(attackerId, defenderId)
             CTH->>Bus: PublishAsync(CombatEndedEvent MobDied, DefenderName=captured)
             Bus->>CH: HandleAsync (p=20) → "You have slain X!" broadcast
-            Bus->>MDH: HandleAsync (p=80) → ExitState + RemoveBlueprintComponent + DestroyEntity
+            Bus->>MDH: HandleAsync (p=80) → ExitState + MobDiedEvent + DestroyEntity
         else result.Outcome == PlayerIncapacitated
-            CTH->>CTH: SetCurrentHp(defenderId, 1)
             CTH->>CS: EndCombat + ExitState on both
             CTH->>Bus: PublishAsync(CombatEndedEvent PlayerIncapacitated)
             Bus->>CH: HandleAsync → incapacitation narrative
+            CTH->>DS: OnHpChanged(defenderId, hpBefore, hpAfter) → BecameIncapacitated
+            CTH->>Bus: PublishAsync(PlayerIncapacitatedEvent)
+            Bus->>DNH: HandleAsync (p=80) → "You collapse..." to player; room broadcast
         end
     end
 ```
@@ -38,10 +43,10 @@ sequenceDiagram
 1. `HeartbeatBackgroundService` publishes `HeartbeatTickEvent`; `CombatTickHandler` (priority 20) handles it.
 2. **Snapshot.** Calls `EntityService.GetAllComponents<CombatStateComponent>().ToList()` — snapshot before iteration to avoid mutation during enumeration.
 3. **Deduplication.** For each `(entityId, state)` in the snapshot: skip if `entityId >= state.OpponentEntityId`. This ensures each pair is processed exactly once; the lower entity id is designated the "attacker" for this round.
-4. **Round execution.** Calls `ICombatSystem.ExecuteRound(attackerEntityId, defenderEntityId)` → `CombatRoundResult`. The formula: hit check `roll = Random.Shared.Next(1,21) + body/2 >= 10 + defense`; if hit, damage `= Random.Shared.Next(1, attackPower+2)` applied via `IAttributeSystem.SetCurrentHp`. *(Stat source changed from `Dexterity` to `Body` in slice 9-d; `AttackPower` and `Defense` are both Body-governed — see [`docs/use-cases/stat-resource-substrate.md`](../../use-cases/stat-resource-substrate.md).)*
+4. **Round execution.** Reads `hpBefore = IStatSystem.GetCurrentHp(defenderEntityId)`. Calls `ICombatSystem.ExecuteRound(attackerEntityId, defenderEntityId)` → `CombatRoundResult`. The formula: hit check `roll = Random.Shared.Next(1,21) + body/2 >= 10 + defense`; if hit, damage `= Random.Shared.Next(1, attackPower+2)` applied via `IAttributeSystem.SetCurrentHp`. *(Stat source changed from `Dexterity` to `Body` in slice 9-d; `AttackPower` and `Defense` are both Body-governed — see [`docs/use-cases/stat-resource-substrate.md`](../../use-cases/stat-resource-substrate.md).)*
 5. Publishes `CombatRoundEvent`. `CombatHandler` (priority 20) broadcasts hit/miss/damage narrative.
-6. **`MobDied` path.** Captures `MobDataComponent.Name` from the mob entity (point-in-time capture, before destruction). Calls `ICombatSystem.EndCombat`. Publishes `CombatEndedEvent(MobDied, DefenderName=mobName)`. `CombatHandler` (priority 20) broadcasts `"You have slain <mob>!"` using `DefenderName` from the payload. `CombatMobDeathHandler` (priority 80) then calls `IEntityStateService.ExitState(attackerEntityId, InCombat)`, removes `BlueprintComponent` (INV-21), and calls `EntityService.DestroyEntity(mobEntityId)`.
-7. **`PlayerIncapacitated` path.** Calls `IAttributeSystem.SetCurrentHp(defenderEntityId, 1)` (stub clamp, slice 10 will add full death mechanics). Calls `ICombatSystem.EndCombat` + `IEntityStateService.ExitState(InCombat)` on both entities. Publishes `CombatEndedEvent(PlayerIncapacitated)`. `CombatHandler` broadcasts incapacitation narrative.
+6. **`MobDied` path.** Captures `MobDataComponent.Name` from the mob entity (point-in-time capture, before destruction). Calls `ICombatSystem.EndCombat`. Publishes `CombatEndedEvent(MobDied, DefenderName=mobName)`. `CombatHandler` (priority 20) broadcasts `"You have slain <mob>!"` using `DefenderName` from the payload. `CombatMobDeathHandler` (priority 80) then calls `IEntityStateService.ExitState(attackerEntityId, InCombat)`, publishes `MobDiedEvent` (with `KillerEntityId`), and calls `EntityService.DestroyEntity(mobEntityId)`.
+7. **`PlayerIncapacitated` path.** Calls `ICombatSystem.EndCombat` + `IEntityStateService.ExitState(InCombat)` on both entities. Publishes `CombatEndedEvent(PlayerIncapacitated)` — `CombatHandler` broadcasts incapacitation narrative. Then reads `hpAfter` and calls `IDeathSystem.OnHpChanged(defenderEntityId, hpBefore, hpAfter)`. If the result is `BecameIncapacitated`, publishes `PlayerIncapacitatedEvent(defenderEntityId, roomEntityId)` to begin the bleed-out lifecycle (see [Flow 22 — death and respawn](flow-22-death-and-respawn.md)).
 
 **Cross-references.**
 - [`Core/Modules/Combat/Handlers/CombatTickHandler.cs`](../../../Core/Modules/Combat/Handlers/CombatTickHandler.cs)

--- a/docs/architecture/flows/flow-21-effect-tick.md
+++ b/docs/architecture/flows/flow-21-effect-tick.md
@@ -2,7 +2,7 @@
 
 > [Back to flows index](README.md)
 
-**Summary.** `EffectTickHandler` subscribes to `HeartbeatTickEvent` at priority 20. On each tick it calls `IEffectSystem.AdvanceTick`, which advances elapsed time on all `Timed` effects, collects `Periodic` applications due this tick, and removes just-expired effects. The handler then applies each periodic magnitude to the relevant pool via `IAttributeSystem` (in `Phase` order — HoT before DoT) and publishes `EffectExpiredEvent` for every effect that expired.
+**Summary.** `EffectTickHandler` subscribes to `HeartbeatTickEvent` at priority 20. On each tick it calls `IEffectSystem.AdvanceTick`, which advances elapsed time on all `Timed` effects, collects `Periodic` applications due this tick, and removes just-expired effects. The handler then applies each periodic magnitude to the relevant pool via `IAttributeSystem` (in `Phase` order — HoT before DoT) and publishes `EffectExpiredEvent` for every effect that expired. For `HpCurrent` applications, the handler additionally calls `IDeathSystem.OnHpChanged` so a DoT that drives HP to 0 enters the incapacitation lifecycle.
 
 **Trigger.** `HeartbeatTickEvent` dispatched by `HeartbeatBackgroundService` (see [Flow 16](flow-16-heartbeat-tick.md)). `EffectTickHandler` fires before `CombatTickHandler` (both priority 20; effects are processed before the combat round so updated pool values are available immediately).
 
@@ -11,12 +11,23 @@ sequenceDiagram
     participant ETH as EffectTickHandler (p=20)
     participant ES as IEffectSystem
     participant AS as IAttributeSystem
+    participant DS as IDeathSystem
     participant Bus as IEventBus
 
     ETH->>ES: AdvanceTick(elapsed) → EffectTickResult
     note over ES: advance Elapsed on Timed effects;<br/>collect Periodic apps + expired;<br/>remove expired from EffectsComponent
     loop per PeriodicApplication (Phase order)
-        ETH->>AS: SetCurrentX(entityId, current + magnitude)
+        alt TargetScore == HpCurrent
+            ETH->>AS: hpBefore = GetCurrentHp(entityId)
+            ETH->>AS: SetCurrentHp(entityId, hpBefore + magnitude)
+            ETH->>AS: hpAfter = GetCurrentHp(entityId)
+            ETH->>DS: OnHpChanged(entityId, hpBefore, hpAfter)
+            opt result == BecameIncapacitated
+                ETH->>Bus: PublishAsync(PlayerIncapacitatedEvent)
+            end
+        else other pool
+            ETH->>AS: SetCurrentX(entityId, current + magnitude)
+        end
     end
     loop per expired effect
         ETH->>Bus: PublishAsync(EffectExpiredEvent{TargetId, EffectId})
@@ -33,7 +44,9 @@ sequenceDiagram
    - Collects any `Periodic` effects as due applications (fire once per tick).
    - Sorts both lists by `Phase` (ascending: `Early` < `Normal` < `Late`).
    - Returns `EffectTickResult { DueApplications, Expired }`.
-3. **Periodic application.** For each `PeriodicApplication` in `DueApplications` (Phase order), calls `IAttributeSystem.SetCurrentX(entityId, current + magnitude)` where X is the pool matching `effect.Params.TargetScore` (e.g. `HpCurrent` → `SetCurrentHp`). `IAttributeSystem` clamps to `[0, MaxX]` automatically. `StatModifier` periodic effects targeting non-pool scores are a no-op here — their contribution is read via `IEffectSystem.GetModifiers` at query time.
+3. **Periodic application.** For each `PeriodicApplication` in `DueApplications` (Phase order):
+   - If `TargetScore == HpCurrent`: reads `hpBefore`, calls `IAttributeSystem.SetCurrentHp(entityId, hpBefore + magnitude)`, reads `hpAfter`, then calls `IDeathSystem.OnHpChanged(entityId, hpBefore, hpAfter)`. If the result is `BecameIncapacitated`, publishes `PlayerIncapacitatedEvent(entityId, roomEntityId)`.
+   - All other pool scores: calls `IAttributeSystem.SetCurrentX(entityId, current + magnitude)` directly. `IAttributeSystem` clamps to `[0, MaxX]` automatically. `StatModifier` periodic effects targeting non-pool scores are a no-op here — their contribution is read via `IEffectSystem.GetModifiers` at query time.
 4. **Expiry notification.** For each `(entityId, effect)` in `Expired`, publishes `EffectExpiredEvent { TargetId = entityId, EffectId = effect.EffectId }`. A player-facing "effect fades" broadcast is deferred to a future notification slice.
 
 **Phase ordering.** `EffectPhase.Early` (e.g. `regen` HoT) fires before `EffectPhase.Late` (e.g. `poison` DoT) within a single tick. This ensures a heal-before-damage ordering when both apply on the same tick, preventing an entity from dying to DoT before a HoT that could save it.

--- a/docs/architecture/flows/flow-22-incapacitation-bleedout.md
+++ b/docs/architecture/flows/flow-22-incapacitation-bleedout.md
@@ -1,0 +1,54 @@
+# Flow 22 — Player incapacitation and bleed-out
+
+> [Back to flows index](README.md)
+
+**Summary.** When a player's HP crosses from positive to zero-or-below during combat (see [Flow 18](flow-18-combat-round-pulse.md)), `CombatTickHandler` calls `IDeathSystem.OnHpChanged` and, if `BecameIncapacitated` is returned, publishes `PlayerIncapacitatedEvent`. On subsequent heartbeat ticks, `DeathTickHandler` bleeds the player by `Death:BleedPerTick` HP per tick while they remain incapacitated. `DeathNarrationHandler` (priority 80) narrates each bleed tick: a first-person status message to the player and a third-person warning to all other players in the same room.
+
+**Trigger.** `PlayerIncapacitatedEvent` published by `CombatTickHandler` (see [Flow 18](flow-18-combat-round-pulse.md)); then `HeartbeatTickEvent` ticks while `EntityStateFlags.Incapacitated` is set.
+
+```mermaid
+sequenceDiagram
+    participant DTH as DeathTickHandler (p=20)
+    participant DS as IDeathSystem
+    participant AS as IAttributeSystem
+    participant ESS as IEntityStateService
+    participant Bus as IEventBus
+    participant DNH as DeathNarrationHandler (p=80)
+
+    Note over DTH: On PlayerIncapacitatedEvent (via CombatTickHandler)
+    Bus->>DNH: HandleAsync(PlayerIncapacitatedEvent) → "You collapse, bleeding out..."
+
+    loop Each HeartbeatTickEvent while Incapacitated
+        DTH->>ESS: GetStates → filter Incapacitated entities
+        DTH->>AS: SetCurrentHp(entityId, currentHp - BleedPerTick)
+        DTH->>DS: OnHpChanged(entityId, hpBefore, hpAfter)
+        alt hpAfter <= HpFloor → Died
+            DTH->>Bus: PublishAsync(PlayerDiedEvent)
+            Bus->>DNH: HandleAsync(PlayerDiedEvent) → "You have died."
+        else still incapacitated
+            DTH->>Bus: PublishAsync(PlayerBleedingEvent)
+            Bus->>DNH: HandleAsync(PlayerBleedingEvent) → bleed status to player + room broadcast
+        end
+    end
+```
+
+**Steps.**
+
+1. `PlayerIncapacitatedEvent` fires (published by `CombatTickHandler`). `DeathNarrationHandler` (priority 80) writes `"You collapse, bleeding out..."` to the player and broadcasts `"<Name> collapses!"` to the room.
+2. On each subsequent `HeartbeatTickEvent`, `DeathTickHandler` (priority 20) queries all entities with `EntityStateFlags.Incapacitated`.
+3. For each incapacitated entity: reads current HP, applies bleed (`IAttributeSystem.SetCurrentHp(entityId, currentHp - BleedPerTick)`).
+4. Calls `IDeathSystem.OnHpChanged(entityId, hpBefore, hpAfter)`.
+   - If the result is `Died` (HP ≤ `Death:HpFloor`, default -10): publishes `PlayerDiedEvent` → see [Flow 23](flow-23-player-death-respawn.md).
+   - Otherwise: publishes `PlayerBleedingEvent(entityId, newHp, hpFloor)` (thin payload — no room id). `DeathNarrationHandler` resolves the room from `LocationComponent` and sends two messages: `"You are bleeding out (hp/floor). Without healing you will die."` to the player only, and `"<Name> is bleeding out and near death."` to all other players in the room (via `audienceFilter`).
+5. Incapacitated players cannot use commands other than those explicitly allowlisted (`help`, `commands`, `score`) — the `CommandDispatcher` incapacitation gate blocks all others with `"You are incapacitated and cannot do that."` (see [Flow 3](flow-03-player-command-lifecycle.md)).
+
+**Cross-references.**
+- [`Core/Modules/Death/Handlers/DeathTickHandler.cs`](../../../Core/Modules/Death/Handlers/DeathTickHandler.cs)
+- [`Core/Modules/Death/Handlers/DeathNarrationHandler.cs`](../../../Core/Modules/Death/Handlers/DeathNarrationHandler.cs)
+- [`Core/Modules/Death/Systems/IDeathSystem.cs`](../../../Core/Modules/Death/Systems/IDeathSystem.cs)
+- [`Core/Modules/Death/Events/PlayerIncapacitatedEvent.cs`](../../../Core/Modules/Death/Events/PlayerIncapacitatedEvent.cs)
+- [`Core/Modules/Death/Events/PlayerBleedingEvent.cs`](../../../Core/Modules/Death/Events/PlayerBleedingEvent.cs)
+- [`Core/Commands/CommandDispatcher.cs`](../../../Core/Commands/CommandDispatcher.cs) — incapacitation gate
+- [Flow 18 — Combat round pulse](flow-18-combat-round-pulse.md) — incapacitation trigger
+- [Flow 23 — Player death and respawn](flow-23-player-death-respawn.md) — bleed-out terminal path
+- [`docs/use-cases/death-and-respawn.md`](../../use-cases/death-and-respawn.md) — slice 10 spec

--- a/docs/architecture/flows/flow-23-player-death-respawn.md
+++ b/docs/architecture/flows/flow-23-player-death-respawn.md
@@ -1,0 +1,61 @@
+# Flow 23 — Player death and respawn
+
+> [Back to flows index](README.md)
+
+**Summary.** When bleed-out completes (HP ≤ `Death:HpFloor`), `DeathTickHandler` publishes `PlayerDiedEvent`. `DeathNarrationHandler` (priority 80) narrates the death. `PlayerDeathHandler` (priority 20) orchestrates the full respawn: calls `IDeathSystem.Respawn` (exits Incapacitated, teleports to respawn room, strips impermanent effects, restores pools to 25% of max). Pool/location/effect mutations are covered by the next periodic flush (INV-22 — no `SaveEntityAsync` on a runtime state transition). `DeathNarrationHandler` broadcasts the respawn description.
+
+**Trigger.** `PlayerDiedEvent` published by `DeathTickHandler` when `IDeathSystem.OnHpChanged` returns `Died`.
+
+```mermaid
+sequenceDiagram
+    participant DTH as DeathTickHandler (p=20)
+    participant Bus as IEventBus
+    participant DNH as DeathNarrationHandler (p=80)
+    participant PDH as PlayerDeathHandler (p=20)
+    participant DS as IDeathSystem
+
+    DTH->>Bus: PublishAsync(PlayerDiedEvent)
+    Bus->>DNH: HandleAsync(PlayerDiedEvent p=80) → "You have died." + room broadcast
+    Bus->>PDH: HandleAsync(PlayerDiedEvent p=20)
+    PDH->>DS: Respawn(entityId)
+    DS->>DS: ExitState(Incapacitated)
+    DS->>DS: resolve RespawnComponent.RoomBlueprintId → LocationComponent update
+    DS->>DS: RemoveImpermanent effects
+    DS->>DS: SetCurrentHp/Mana/Stamina/Astra = floor(Max * RespawnPoolPercent)
+    PDH->>Bus: PublishAsync(PlayerRespawnedEvent)
+    Bus->>DNH: HandleAsync(PlayerRespawnedEvent p=80) → SendRoomDescriptionAsync to player
+    Note over PDH: No SaveEntityAsync — periodic flush covers pool/location/effect mutations (INV-22)
+```
+
+**Steps.**
+
+1. `DeathTickHandler` detects HP ≤ `Death:HpFloor` via `IDeathSystem.OnHpChanged` returning `Died`, and publishes `PlayerDiedEvent(entityId, roomEntityId)`.
+2. `DeathNarrationHandler` (priority 80) writes `"You have died."` to the player and broadcasts the death message to the room.
+3. `PlayerDeathHandler` (priority 20) calls `IDeathSystem.Respawn(entityId)`:
+   - Calls `IEntityStateService.ExitState(entityId, Incapacitated)` — clears the flag, removes `EntityStateComponent` if no other flags remain.
+   - Resolves `RespawnComponent.RoomBlueprintId` to a live room entity id (same resolution path as `CharacterHydrationHandler`). Falls back to `WorldConfiguration.StartingRoomEntityId` if unresolvable (logs warning).
+   - Updates `LocationComponent` to the resolved room.
+   - Calls `IEffectSystem.RemoveImpermanent(entityId)` — strips all non-`UntilRemoved` effects.
+   - Restores HP/Mana/Stamina/Astra to `floor(Max × Death:RespawnPoolPercent)` (default 25% of max).
+4. `PlayerDeathHandler` publishes `PlayerRespawnedEvent(entityId, roomEntityId)`.
+5. `DeathNarrationHandler` handles `PlayerRespawnedEvent` and calls `IBroadcastSystem.SendRoomDescriptionAsync` to show the player their new surroundings.
+
+> **Persistence note.** No `SaveEntityAsync` is called in this flow. The location, pool, and effect mutations are runtime state changes covered by the next `PersistenceFlushTimer` sweep (INV-22). The admin `setrespawn` command is the only Death-module path that calls `SaveEntityAsync` — it is an admin boundary save, not a runtime state transition.
+
+**Respawn room resolution order.**
+1. `RespawnComponent.RoomBlueprintId` (if present and resolvable in the live blueprint map).
+2. `WorldConfiguration.StartingRoomEntityId` (fallback, with a warning log).
+
+The admin `setrespawn <player> <roomBlueprintId>` command sets option 1 and persists it immediately (INV-22 boundary save).
+
+**Cross-references.**
+- [`Core/Modules/Death/Handlers/PlayerDeathHandler.cs`](../../../Core/Modules/Death/Handlers/PlayerDeathHandler.cs)
+- [`Core/Modules/Death/Handlers/DeathNarrationHandler.cs`](../../../Core/Modules/Death/Handlers/DeathNarrationHandler.cs)
+- [`Core/Modules/Death/Handlers/DeathTickHandler.cs`](../../../Core/Modules/Death/Handlers/DeathTickHandler.cs)
+- [`Core/Modules/Death/Systems/IDeathSystem.cs`](../../../Core/Modules/Death/Systems/IDeathSystem.cs)
+- [`Core/Modules/Death/Commands/SetRespawnCommand.cs`](../../../Core/Modules/Death/Commands/SetRespawnCommand.cs)
+- [`Core/Modules/Death/Events/PlayerDiedEvent.cs`](../../../Core/Modules/Death/Events/PlayerDiedEvent.cs)
+- [`Core/Modules/Death/Events/PlayerRespawnedEvent.cs`](../../../Core/Modules/Death/Events/PlayerRespawnedEvent.cs)
+- [`Core/ECS/Components/RespawnComponent.cs`](../../../Core/ECS/Components/RespawnComponent.cs)
+- [Flow 22 — Player incapacitation and bleed-out](flow-22-incapacitation-bleedout.md)
+- [`docs/use-cases/death-and-respawn.md`](../../use-cases/death-and-respawn.md) — slice 10 spec

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -31,7 +31,8 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 **Description:** Prints a category-grouped one-line index of all commands visible to the caller. Same visibility filtering as `help` (admin commands hidden when their `RequiredPrivileges` are unsatisfied).  
 **Usage:** `commands`  
 **Schema:** no arguments  
-**Events:** none
+**Events:** none  
+**UsableWhileIncapacitated:** `true`
 
 ---
 
@@ -119,7 +120,8 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 **Description:** With no argument, lists all commands visible to the caller grouped by category. With a verb argument, shows `LongDescription` and `Usage` for that command.  
 **Usage:** `help [<verb>]`  
 **Schema:** optional `Token string "verb"`  
-**Events:** none
+**Events:** none  
+**UsableWhileIncapacitated:** `true`
 
 ---
 
@@ -192,11 +194,12 @@ Living catalog of every registered command. Commands are the thinnest layer — 
 **Aliases:** none  
 **MatchingMode:** `Partial`  
 **Location:** `Core/Modules/Attributes/Commands/ScoreCommand.cs`  
-**Description:** Displays the invoking player's Level, HP (`CurrentHp/MaxHp`), Mana, Stamina, Astra, and the four attributes (Mind, Body, Spirit, Attunement) in a formatted `ScoreDisplayMessage`. If `AttributesComponent` or `PoolsComponent` are absent (pre-hydration edge case), defaults are shown. No events fired.  
+**Description:** Displays the invoking player's Level, HP (`CurrentHp/MaxHp`), Mana, Stamina, Astra, the four attributes (Mind, Body, Spirit, Attunement), and the current respawn room blueprint id (from `RespawnComponent.RoomBlueprintId`; shows `(starting room)` when null). Also shows a highlighted `** INCAPACITATED — bleeding out **` status line when the player is currently incapacitated (from `IEntityStateService`). If `AttributesComponent` or `PoolsComponent` are absent (pre-hydration edge case), defaults are shown. No events fired.  
 **Usage:** `score`  
 **Schema:** no arguments  
-**Dependencies:** `EntityService`  
-**Events:** none
+**Dependencies:** `EntityService`, `IStatSystem`, `IEntityStateService`  
+**Events:** none  
+**UsableWhileIncapacitated:** `true`
 
 ---
 
@@ -338,6 +341,20 @@ All admin commands require `AdminRequirement`. The dispatcher enforces this via 
 **Usage:** `setplayer <characterName> <property> <value>`  
 **Schema:** `Token string "characterName"` (required), `Token string "property"` (required: `level`, `hp`, `mind`, `body`, `spirit`, `attunement`, `mana`, `maxmana`, `stamina`, `maxstamina`, `astra`, `maxastra`), `Token string "value"` (required, positive integer)  
 **Events:** `PlayerAttributeSetByAdminEvent`  
+**RequiredPrivileges:** `AdminRequirement`
+
+---
+
+### `setrespawn`
+
+**Aliases:** none  
+**MatchingMode:** `Full`  
+**Location:** `Core/Modules/Death/Commands/SetRespawnCommand.cs`  
+**Description:** Sets the respawn room blueprint id for a currently-connected player. Resolves the target player by character name via `ISessionManager.GetAll()`. Validates the blueprint exists via `IDeathSystem.SetRespawn` (fails with a descriptive error if the blueprint is not in `ITemplateRegistry`). On success: persists the player entity immediately (admin boundary save, INV-22), then publishes `PlayerRespawnSetByAdminEvent` for the audit log.  
+**Usage:** `setrespawn <characterName> <roomBlueprintId>`  
+**Schema:** `Token string "characterName"` (required), `Token string "roomBlueprintId"` (required)  
+**Dependencies:** `IDeathSystem`, `ISessionManager`, `EntityService`, `IEventBus`, `IPersistenceSystem`  
+**Events:** `PlayerRespawnSetByAdminEvent`  
 **RequiredPrivileges:** `AdminRequirement`
 
 ---

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -55,6 +55,7 @@ Persistence uses two independent opt-ins. See [../architecture/06-persistence.md
 | Account | `AccountComponent` | `Username` (lowercase-normalized), `PasswordHash` (PBKDF2-SHA256), `CharacterEntityIds`, `CreatedAtUtc` | yes |
 | Account | `CharacterComponent` | `AccountEntityId`, `CharacterName`, `CreatedAtUtc`, `LastLoginUtc` | yes |
 | Effects | `EffectsComponent` | `List<Effect> Effects` — active timed/permanent effects on an entity. `[Persistent]`, lifetime-filtered `JsonConverter` (`EffectsComponentJsonConverter`) serializes only `UntilRemoved` effects — timed effects are transient by design. Located in `Core/ECS/Components/` (cross-cutting). | yes |
+| Death | `RespawnComponent` | `RoomBlueprintId: string?` — stable blueprint id of the room where this entity respawns after death. `null` means "use the world starting room" (fallback in `IDeathSystem.Respawn`). Stores the blueprint id rather than the runtime entity id because room entity ids are not stable across restarts. Attached to every new character by `AccountSystem.CreateCharacterAsync`. Set by `SetRespawnCommand` (admin boundary save, INV-22). Located in `Core/ECS/Components/` (cross-cutting). | yes |
 
 ---
 

--- a/docs/reference/handlers.md
+++ b/docs/reference/handlers.md
@@ -86,8 +86,29 @@ Ask:
 **Location:** `Core/Modules/Effects/Handlers/EffectTickHandler.cs`
 **Uses:** `IEffectSystem`, `IAttributeSystem`, `IEventBus`
 
+### DeathTickHandler
+**Events:** `HeartbeatTickEvent`
+**Priority:** 20 (`HandlerPriority.Domain`)
+**Responsibilities:** On each tick: queries all entities with `EntityStateFlags.Incapacitated` set. For each, applies `DeathOptions.BleedPerTick` damage via `IAttributeSystem.SetCurrentHp`. Reads the new HP and calls `IDeathSystem.OnHpChanged`. If the result is `Died`, publishes `PlayerDiedEvent(entityId, roomEntityId)`. Otherwise publishes `PlayerBleedingEvent(entityId, roomEntityId, newHp, hpFloor)` to notify observers of ongoing bleed. Fires after `CombatTickHandler` and `EffectTickHandler` so all pool mutations for a tick are settled before bleed is applied.
+**Location:** `Core/Modules/Death/Handlers/DeathTickHandler.cs`
+**Uses:** `EntityService`, `IDeathSystem`, `IAttributeSystem`, `IEntityStateService`, `IEventBus`
+
+### PlayerDeathHandler
+**Events:** `PlayerDiedEvent`
+**Priority:** 20 (`HandlerPriority.Domain`)
+**Responsibilities:** Orchestrates the full death-to-respawn sequence. Calls `IDeathSystem.Respawn(entityId)` — this exits Incapacitated state, teleports to respawn room, strips impermanent effects, and restores pools. Then calls `IPersistenceSystem.SaveEntityAsync(entityId)` to make the new location and pools durable before the player re-enters the world.
+**Location:** `Core/Modules/Death/Handlers/PlayerDeathHandler.cs`
+**Uses:** `IDeathSystem`, `IPersistenceSystem`
+
+### DeathNarrationHandler
+**Events:** `PlayerIncapacitatedEvent`, `PlayerBleedingEvent`, `PlayerDiedEvent`, `PlayerRespawnedEvent`
+**Priority:** 80 (`HandlerPriority.Notification`)
+**Responsibilities:** Pure output fan-out — no domain logic, no persistence. On `PlayerIncapacitatedEvent`: writes "You collapse, bleeding out..." to the player; broadcasts "X collapses!" to the room. On `PlayerBleedingEvent`: writes HP-level bleed status to the player only (severity-coded: critical when HP ≤ floor+5, warning otherwise). On `PlayerDiedEvent`: writes "You have died." to the player; broadcasts death message to the room. On `PlayerRespawnedEvent`: writes respawn room description to the player via `IBroadcastSystem.SendRoomDescriptionAsync`.
+**Location:** `Core/Modules/Death/Handlers/DeathNarrationHandler.cs`
+**Uses:** `EntityService`, `IBroadcastSystem`
+
 ### AdminAuditHandler
-**Events:** `EntitySpawnedByAdminEvent`, `PlayerTeleportedByAdminEvent`, `RoomExitAuthoredByAdminEvent`, `ContentReloadedEvent` (Phase 3 slice 2); `RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent` (Phase 3 slice 5a); `ItemCreatedByAdminEvent`, `ItemPropertySetByAdminEvent` (Phase 3 slice 6); `MobCreatedByAdminEvent`, `MobPropertySetByAdminEvent` (Phase 3 slice 8); `PlayerAttributeSetByAdminEvent` (Phase 3 slice 8a); `CombatEndedEvent` (Phase 3 slice 9); `EffectAppliedByAdminEvent` (Phase 3 slice 9-e).
+**Events:** `EntitySpawnedByAdminEvent`, `PlayerTeleportedByAdminEvent`, `RoomExitAuthoredByAdminEvent`, `ContentReloadedEvent` (Phase 3 slice 2); `RoomCreatedByAdminEvent`, `RoomPropertySetByAdminEvent` (Phase 3 slice 5a); `ItemCreatedByAdminEvent`, `ItemPropertySetByAdminEvent` (Phase 3 slice 6); `MobCreatedByAdminEvent`, `MobPropertySetByAdminEvent` (Phase 3 slice 8); `PlayerAttributeSetByAdminEvent` (Phase 3 slice 8a); `CombatEndedEvent` (Phase 3 slice 9); `EffectAppliedByAdminEvent` (Phase 3 slice 9-e); `PlayerRespawnSetByAdminEvent` (Phase 3 slice 10).
 **Priority:** 80 (`HandlerPriority.Notification`)
 **Responsibilities:** writes one structured-log entry per admin action via `ILogger<AdminAuditHandler>`. Uses a stable structured event name (`AdminCommandExecuted`) so log scrapers can filter without parsing free text. No dedicated audit-file sink in this slice.
 **Location:** `Core/Modules/Admin/Handlers/AdminAuditHandler.cs`

--- a/docs/reference/systems.md
+++ b/docs/reference/systems.md
@@ -455,6 +455,28 @@ public enum CombatRoundOutcome { Hit, Miss, MobDied, PlayerIncapacitated }
 ```
 `TryFindTargetInRoom` prefix-matches `token` against `MobDataComponent.Name` and `Keywords` for entities with `MobDataComponent` in the given room. `StartCombat`/`EndCombat` add/remove `CombatStateComponent` on both participants — does not call `IEntityStateService` (cohesion separation; commands and handlers coordinate both layers). `ExecuteRound` formula: hit check `roll = Random.Shared.Next(1,21) + dex/2 >= 10 + defense`; damage `Random.Shared.Next(1, attackPower+2)` applied via `IAttributeSystem.SetCurrentHp`; outcome `MobDied` if defender has `MobDataComponent` and HP == 0, `PlayerIncapacitated` if defender has `CharacterComponent` and HP == 0. Implemented (Phase 3 slice 9).
 
+### DeathSystem
+**Purpose:** Domain system owning the HP-threshold evaluation, respawn mutation, and respawn-location management for the player death lifecycle. Pure: never touches the event bus or persistence (INV-5, INV-8). Callers (handlers, initiators) read the returned `DeathTransition` and publish the appropriate events.
+**Location:** `Core/Modules/Death/Systems/DeathSystem.cs` (implementation) · `Core/Modules/Death/Systems/IDeathSystem.cs` (interface)
+**Dependencies:** `EntityService`, `IEntityStateService`, `IAttributeSystem`, `IEffectSystem`, `ITemplateRegistry`, `WorldConfiguration`, `IConfiguration`, `ILogger<DeathSystem>`.
+```csharp
+public interface IDeathSystem
+{
+    /// <summary>Evaluates HP-threshold crossings after an HP mutation. Returns BecameIncapacitated,
+    /// Died, or None.</summary>
+    DeathTransition OnHpChanged(uint entityId, int previousHp, int newHp);
+
+    /// <summary>Exits Incapacitated state, relocates to respawn room, strips impermanent effects,
+    /// and restores all pools to Death:RespawnPoolPercent of their maxima.</summary>
+    void Respawn(uint entityId);
+
+    /// <summary>Validates the blueprint exists and sets RespawnComponent.RoomBlueprintId.
+    /// Returns false + failReason when the blueprint is not found.</summary>
+    bool SetRespawn(uint entityId, string roomBlueprintId, out string? failReason);
+}
+```
+`OnHpChanged` only applies to entities with `CharacterComponent` — mobs never enter the death pipeline. Configuration: `Death:HpFloor` (default `-10`), `Death:RespawnPoolPercent` (default `0.25`). Registered via `AddDeathModule()`. Implemented (Phase 3 slice 10).
+
 ### SpawnSystem
 **Purpose:** Tracks spawn slot occupancy for world-content entities (mobs, world-spawn items) and schedules respawns. Self-initializes from the live entity graph on `WorldContentReadyEvent`; reacts to `MobDiedEvent` and `ItemPickedUpEvent` to mark slots vacant; respawns on `HeartbeatTickEvent`. No events published; no persistence (INV-5, INV-8). Implemented (persistence reform Stage C).
 **Location:** `Core/Modules/Spawn/Systems/SpawnSystem.cs`

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -72,6 +72,23 @@ Deferred from slice 7 design notes. Two related capabilities:
 
 Both are meaningful improvements to UX but would bloat slices 6–7. Revisit when the number of "are you sure?" flows justifies the infrastructure cost.
 
+### 🟢 `IOptions<T>` sweep — typed config options across Core
+
+Surfaced during slice 10 architecture review. Every configuration block with multiple consumers in `Core/` should be bound via a typed options class + `services.Configure<T>(configuration.GetSection("X"))` rather than via raw `IConfiguration["X:Key"]` reads scattered across constructors. Raw reads have no IDE navigation, no compile-time safety, and duplicate default values across files.
+
+**Known sites** (as of slice 10):
+
+| Config section | Files using raw reads | Typed class exists? |
+|---|---|---|
+| `Death:` | `DeathSystem`, `DeathTickHandler`, `AttributeSystem` | ✅ `DeathOptions` — **wired in slice 10**; `AttributeSystem` cross-module dependency flagged below |
+| `World:` | `WorldContentLoader` (×2), `RoomContentWriter`, `ItemContentWriter`, `MobContentWriter` | ❌ |
+| `Persistence:` | `PersistenceSystem` | ❌ |
+| `CharacterDefaults:` | `AccountSystem` (slice 9-d) | ❌ |
+
+**Specific follow-up for `AttributeSystem`.** It currently injects `IOptions<DeathOptions>` solely to read the HP-floor clamp — a cross-module dependency (`Attributes` → `Death`). The right long-term shape is either: (a) move `HpFloor` to an `AttributeOptions` class so `AttributeSystem` owns its own floor config, or (b) remove the floor clamp from `AttributeSystem` entirely and let callers (`DeathTickHandler`) enforce the floor before calling `SetCurrentHp`. Option (b) is the cleaner layer: `AttributeSystem` becomes a pure setter with `[0, Max]` clamping, and the death floor is a Death-module concern only.
+
+**Work.** For each section without a typed class: create the options class, wire `services.Configure<T>()` in the owning module's `AddXModule()` method (or in `Server/Program.cs` following the `OutputConfiguration` + `DeathOptions` pattern), and replace raw string reads with `IOptions<T>` injection. Then resolve the `AttributeSystem` cross-module dependency.
+
 ### 🟢 Persistence save-on-change cleanup + manual `save`/`quit` commands
 
 Follow-up from the death-and-respawn slice (slice 10), where INV-22 was reworded to name **three** permitted `SaveEntityAsync` boundary categories — construction, admin boundary, session-end. Two cleanup items and two new commands remain:

--- a/docs/use-cases/death-and-respawn.md
+++ b/docs/use-cases/death-and-respawn.md
@@ -1,6 +1,6 @@
 # Use Case: Death and Respawn
 
-**Status:** planned
+**Status:** implemented
 **Actors:** Player, Mob, System, Administrator
 **Module:** `Core/Modules/Death/` (new — `IDeathSystem`, incapacitation/bleed/respawn flow, tick handler, death handlers, admin commands), `Core/ECS/Components/` (`RespawnComponent` — cross-cutting persistent), `Core/Modules/EntityState/` (`Incapacitated` flag — reused), `Core/Modules/Combat/` (HP-zero stub becomes a real seam), `Core/Modules/Mobs/` (`MobDiedEvent` extended with killer), `Core/Commands/` (dispatcher-level incapacitation gate), `Core/Modules/Time/` (heartbeat consumer)
 
@@ -135,86 +135,6 @@ Mob death already destroys the entity and publishes `MobDiedEvent` (slice 9 / pe
 
 ---
 
-## Implementation plan — work packages
-
-> **Sub-agent execution.** **WP-1 lands first** (the death system, seam, components, config, and the HP-floor change — everything with no event/handler wiring). **WP-2 and WP-3 depend only on WP-1, not on each other**, so they can run in parallel. The **primary agent runs `architecture-reviewer` (code mode) across the combined diff** after all three land — sub-agents do not self-review.
-
-### WP-1 — Death system, components, config, HP-floor seam *(no event wiring)*
-- **Scope:** the domain decision surface and its data, with no handlers/events yet.
-- **Files:** `RespawnComponent.cs` (`Core/ECS/Components/`, `[Persistent]`); `IDeathSystem.cs`/`DeathSystem.cs` (`Core/Modules/Death/Systems/` — `OnHpChanged`, `Respawn`, `SetRespawn`, `DeathTransition` enum); `DeathOptions.cs` (`Death:` section bind) + `appsettings.json` keys (`Death:HpFloor=-10`, `Death:BleedPerTick=1`, `Death:RespawnPoolPercent=0.25`); `IEffectSystem`/`EffectSystem` add `RemoveImpermanent`; `IAttributeSystem`/`AttributeSystem` change `SetCurrentHp` lower clamp from `0` to `Death:HpFloor`; `AccountSystem.CreateCharacterAsync` attaches `RespawnComponent`; `CombatSystem.ExecuteRound` removes the clamp-to-1 stub; `DeathModule.cs` (registration only).
-- **Depends on:** nothing (lands first).
-- **Out of scope:** all event publishing, handlers, the dispatcher gate, admin command.
-- **Exit (testable):** solution builds; `IDeathSystem.OnHpChanged` returns `BecameIncapacitated`/`Died`/`None` correctly; `SetCurrentHp` floors at `-10`; a freshly-created character has `RespawnComponent`; `RemoveImpermanent` strips timed effects and keeps `UntilRemoved`.
-
-### WP-2 — Pipeline wiring: incapacitation, bleed, death, respawn *(depends on WP-1)*
-- **Scope:** the heartbeat-driven bleed pulse and the death→respawn handlers + their events; combat/effect handlers call `OnHpChanged`.
-- **Files:** events (`PlayerIncapacitatedEvent`, `PlayerBleedingEvent`, `PlayerDiedEvent`, `PlayerRespawnedEvent`); `DeathTickHandler.cs`, `PlayerDeathHandler.cs`, `DeathNarrationHandler.cs`; `CombatTickHandler.cs` + `EffectTickHandler.cs` call `IDeathSystem.OnHpChanged` and publish `PlayerIncapacitatedEvent` on the incap transition (combat's clamp-to-1 path replaced); `MobDiedEvent.cs` extended with `KillerEntityId`; `CombatMobDeathHandler.cs` passes the killer; `Program.cs` subscriptions; `flow-18`/`flow-21` updated for the `OnHpChanged` call; `docs/architecture/03-events.md` "Worked example: Player death" (~L264) corrected — this slice ships the real `PlayerDiedEvent`/`PlayerDeathHandler`, so the stale save-on-change description is replaced with the periodic-flush model (INV-22).
-- **Depends on:** WP-1.
-- **Out of scope:** the dispatcher gate and admin command (WP-3).
-- **Exit (testable):** a player driven to 0 HP by combat *or* poison becomes incapacitated; bleeds 1/tick with a message each tick; dies at -10; respawns at the stored room with pools at 25% and timed effects cleared while permanent effects remain; `MobDiedEvent` carries the killer id.
-
-### WP-3 — Command-block gate + admin respawn tooling *(depends on WP-1)*
-- **Scope:** the dispatcher incapacitation gate and the respawn authoring/inspection surface.
-- **Files:** `ICommand.cs` (+ `UsableWhileIncapacitated`, default `false` via a base/default-interface or each command); `CommandDispatcher.cs` (incapacitation gate + `CommandOutcome.Refused`); flag the allowlist commands (`quit`, `help`, `commands`, `score`) `true`; `SetRespawnCommand.cs` + `PlayerRespawnSetByAdminEvent.cs`; `AdminAuditHandler.cs` (+ new event); `ScoreDisplayMessage`/`ScoreCommand` show the respawn room (inspection surface, INV-18); reference-catalog sweep (`components.md`, `systems.md`, `handlers.md`, `commands.md`, `events` mentions) **owned by WP-3** across all three packages; `.claude/skills/add-command/SKILL.md` §Persistence (INV-20) — the "admin boundary save" subsection (with `setrespawn` as the worked example) was added when INV-22 was reworded alongside this slice; WP-3 only verifies it still matches the shipped `SetRespawnCommand`.
-- **Depends on:** WP-1 (needs `IEntityStateService.IsInState` — already exists — and the `Incapacitated` flag set by WP-2 at runtime, but not WP-2's code to compile).
-- **Out of scope:** the bleed/death pipeline (WP-2).
-- **Exit (testable):** an incapacitated player's `north` is refused with a message while `score`/`quit` still work; `setrespawn <player> room.x` validates the blueprint, persists, and `score` shows the new respawn room; `flow-03` updated for the gate.
-
----
-
-## Content tooling impact
-
-- **Admin authoring:** `setrespawn <player> <roomBlueprintId>` sets a player's respawn location at runtime (validated against `ITemplateRegistry`), routed through `IDeathSystem.SetRespawn` (the *system* owns the logic; the command is a thin caller, so the future content editor reuses it — editor-forward, per the `setplayer`/`setmob` precedent).
-- **Inspection:** `score` is extended to display the current respawn room blueprint id (and the incapacitated/bleeding state when active) so a designer can verify both new pieces of state in the same PR (INV-18). The bleed state is also self-evident from the per-tick `PlayerBleedingEvent` message.
-- **Balance config:** `Death:HpFloor`, `Death:BleedPerTick`, `Death:RespawnPoolPercent` are tunable in `appsettings.json` (see Cross-cutting → Configuration for the category justification).
-- No new YAML template kind or `TemplateRegistry` entry — death/respawn state lives on player (persistent) entities, authored via creation defaults + admin command, not via content files.
-
----
-
-## Cross-cutting surfaces stressed
-
-- **Commands — Gap exposed (framework lands in this slice, WP-3).** The requirement "an incapacitated player can execute *no* commands" cannot be met by the existing per-command `RequiredPrivileges` opt-in: that would force every current and future command to declare an incapacitation requirement, a pattern repeated ≥3× and silently broken by any new command that forgets it (INV-19). The correct shape is a **dispatcher-level state gate** + a single `ICommand.UsableWhileIncapacitated` opt-*out* flag (default-deny). This is a small, structural addition to `CommandDispatcher` and `ICommand`, landed in the same slice. **Disposition: framework slice lands alongside (WP-3), not deferred.** Resolution before merge.
-- **Event bus — Adequate.** Four new past-tense events + one extended event; all published by Initiators/Handlers (tick handlers, death handler, admin command), never by systems (INV-5). Tick-frequency publication of `PlayerBleedingEvent` mirrors the established `CombatRoundEvent`/`EffectExpiredEvent` per-tick pattern — no new infrastructure.
-- **Time / heartbeat — Adequate.** `DeathTickHandler` is a third `HeartbeatTickEvent` subscriber alongside `CombatTickHandler` and `EffectTickHandler`. Ordering note: bleed (this handler) and DoT effects (`EffectTickHandler`) both reduce HP on the same tick; both route their HP mutation through `IDeathSystem.OnHpChanged`, so whichever runs first that drives HP to the floor publishes `PlayerDiedEvent` and the other observes `Incapacitated` already cleared — idempotent. No ordering dependency introduced (both priority 20; death-vs-effect order is not load-bearing because the threshold check is monotonic).
-- **ECS queries — Adequate.** Bleed pulse queries `EntityStateComponent` for the `Incapacitated` flag (same snapshot-before-iterate pattern as `CombatStateComponent` in combat). No new query infrastructure.
-- **Configuration — Adequate.** `Death:HpFloor` / `Death:BleedPerTick` / `Death:RespawnPoolPercent` are surfaced via `IConfiguration` (`DeathOptions`) per [`../architecture/05-configuration.md`](../architecture/05-configuration.md). These are **Category-3 balance constants surfaced as settings** (the same OD-2 "tune without recompile" trigger that `CharacterDefaults:` used in 9-d) — chosen over hardcoded constants specifically because the user requires the pool-restore percent to be appsettings-configurable. End-state promotion to a content definition tracks with the content editor (backlog).
-- **Output / broadcast — Adequate.** Death/respawn/bleed messages use existing `IBroadcastSystem` (room fan-out + single-player writes) and typed `PlainMessage`/existing message shapes; the `score` respawn-room line extends `ScoreDisplayMessage` in place. No new output infrastructure.
-- **Sessions — Adequate.** The dispatcher gate reads `session.PlayerEntityId` (already available); no session-model change.
-- **Persistence — see the dedicated audit below. Gap: none; one classification confirmation required.**
-
-### Persistence opt-in audit (INV-22 / INV-23)
-
-**Level 1 — entity domain classification.**
-- The slice introduces no new entity construction path. It adds a component to the **player (persistent)** domain entity at creation (`AccountSystem.CreateCharacterAsync`, which already adds `PersistentEntity`). No world-content entity is touched. No domain transition occurs (a player never changes persistence domain on death — it respawns as the same persistent entity).
-- Mob death (Flow D-5) destroys a **world-content** entity (no `PersistentEntity`); `DestroyEntity` is the single exit point and already auto-cleans (no SQLite row exists). Unchanged.
-
-**Level 2 — component inclusion.**
-- `RespawnComponent` → **`[Persistent]`.** It holds player state (respawn location) that must survive a restart. Stores `RoomBlueprintId` (stable cross-restart), not the runtime `RoomEntityId`, mirroring `LocationComponent`'s persistence split. Confirmed correct.
-- `EntityStateComponent` (the `Incapacitated` flag holder) → **omit `[Persistent]` (unchanged, slice 9-a).** Transient by design: a crash mid-incapacitation reconnects the player with last-flushed HP and no flag. If last-flushed HP was ≤ 0 the player reconnects "wounded but conscious"; the next damage re-enters the pipeline. Acceptable MUD convention; matches the slice 9-a decision. No change.
-- `PoolsComponent`, `LocationComponent`, `EffectsComponent` → already `[Persistent]` (correct); the slice writes them via existing seams. The respawn pool/location/effect mutations ride the existing persistence of these components. No `[Persistent]` correction needed.
-
-**Level 3 — save-on-change scope.**
-- The death→respawn pipeline (Flow D-4) performs **no `SaveEntityAsync`** — the location/pool/effect mutations are runtime state changes covered by the periodic flush (INV-22). Confirmed compliant.
-- `SetRespawnCommand` (Flow D-6) calls `SaveEntityAsync` — this is the **admin boundary save** category named in INV-22 (admin-gated mutation via a domain system → `SaveEntityAsync` → publish audit event), consistent with the existing `setplayer` precedent. **Disposition: resolved — keep the explicit save.** An admin mutation lands durably without waiting for the periodic flush. (See Resolved decisions #1.)
-
----
-
-## Flows introduced or modified
-
-**New canonical flows (add to `flows/README.md`):**
-- **Flow 22 — Player incapacitation and bleed-out** (`flow-22-incapacitation-bleedout.md`): HP→0 entry from combat/effects, the dispatcher command-block, and the heartbeat bleed pulse.
-- **Flow 23 — Player death and respawn** (`flow-23-player-death-respawn.md`): `PlayerDiedEvent` → `IDeathSystem.Respawn` → relocation, effect expiry, pool restore, narration.
-
-**Modified canonical flows:**
-- **Flow 03 — Player command lifecycle** (`flow-03-player-command-lifecycle.md`): add the incapacitation gate between verb resolution and the privilege gate; add `CommandOutcome.Refused`.
-- **Flow 18 — Combat round pulse**: the `PlayerIncapacitated` branch no longer clamps HP to 1; it applies real damage and calls `IDeathSystem.OnHpChanged`, publishing `PlayerIncapacitatedEvent`.
-- **Flow 21 — Effect tick**: a DoT tick that drives a player to 0 HP now calls `IDeathSystem.OnHpChanged` and publishes `PlayerIncapacitatedEvent` (the effect tick becomes a death-pipeline entry point).
-- **Flow 20 — Mob death and respawn**: `MobDiedEvent` payload gains `KillerEntityId` (note only; spawn-slot logic unchanged).
-
-The implementation PR must update `flows/README.md` (new rows 22–23) and the four modified flow files. Drift is a merge blocker.
-
----
-
 ## Design Notes
 
 - **HP threshold, not a death command.** Per requirement 2, incapacitation and death key off the HP pool crossing a threshold, evaluated by `IDeathSystem.OnHpChanged` and called by whichever Initiator mutated HP. This is why combat *and* effect ticks both reach the same pipeline with no duplicated death logic — the single decision seam is the anti-duplication mechanism (INV-19). `IAttributeSystem` deliberately does **not** call `OnHpChanged` itself: a core/domain compute seam chaining into a domain decision would violate the layer discipline and create a hidden side-effect on every HP write (combat would re-enter death logic mid-round). The caller owns the threshold call.
@@ -225,18 +145,6 @@ The implementation PR must update `flows/README.md` (new rows 22–23) and the f
 - **25% pool restore is a flat fraction.** Every pool is set to `floor(Max * RespawnPoolPercent)`. Per-pool fractions (e.g. respawn with full Stamina but quarter Mana) are deferred — the single config key is the simplest shape that satisfies the requirement and is trivially generalized later.
 - **No corpse, no item loss, no XP loss.** Death penalty beyond pool-restoration is out of scope. The respawn is "soft" (relocate + restore) — the substrate a future harsher-death or corpse-retrieval slice builds on. The `PlayerDiedEvent` payload carries the death room id so a future corpse-spawn handler has the location without re-deriving it.
 - **`SetCurrentHp` floor change is shared.** Lowering the clamp floor to `Death:HpFloor` affects every `SetCurrentHp` caller. This is intentional: overkill (a 50-damage blow at 5 HP) should land the player at a negative value the bleed-out reads, not be silently clamped to 0/1. Mobs reach 0 and die immediately (handled by combat's `MobDied` outcome before any negative value matters), so the negative floor is a player-only concern in practice.
-- **On ship:** author `architecture/subsystems/death.md` (the living design of the incapacitation/death/respawn system) and trim this doc to the durable behavior spec per the docs lifecycle.
-
----
-
-## Resolved decisions
-
-*All four design forks were settled with the owner before spec review; recorded here so they are not re-litigated.*
-
-1. **Admin respawn-set save (INV-22 boundary). → Keep the explicit `SaveEntityAsync`.** `SetRespawnCommand` performs an **admin boundary save** — the named INV-22 category (mirroring `setplayer`): an admin-gated mutation lands durably without waiting for the next periodic flush. INV-22 was reworded alongside this slice to name this category explicitly rather than treat it as a strict-reading exception.
-2. **Bleed notification cadence. → Notify every tick.** `PlayerBleedingEvent` fires on every heartbeat tick the player is incapacitated (no throttling). The urgency is intentional; revisit only if play-testing shows it's noisy.
-3. **Allowlist of usable-while-incapacitated commands. → Minimal.** Ship `help`, `commands`, `score` flagged `UsableWhileIncapacitated = true`; nothing else. (Disconnect is transport-level, not a command verb, so it needs no flag — confirmed in spec review: there is no `quit` command in `Core/`.) The default-deny opt-out flag makes adding a future `pray`/`yell` call-for-help a one-line change when that command is authored.
-4. **`KillerEntityId` lifetime / killer-name snapshot. → Defer to the reward slice.** This slice ships only the bare `KillerEntityId` field on `PlayerDiedEvent`/`MobDiedEvent`. No killer-*name* snapshot is captured now; the future `RewardSystem` owns its own snapshot needs (and the killer-destroyed-before-reward edge case).
 
 ---
 


### PR DESCRIPTION
## Summary

Implements Phase 3 slice 10 — the first terminal player outcome. Turns the HP=0 combat/DoT stubs into the full **incapacitation → bleed-out → death → respawn** lifecycle, adds a dispatcher-level command gate for incapacitated players, and ships the mob-death killer seam for a future reward system.

## What changed

### Core/Modules/Death/ (new module)
- `RespawnComponent` — `[Persistent]`, stores `RoomBlueprintId` (cross-restart stable)
- `IDeathSystem` / `DeathSystem` — HP-threshold evaluator (`OnHpChanged` → `DeathTransition`), full respawn mutation (`Respawn`), admin blueprint setter (`SetRespawn`)
- `DeathOptions` — `IOptions<T>`-bound: `HpFloor=-10`, `BleedPerTick=1`, `RespawnPoolPercent=0.25`
- Events: `PlayerIncapacitatedEvent`, `PlayerBleedingEvent`, `PlayerDiedEvent`, `PlayerRespawnedEvent`, `PlayerRespawnSetByAdminEvent`
- `DeathTickHandler` (p=20) — heartbeat bleed pulse; publishes `PlayerBleedingEvent` or `PlayerDiedEvent`
- `PlayerDeathHandler` (p=20) — calls `IDeathSystem.Respawn`, publishes `PlayerRespawnedEvent`
- `DeathNarrationHandler` (p=80) — all four death events; bleed tick writes first-person status to player + third-person warning to room
- `SetRespawnCommand` — admin-gated; blueprint-validated; admin boundary save + audit event

### Seams in existing modules
- `AttributeSystem.SetCurrentHp` — lower clamp changed from `0` → `Death:HpFloor` (overkill now lands negative so bleed-out reads it correctly)
- `CombatSystem.ExecuteRound` — clamp-to-1 stub removed; outcome check uses `<= 0`
- `CombatTickHandler` + `EffectTickHandler` — call `IDeathSystem.OnHpChanged` after HP mutations; publish `PlayerIncapacitatedEvent` on `BecameIncapacitated`
- `MobDiedEvent` — extended with `KillerEntityId`; `CombatMobDeathHandler` passes attacker id (reward seam, no subscriber yet)
- `IEffectSystem` / `EffectSystem` — `RemoveImpermanent` added (strips non-`UntilRemoved` effects on respawn)
- `AccountSystem.CreateCharacterAsync` — attaches `RespawnComponent` at character creation
- `CommandDispatcher` — incapacitation gate (after verb resolution, before privilege); `CommandOutcome.Refused`
- `ICommand` — `UsableWhileIncapacitated` default-interface property (default `false`); `help`, `commands`, `score` set `true`
- `score` command — shows respawn room blueprint id and INCAPACITATED status

### Infrastructure
- `Microsoft.Extensions.Options` added to `Core.csproj`; `services.Configure<DeathOptions>` wired in `Server/Program.cs` (same pattern as `OutputConfiguration`)

### Docs
- `docs/use-cases/death-and-respawn.md` — status → `implemented`; in-flight sections stripped
- New flows 22 (incapacitation/bleed-out) and 23 (death/respawn); flows 03, 18, 21 updated
- Reference catalogs (`components.md`, `systems.md`, `handlers.md`, `commands.md`) updated
- `backlog.md` — `IOptions<T>` sweep item added (covers `World:`, `Persistence:`, `CharacterDefaults:` sections and the `AttributeSystem` cross-module dependency on `DeathOptions`)

## Architecture review: APPROVE WITH NITS (all fixed)

The pre-merge code-mode review flagged four items; all resolved in this PR:
1. **flow-23 doc drift** — removed erroneous `IPersistenceSystem.SaveEntityAsync` step (death/respawn is periodic-flush only; `setrespawn` admin command is the sole boundary save in this module)
2. **use-case status** — trimmed to durable spec, status set to `implemented`
3. **`DeathOptions` dead weight** — all three consumers (`DeathSystem`, `DeathTickHandler`, `AttributeSystem`) now inject `IOptions<DeathOptions>` instead of raw `IConfiguration` string reads
4. **flow-22 payload mismatch** — `PlayerBleedingEvent` correctly carries no `RoomEntityId`; handler resolves room from `LocationComponent`; flow doc updated to match and to document the dual-message bleed narration (player + room)

## Test plan

- [x] Player driven to 0 HP by combat → becomes incapacitated; `north` and other commands refused with message; `score` and `help` still work
- [x] Incapacitated player bleeds 1 HP per heartbeat tick; bleed message appears to player each tick; room sees third-person warning
- [x] At HP ≤ -10 → `PlayerDiedEvent` fires; player respawns at stored room; all four pools at 25% of max; timed effects cleared; permanent (`UntilRemoved`) effects intact
- [x] `setrespawn <player> <invalidId>` → error; `setrespawn <player> <validId>` → persists; `score` shows new room
- [x] Mob killed in combat → `MobDiedEvent.KillerEntityId` set to attacker (no visible change to players)
- [x] `dotnet build Hedron.sln` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)